### PR TITLE
feat: add SpotBugs filter settings and structured filter-file errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,13 @@ Analyze Java code with SpotBugs directly in VS Code. View findings in a dedicate
 
 ## Settings
 
+### Analysis
+
 - `spotbugs.analysis.effort`: SpotBugs effort level (`min`, `default`, `max`). Default: `default`.
 - `spotbugs.analysis.priorityThreshold`: Report bugs with rank less than or equal to this value (1 = most severe, 20 = least). Default: `9`.
-- `spotbugs.analysis.includeFilterPaths`: SpotBugs XML include filter paths (`-include`). Supports absolute and workspace-relative paths.
-- `spotbugs.analysis.excludeFilterPaths`: SpotBugs XML exclude filter paths (`-exclude`). Supports absolute and workspace-relative paths.
-- `spotbugs.analysis.excludeBaselineBugsPaths`: SpotBugs XML baseline bug collection paths (`-excludeBugs`). Supports absolute and workspace-relative paths.
+
+### Filters
+
+- `spotbugs.filters.includePaths`: SpotBugs XML include filter paths (`-include`). Supports absolute and workspace-relative paths.
+- `spotbugs.filters.excludePaths`: SpotBugs XML exclude filter paths (`-exclude`). Supports absolute and workspace-relative paths.
+- `spotbugs.filters.excludeBaselineBugsPaths`: SpotBugs XML baseline bug collection paths (`-excludeBugs`). Supports absolute and workspace-relative paths.

--- a/README.md
+++ b/README.md
@@ -55,3 +55,11 @@ Analyze Java code with SpotBugs directly in VS Code. View findings in a dedicate
 - `spotbugs.filters.includePaths`: SpotBugs XML include filter paths (`-include`). Supports absolute and workspace-relative paths.
 - `spotbugs.filters.excludePaths`: SpotBugs XML exclude filter paths (`-exclude`). Supports absolute and workspace-relative paths.
 - `spotbugs.filters.excludeBaselineBugsPaths`: SpotBugs XML baseline bug collection paths (`-excludeBugs`). Supports absolute and workspace-relative paths.
+
+If any configured filter file is invalid, analysis stops immediately and an error is shown with a code.
+
+- `CFG_FILTER_NOT_FOUND`
+- `CFG_FILTER_NOT_FILE`
+- `CFG_FILTER_UNREADABLE`
+- `CFG_FILTER_XML_INVALID`
+- `CFG_BASELINE_XML_INVALID`

--- a/README.md
+++ b/README.md
@@ -47,3 +47,6 @@ Analyze Java code with SpotBugs directly in VS Code. View findings in a dedicate
 
 - `spotbugs.analysis.effort`: SpotBugs effort level (`min`, `default`, `max`). Default: `default`.
 - `spotbugs.analysis.priorityThreshold`: Report bugs with rank less than or equal to this value (1 = most severe, 20 = least). Default: `9`.
+- `spotbugs.analysis.includeFilterPaths`: SpotBugs XML include filter paths (`-include`). Supports absolute and workspace-relative paths.
+- `spotbugs.analysis.excludeFilterPaths`: SpotBugs XML exclude filter paths (`-exclude`). Supports absolute and workspace-relative paths.
+- `spotbugs.analysis.excludeBaselineBugsPaths`: SpotBugs XML baseline bug collection paths (`-excludeBugs`). Supports absolute and workspace-relative paths.

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/DelegateCommandHandler.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/DelegateCommandHandler.java
@@ -10,6 +10,7 @@ import org.eclipse.jdt.ls.core.internal.IDelegateCommandHandler;
 
 import com.google.gson.Gson;
 import com.spotbugs.vscode.runner.api.CommandResponse;
+import com.spotbugs.vscode.runner.internal.command.ActionInvocation;
 import com.spotbugs.vscode.runner.internal.command.CommandAction;
 import com.spotbugs.vscode.runner.internal.command.RunAnalysisAction;
 
@@ -30,7 +31,14 @@ public class DelegateCommandHandler implements IDelegateCommandHandler {
         }
         Object[] args = arguments != null ? arguments.toArray() : new Object[0];
         try {
-            return action.execute(args);
+            ActionInvocation invocation = new ActionInvocation(
+                    commandId,
+                    args,
+                    monitor,
+                    Thread.currentThread(),
+                    System.nanoTime()
+            );
+            return action.execute(invocation);
         } catch (Exception e) {
             return GSON.toJson(CommandResponse.error("COMMAND_FAILED", "Command failed"));
         }

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/api/ConfigSchema.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/api/ConfigSchema.java
@@ -13,7 +13,10 @@ public class ConfigSchema {
     private List<String> classpaths;          // optional
     private List<String> sourcepaths;         // optional
     private Integer priorityThreshold;        // optional
-    private String excludeFilterPath;         // optional
+    private List<String> includeFilterPaths;  // optional
+    private List<String> excludeFilterPaths;  // optional
+    private List<String> excludeBaselineBugsPaths; // optional
+    private String excludeFilterPath;         // optional legacy field
     private List<String> plugins;             // optional
 
     public Integer getSchemaVersion() { return schemaVersion; }
@@ -21,6 +24,9 @@ public class ConfigSchema {
     public List<String> getClasspaths() { return classpaths; }
     public List<String> getSourcepaths() { return sourcepaths; }
     public Integer getPriorityThreshold() { return priorityThreshold; }
+    public List<String> getIncludeFilterPaths() { return includeFilterPaths; }
+    public List<String> getExcludeFilterPaths() { return excludeFilterPaths; }
+    public List<String> getExcludeBaselineBugsPaths() { return excludeBaselineBugsPaths; }
     public String getExcludeFilterPath() { return excludeFilterPath; }
     public List<String> getPlugins() { return plugins; }
 }

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/AnalyzerService.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/AnalyzerService.java
@@ -6,6 +6,8 @@ import com.spotbugs.vscode.runner.api.BugInfo;
 import com.spotbugs.vscode.runner.internal.config.AnalysisConfig;
 import com.spotbugs.vscode.runner.internal.config.PreferencesApplier;
 
+import org.eclipse.core.runtime.IProgressMonitor;
+
 import edu.umd.cs.findbugs.FindBugs2;
 import edu.umd.cs.findbugs.Project;
 import edu.umd.cs.findbugs.config.UserPreferences;
@@ -37,7 +39,12 @@ public class AnalyzerService {
     }
 
     public List<BugInfo> analyzeToBugs(String... filePaths) {
+        return analyzeToBugs(null, filePaths);
+    }
+
+    public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths) {
         try {
+            checkCanceled(monitor);
             this.lastTargetCount = 0;
             if (filePaths == null || filePaths.length == 0) {
                 return java.util.Collections.emptyList();
@@ -48,11 +55,12 @@ public class AnalyzerService {
             ClasspathConfigurer cpCfg = new ClasspathConfigurer();
             List<java.io.File> cpDirs = cpCfg.directoriesFrom(this.projectClasspaths);
             TargetResolver resolver = new TargetResolver();
-            List<String> targets = resolver.resolveTargets(filePaths, cpDirs);
+            List<String> targets = resolver.resolveTargets(filePaths, cpDirs, monitor);
             this.lastTargetCount = targets.size();
             if (targets.isEmpty()) {
                 return java.util.Collections.emptyList();
             }
+            checkCanceled(monitor);
             for (String t : targets) {
                 project.addFile(t);
             }
@@ -62,14 +70,17 @@ public class AnalyzerService {
             SpotBugsRunner runner = new SpotBugsRunner();
             Integer reporterPriority = computeReporterPriorityThreshold(this.config != null ? this.config.getPriorityThreshold() : null);
             java.util.List<String> plugins = this.config != null ? this.config.getPlugins() : java.util.Collections.emptyList();
+            checkCanceled(monitor);
             List<BugInfo> bugs = runner.run(this.findBugs, project, reporterPriority, plugins);
-            applyFullPaths(bugs, filePaths);
+            checkCanceled(monitor);
+            applyFullPaths(bugs, monitor, filePaths);
             // Precise post-filter by rank when requested
             Integer rankThreshold = this.config != null ? this.config.getPriorityThreshold() : null;
             if (rankThreshold != null) {
                 final int maxRank = Math.max(1, Math.min(20, rankThreshold.intValue()));
                 java.util.Iterator<BugInfo> it = bugs.iterator();
                 while (it.hasNext()) {
+                    checkCanceled(monitor);
                     BugInfo b = it.next();
                     if (b == null) continue;
                     if (b.getRank() > maxRank) it.remove();
@@ -90,7 +101,7 @@ public class AnalyzerService {
         return Integer.valueOf(3);
     }
 
-    private void applyFullPaths(List<BugInfo> bugs, String... filePaths) {
+    private void applyFullPaths(List<BugInfo> bugs, IProgressMonitor monitor, String... filePaths) {
         if (bugs == null || bugs.isEmpty()) {
             return;
         }
@@ -98,16 +109,23 @@ public class AnalyzerService {
         String targetPath = (filePaths != null && filePaths.length > 0) ? filePaths[0] : null;
         SourcePathResolver resolver = new SourcePathResolver();
         for (BugInfo bug : bugs) {
+            checkCanceled(monitor);
             if (bug == null) {
                 continue;
             }
             if (bug.getFullPath() != null && !bug.getFullPath().isEmpty()) {
                 continue;
             }
-            String fullPath = resolver.resolve(bug.getRealSourcePath(), sourcepaths, targetPath);
+            String fullPath = resolver.resolve(bug.getRealSourcePath(), sourcepaths, targetPath, monitor);
             if (fullPath != null && !fullPath.isEmpty()) {
                 bug.setFullPath(fullPath);
             }
+        }
+    }
+
+    private static void checkCanceled(IProgressMonitor monitor) {
+        if (monitor != null && monitor.isCanceled()) {
+            throw new java.util.concurrent.CancellationException("Command cancelled");
         }
     }
 

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SourcePathResolver.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SourcePathResolver.java
@@ -3,9 +3,16 @@ package com.spotbugs.vscode.runner.internal;
 import java.io.File;
 import java.util.List;
 
+import org.eclipse.core.runtime.IProgressMonitor;
+
 public class SourcePathResolver {
 
     public String resolve(String realSourcePath, List<String> sourcepaths, String targetPath) {
+        return resolve(realSourcePath, sourcepaths, targetPath, null);
+    }
+
+    public String resolve(String realSourcePath, List<String> sourcepaths, String targetPath, IProgressMonitor monitor) {
+        checkCanceled(monitor);
         if (realSourcePath == null || realSourcePath.trim().isEmpty()) {
             return null;
         }
@@ -17,6 +24,7 @@ public class SourcePathResolver {
 
         if (sourcepaths != null && !sourcepaths.isEmpty()) {
             for (String sourceRoot : sourcepaths) {
+                checkCanceled(monitor);
                 if (sourceRoot == null || sourceRoot.trim().isEmpty()) {
                     continue;
                 }
@@ -44,5 +52,11 @@ public class SourcePathResolver {
 
     private static String normalize(String value) {
         return value.replace('\\', '/');
+    }
+
+    private static void checkCanceled(IProgressMonitor monitor) {
+        if (monitor != null && monitor.isCanceled()) {
+            throw new java.util.concurrent.CancellationException("Command cancelled");
+        }
     }
 }

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SpotBugsExecutor.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SpotBugsExecutor.java
@@ -16,6 +16,7 @@ import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.DetectorFactoryCollection;
 import edu.umd.cs.findbugs.FindBugs2;
 import edu.umd.cs.findbugs.Project;
+import edu.umd.cs.findbugs.config.UserPreferences;
 
 public class SpotBugsExecutor {
 
@@ -38,6 +39,11 @@ public class SpotBugsExecutor {
     public List<BugInfo> executeBugs() throws IOException, InterruptedException {
         findBugs.setProject(project);
         findBugs.setBugReporter(bugReporter);
+        UserPreferences currentPreferences = findBugs.getUserPreferences();
+        if (currentPreferences != null) {
+            // Re-apply current preferences so filter wrappers bind to the current bug reporter chain.
+            findBugs.setUserPreferences(currentPreferences);
+        }
 
         ClassLoader prev = Thread.currentThread().getContextClassLoader();
         URLClassLoader pluginLoader = null;

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/TargetResolver.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/TargetResolver.java
@@ -7,6 +7,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.eclipse.core.runtime.IProgressMonitor;
+
 /**
  * Resolves input paths (.java/.class/.jar/directories) into concrete analysis targets
  * (.class and .jar files). Uses classpath directories to map sources to outputs.
@@ -14,20 +16,25 @@ import java.util.Set;
 public class TargetResolver {
 
     public List<String> resolveTargets(String[] inputs, List<File> classpathDirs) throws IOException {
+        return resolveTargets(inputs, classpathDirs, null);
+    }
+
+    public List<String> resolveTargets(String[] inputs, List<File> classpathDirs, IProgressMonitor monitor) throws IOException {
         List<String> targets = new ArrayList<>();
         Set<String> seen = new HashSet<>();
         if (inputs == null) {
             return targets;
         }
         for (String p : inputs) {
+            checkCanceled(monitor);
             if (p == null || p.trim().isEmpty()) {
                 continue;
             }
             File f = new File(p);
             if (f.isDirectory()) {
                 // If a source directory is selected, map it to an output directory first.
-                if (!collectOutputClassesForSourceDirectory(p, classpathDirs, targets, seen)) {
-                    collectTargetsRecursively(f, classpathDirs, targets, seen);
+                if (!collectOutputClassesForSourceDirectory(p, classpathDirs, targets, seen, monitor)) {
+                    collectTargetsRecursively(f, classpathDirs, targets, seen, monitor);
                 }
                 continue;
             }
@@ -36,24 +43,25 @@ public class TargetResolver {
                 continue;
             }
             if (p.endsWith(".java")) {
-                addTargetsForJavaFile(p, classpathDirs, targets, seen);
+                addTargetsForJavaFile(p, classpathDirs, targets, seen, monitor);
                 continue;
             }
             // Unknown type: add existing file or scan directory
             if (f.exists()) {
                 if (f.isFile()) addIfNew(f.getAbsolutePath(), targets, seen);
-                else if (f.isDirectory()) collectTargetsRecursively(f, classpathDirs, targets, seen);
+                else if (f.isDirectory()) collectTargetsRecursively(f, classpathDirs, targets, seen, monitor);
             }
         }
         return targets;
     }
 
-    private void collectTargetsRecursively(File dir, List<File> classpathDirs, List<String> out, Set<String> seen) throws IOException {
+    private void collectTargetsRecursively(File dir, List<File> classpathDirs, List<String> out, Set<String> seen, IProgressMonitor monitor) throws IOException {
         File[] children = dir.listFiles();
         if (children == null) return;
         for (File c : children) {
+            checkCanceled(monitor);
             if (c.isDirectory()) {
-                collectTargetsRecursively(c, classpathDirs, out, seen);
+                collectTargetsRecursively(c, classpathDirs, out, seen, monitor);
                 continue;
             }
             if (!c.isFile()) {
@@ -65,18 +73,19 @@ public class TargetResolver {
                 continue;
             }
             if (name.endsWith(".java")) {
-                addTargetsForJavaFile(c.getAbsolutePath(), classpathDirs, out, seen);
+                addTargetsForJavaFile(c.getAbsolutePath(), classpathDirs, out, seen, monitor);
                 continue;
             }
         }
     }
 
-    private boolean collectClassFilesByBasename(File dir, String baseName, List<String> out, Set<String> seen) throws IOException {
+    private boolean collectClassFilesByBasename(File dir, String baseName, List<String> out, Set<String> seen, IProgressMonitor monitor) throws IOException {
         File[] children = dir.listFiles();
         if (children == null) return false;
         for (File c : children) {
+            checkCanceled(monitor);
             if (c.isDirectory()) {
-                if (collectClassFilesByBasename(c, baseName, out, seen)) {
+                if (collectClassFilesByBasename(c, baseName, out, seen, monitor)) {
                     return true;
                 }
                 continue;
@@ -93,7 +102,8 @@ public class TargetResolver {
             String sourceDir,
             List<File> classpathDirs,
             List<String> out,
-            Set<String> seen
+            Set<String> seen,
+            IProgressMonitor monitor
     ) throws IOException {
         String rel = deriveRelativePathFromSource(sourceDir);
         if (rel == null) {
@@ -106,11 +116,12 @@ public class TargetResolver {
         boolean added = false;
         String relDir = normalizePath(rel);
         for (File dir : classpathDirs) {
+            checkCanceled(monitor);
             if (dir == null) continue;
             File candidate = relDir.isEmpty() ? dir : new File(dir, relDir);
             if (candidate.exists() && candidate.isDirectory()) {
                 int before = out.size();
-                collectTargetsRecursively(candidate, classpathDirs, out, seen);
+                collectTargetsRecursively(candidate, classpathDirs, out, seen, monitor);
                 if (out.size() > before) {
                     added = true;
                 }
@@ -123,13 +134,15 @@ public class TargetResolver {
             String javaPath,
             List<File> classpathDirs,
             List<String> out,
-            Set<String> seen
+            Set<String> seen,
+            IProgressMonitor monitor
     ) throws IOException {
         boolean added = false;
         String rel = deriveRelativePathFromSource(javaPath);
         if (rel != null && classpathDirs != null && !classpathDirs.isEmpty()) {
             String classRel = normalizePath(rel).replace(".java", ".class");
             for (File dir : classpathDirs) {
+                checkCanceled(monitor);
                 if (dir == null) continue;
                 File candidate = new File(dir, classRel);
                 if (candidate.exists() && candidate.isFile()) {
@@ -144,8 +157,9 @@ public class TargetResolver {
             // Fallback: basename scan (may be ambiguous when multiple classes share the same simple name)
             String baseName = stripExtension(new File(javaPath).getName());
             for (File dir : classpathDirs) {
+                checkCanceled(monitor);
                 if (dir == null) continue;
-                if (collectClassFilesByBasename(dir, baseName, out, seen)) {
+                if (collectClassFilesByBasename(dir, baseName, out, seen, monitor)) {
                     added = true;
                     break;
                 }
@@ -186,5 +200,11 @@ public class TargetResolver {
 
     private void addIfNew(String path, List<String> out, Set<String> seen) {
         if (seen.add(path)) out.add(path);
+    }
+
+    private static void checkCanceled(IProgressMonitor monitor) {
+        if (monitor != null && monitor.isCanceled()) {
+            throw new java.util.concurrent.CancellationException("Command cancelled");
+        }
     }
 }

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/AbstractCommandAction.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/AbstractCommandAction.java
@@ -17,10 +17,12 @@ public abstract class AbstractCommandAction implements CommandAction {
     private final Gson gson = new Gson();
 
     @Override
-    public final String execute(Object... args) {
-        ActionContext context = new ActionContext(args);
+    public final String execute(ActionInvocation invocation) {
+        ActionContext context = new ActionContext(invocation);
         try {
+            context.checkCanceled();
             CommandResult result = run(context);
+            context.checkCanceled();
             if (result == null) {
                 return gson.toJson(Collections.emptyMap());
             }
@@ -81,9 +83,11 @@ public abstract class AbstractCommandAction implements CommandAction {
      */
     protected static final class ActionContext {
         private final Object[] args;
+        private final ActionInvocation invocation;
 
-        ActionContext(Object[] args) {
-            this.args = args != null ? args : new Object[0];
+        ActionContext(ActionInvocation invocation) {
+            this.invocation = invocation;
+            this.args = invocation != null ? invocation.getArgs() : new Object[0];
         }
 
         public int size() {
@@ -121,6 +125,33 @@ public abstract class AbstractCommandAction implements CommandAction {
 
         public Object[] raw() {
             return args.clone();
+        }
+
+        public boolean isCanceled() {
+            org.eclipse.core.runtime.IProgressMonitor monitor = monitor();
+            return monitor != null && monitor.isCanceled();
+        }
+
+        public void checkCanceled() throws CommandActionException {
+            if (isCanceled()) {
+                throw new CommandActionException(DEFAULT_ERROR_CODE, "Command cancelled");
+            }
+        }
+
+        public String commandId() {
+            return invocation != null ? invocation.getCommandId() : null;
+        }
+
+        public org.eclipse.core.runtime.IProgressMonitor monitor() {
+            return invocation != null ? invocation.getMonitor() : null;
+        }
+
+        public Thread thread() {
+            return invocation != null ? invocation.getThread() : null;
+        }
+
+        public long startNanos() {
+            return invocation != null ? invocation.getStartNanos() : 0L;
         }
     }
 

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/ActionInvocation.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/ActionInvocation.java
@@ -1,0 +1,42 @@
+package com.spotbugs.vscode.runner.internal.command;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+
+/**
+ * Captures a single command invocation with thread and monitor context.
+ */
+public final class ActionInvocation {
+    private final String commandId;
+    private final Object[] args;
+    private final IProgressMonitor monitor;
+    private final Thread thread;
+    private final long startNanos;
+
+    public ActionInvocation(String commandId, Object[] args, IProgressMonitor monitor, Thread thread, long startNanos) {
+        this.commandId = commandId;
+        this.args = args != null ? args : new Object[0];
+        this.monitor = monitor;
+        this.thread = thread;
+        this.startNanos = startNanos;
+    }
+
+    public String getCommandId() {
+        return commandId;
+    }
+
+    public Object[] getArgs() {
+        return args;
+    }
+
+    public IProgressMonitor getMonitor() {
+        return monitor;
+    }
+
+    public Thread getThread() {
+        return thread;
+    }
+
+    public long getStartNanos() {
+        return startNanos;
+    }
+}

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/CommandAction.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/CommandAction.java
@@ -13,12 +13,12 @@ public interface CommandAction {
     String id();
 
     /**
-     * Execute the action for the given arguments.
+     * Execute the action for the given invocation.
      *
-     * @param args raw arguments supplied by the language server invocation.
+     * @param invocation command invocation context.
      * @return JSON string payload to be forwarded to the VS Code client.
      * @throws Exception if the command processing fails; the caller is expected
      *                   to translate the failure into the standard error envelope.
      */
-    String execute(Object... args) throws Exception;
+    String execute(ActionInvocation invocation) throws Exception;
 }

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisAction.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisAction.java
@@ -87,6 +87,6 @@ public final class RunAnalysisAction extends AbstractCommandAction {
     private CommandActionException configFailure(ConfigError error) {
         String code = error != null ? error.getCode() : "CFG_ERROR";
         String message = error != null ? error.getMessage() : "Configuration error";
-        return new CommandActionException(code, code + ": " + message);
+        return new CommandActionException(code, message);
     }
 }

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisAction.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisAction.java
@@ -54,7 +54,7 @@ public final class RunAnalysisAction extends AbstractCommandAction {
         AnalyzerService analyzer = new AnalyzerService();
         analyzer.setConfiguration(config);
         long start = System.currentTimeMillis();
-        List<BugInfo> bugs = analyzer.analyzeToBugs(targetPath);
+        List<BugInfo> bugs = analyzer.analyzeToBugs(context.monitor(), targetPath);
         long elapsed = System.currentTimeMillis() - start;
 
         List<BugInfo> results = bugs != null ? bugs : java.util.Collections.emptyList();

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/config/AnalysisConfig.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/config/AnalysisConfig.java
@@ -14,7 +14,10 @@ public class AnalysisConfig {
     private final List<String> classpaths;
     private final List<String> sourcepaths;
     private final Integer priorityThreshold; // optional
-    private final String excludeFilterPath;  // optional
+    private final List<String> includeFilterPaths; // optional
+    private final List<String> excludeFilterPaths; // optional
+    private final List<String> excludeBaselineBugsPaths; // optional
+    private final String excludeFilterPath;  // optional legacy field
     private final List<String> plugins;      // optional
 
     private AnalysisConfig(Builder b) {
@@ -26,6 +29,15 @@ public class AnalysisConfig {
                 ? Collections.emptyList()
                 : Collections.unmodifiableList(new ArrayList<>(b.sourcepaths));
         this.priorityThreshold = b.priorityThreshold;
+        this.includeFilterPaths = b.includeFilterPaths == null
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(new ArrayList<>(b.includeFilterPaths));
+        this.excludeFilterPaths = b.excludeFilterPaths == null
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(new ArrayList<>(b.excludeFilterPaths));
+        this.excludeBaselineBugsPaths = b.excludeBaselineBugsPaths == null
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(new ArrayList<>(b.excludeBaselineBugsPaths));
         this.excludeFilterPath = b.excludeFilterPath;
         this.plugins = b.plugins == null
                 ? Collections.emptyList()
@@ -36,6 +48,9 @@ public class AnalysisConfig {
     public List<String> getClasspaths() { return classpaths; }
     public List<String> getSourcepaths() { return sourcepaths; }
     public Integer getPriorityThreshold() { return priorityThreshold; }
+    public List<String> getIncludeFilterPaths() { return includeFilterPaths; }
+    public List<String> getExcludeFilterPaths() { return excludeFilterPaths; }
+    public List<String> getExcludeBaselineBugsPaths() { return excludeBaselineBugsPaths; }
     public String getExcludeFilterPath() { return excludeFilterPath; }
     public List<String> getPlugins() { return plugins; }
 
@@ -47,6 +62,9 @@ public class AnalysisConfig {
         private List<String> classpaths;
         private List<String> sourcepaths;
         private Integer priorityThreshold;
+        private List<String> includeFilterPaths;
+        private List<String> excludeFilterPaths;
+        private List<String> excludeBaselineBugsPaths;
         private String excludeFilterPath;
         private List<String> plugins;
 
@@ -54,6 +72,9 @@ public class AnalysisConfig {
         Builder classpaths(List<String> cp) { this.classpaths = cp; return this; }
         Builder sourcepaths(List<String> sp) { this.sourcepaths = sp; return this; }
         Builder priorityThreshold(Integer p) { this.priorityThreshold = p; return this; }
+        Builder includeFilterPaths(List<String> p) { this.includeFilterPaths = p; return this; }
+        Builder excludeFilterPaths(List<String> p) { this.excludeFilterPaths = p; return this; }
+        Builder excludeBaselineBugsPaths(List<String> p) { this.excludeBaselineBugsPaths = p; return this; }
         Builder excludeFilterPath(String p) { this.excludeFilterPath = p; return this; }
         Builder plugins(List<String> p) { this.plugins = p; return this; }
 

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/config/ConfigValidator.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/config/ConfigValidator.java
@@ -24,7 +24,14 @@ public class ConfigValidator {
 
         // Optional fields: normalize empties to null
         Integer priorityThreshold = schema.getPriorityThreshold();
+        List<String> includeFilterPaths = normalizeList(schema.getIncludeFilterPaths());
+        List<String> excludeFilterPaths = normalizeList(schema.getExcludeFilterPaths());
+        List<String> excludeBaselineBugsPaths = normalizeList(schema.getExcludeBaselineBugsPaths());
         String excludeFilterPath = normalizeString(schema.getExcludeFilterPath());
+        if (excludeFilterPaths.isEmpty() && excludeFilterPath != null) {
+            excludeFilterPaths = new ArrayList<>();
+            excludeFilterPaths.add(excludeFilterPath);
+        }
         List<String> plugins = normalizeList(schema.getPlugins());
 
         AnalysisConfig cfg = AnalysisConfig
@@ -33,6 +40,9 @@ public class ConfigValidator {
             .classpaths(cps)
             .sourcepaths(sps)
             .priorityThreshold(priorityThreshold)
+            .includeFilterPaths(includeFilterPaths)
+            .excludeFilterPaths(excludeFilterPaths)
+            .excludeBaselineBugsPaths(excludeBaselineBugsPaths)
             .excludeFilterPath(excludeFilterPath)
             .plugins(plugins)
             .build();

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/config/ConfigValidator.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/config/ConfigValidator.java
@@ -5,6 +5,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.spotbugs.vscode.runner.api.ConfigError;
 import com.spotbugs.vscode.runner.api.ConfigSchema;
 
 /** Validates a wire schema and maps to a domain AnalysisConfig. */
@@ -33,6 +34,19 @@ public class ConfigValidator {
             excludeFilterPaths.add(excludeFilterPath);
         }
         List<String> plugins = normalizeList(schema.getPlugins());
+
+        ConfigError includeFilterError = FilterFileValidator.validateIncludeFilters(includeFilterPaths);
+        if (includeFilterError != null) {
+            return ConfigValidationResult.error(includeFilterError.getCode(), includeFilterError.getMessage());
+        }
+        ConfigError excludeFilterError = FilterFileValidator.validateExcludeFilters(excludeFilterPaths);
+        if (excludeFilterError != null) {
+            return ConfigValidationResult.error(excludeFilterError.getCode(), excludeFilterError.getMessage());
+        }
+        ConfigError baselineFilterError = FilterFileValidator.validateBaselineFilters(excludeBaselineBugsPaths);
+        if (baselineFilterError != null) {
+            return ConfigValidationResult.error(baselineFilterError.getCode(), baselineFilterError.getMessage());
+        }
 
         AnalysisConfig cfg = AnalysisConfig
             .newBuilder()

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/config/FilterFileValidator.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/config/FilterFileValidator.java
@@ -1,0 +1,94 @@
+package com.spotbugs.vscode.runner.internal.config;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.List;
+
+import com.spotbugs.vscode.runner.api.ConfigError;
+
+import edu.umd.cs.findbugs.ExcludingHashesBugReporter;
+import edu.umd.cs.findbugs.filter.Filter;
+
+/**
+ * Validates SpotBugs filter files before analysis starts.
+ */
+final class FilterFileValidator {
+
+    private static final String CODE_FILTER_NOT_FOUND = "CFG_FILTER_NOT_FOUND";
+    private static final String CODE_FILTER_NOT_FILE = "CFG_FILTER_NOT_FILE";
+    private static final String CODE_FILTER_UNREADABLE = "CFG_FILTER_UNREADABLE";
+    private static final String CODE_FILTER_XML_INVALID = "CFG_FILTER_XML_INVALID";
+    private static final String CODE_BASELINE_XML_INVALID = "CFG_BASELINE_XML_INVALID";
+
+    private FilterFileValidator() {
+    }
+
+    static ConfigError validateIncludeFilters(List<String> includeFilterPaths) {
+        return validateFilterList(includeFilterPaths, "include", false);
+    }
+
+    static ConfigError validateExcludeFilters(List<String> excludeFilterPaths) {
+        return validateFilterList(excludeFilterPaths, "exclude", false);
+    }
+
+    static ConfigError validateBaselineFilters(List<String> baselineFilterPaths) {
+        return validateFilterList(baselineFilterPaths, "baseline", true);
+    }
+
+    private static ConfigError validateFilterList(List<String> paths, String kind, boolean baseline) {
+        if (paths == null || paths.isEmpty()) {
+            return null;
+        }
+        for (String rawPath : paths) {
+            ConfigError error = validateSinglePath(rawPath, kind, baseline);
+            if (error != null) {
+                return error;
+            }
+        }
+        return null;
+    }
+
+    private static ConfigError validateSinglePath(String rawPath, String kind, boolean baseline) {
+        String absolutePath = new File(rawPath).getAbsolutePath();
+        File filterFile = new File(absolutePath);
+        if (!filterFile.exists()) {
+            return error(CODE_FILTER_NOT_FOUND, kind + " filter file not found: " + absolutePath);
+        }
+        if (!filterFile.isFile()) {
+            return error(CODE_FILTER_NOT_FILE, kind + " filter file is not a regular file: " + absolutePath);
+        }
+        if (!filterFile.canRead()) {
+            return error(CODE_FILTER_UNREADABLE, kind + " filter file is not readable: " + absolutePath);
+        }
+        try {
+            if (baseline) {
+                ExcludingHashesBugReporter.addToExcludedInstanceHashes(new HashSet<String>(), absolutePath);
+            } else {
+                Filter.parseFilter(absolutePath);
+            }
+        } catch (Exception e) {
+            String code = baseline ? CODE_BASELINE_XML_INVALID : CODE_FILTER_XML_INVALID;
+            return error(code, kind + " filter file is invalid: " + absolutePath + " (" + rootCauseMessage(e) + ")");
+        }
+        return null;
+    }
+
+    private static ConfigError error(String code, String message) {
+        return new ConfigError(code, message);
+    }
+
+    private static String rootCauseMessage(Throwable throwable) {
+        if (throwable == null) {
+            return "Unknown error";
+        }
+        Throwable root = throwable;
+        while (root.getCause() != null && root.getCause() != root) {
+            root = root.getCause();
+        }
+        String message = root.getMessage();
+        if (message == null || message.trim().isEmpty()) {
+            return root.getClass().getSimpleName();
+        }
+        return message.trim();
+    }
+}

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/config/PreferencesApplier.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/config/PreferencesApplier.java
@@ -1,5 +1,10 @@
 package com.spotbugs.vscode.runner.internal.config;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 import edu.umd.cs.findbugs.FindBugs2;
 import edu.umd.cs.findbugs.config.UserPreferences;
 
@@ -12,9 +17,13 @@ public class PreferencesApplier {
         String effortString = toEffortString(cfg.getEffort());
         prefs.setEffort(effortString);
 
+        // Filter files are applied by FindBugs2#setUserPreferences via configureFilters.
+        prefs.setIncludeFilterFiles(toEnabledPathMap(cfg.getIncludeFilterPaths()));
+        prefs.setExcludeFilterFiles(toEnabledPathMap(resolveExcludeFilterPaths(cfg)));
+        prefs.setExcludeBugsFiles(toEnabledPathMap(cfg.getExcludeBaselineBugsPaths()));
+
         // rank threshold is handled via BugReporter in SpotBugsExecutor
         // plugins are loaded via a temporary context ClassLoader in SpotBugsExecutor
-        // TODO: excludeFilterPath can be applied to engine if/when a stable API is adopted
     }
 
     private static String toEffortString(Effort e) {
@@ -24,5 +33,39 @@ public class PreferencesApplier {
             case MAX: return "max";
             default: return "default";
         }
+    }
+
+    private static List<String> resolveExcludeFilterPaths(AnalysisConfig cfg) {
+        List<String> configured = cfg.getExcludeFilterPaths();
+        if (configured != null && !configured.isEmpty()) {
+            return configured;
+        }
+        String legacyPath = normalizePath(cfg.getExcludeFilterPath());
+        if (legacyPath == null) {
+            return Collections.emptyList();
+        }
+        return Collections.singletonList(legacyPath);
+    }
+
+    private static Map<String, Boolean> toEnabledPathMap(List<String> paths) {
+        if (paths == null || paths.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<String, Boolean> files = new LinkedHashMap<>();
+        for (String path : paths) {
+            String normalized = normalizePath(path);
+            if (normalized != null) {
+                files.put(normalized, Boolean.TRUE);
+            }
+        }
+        return files.isEmpty() ? Collections.emptyMap() : files;
+    }
+
+    private static String normalizePath(String path) {
+        if (path == null) {
+            return null;
+        }
+        String trimmed = path.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 }

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
           "spotbugs.analysis.includeFilterPaths": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "pattern": "^.*\\.xml$"
             },
             "default": [],
             "uniqueItems": true,
@@ -102,7 +103,8 @@
           "spotbugs.analysis.excludeFilterPaths": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "pattern": "^.*\\.xml$"
             },
             "default": [],
             "uniqueItems": true,
@@ -112,7 +114,8 @@
           "spotbugs.analysis.excludeBaselineBugsPaths": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "pattern": "^.*\\.xml$"
             },
             "default": [],
             "uniqueItems": true,

--- a/package.json
+++ b/package.json
@@ -88,6 +88,36 @@
             "minimum": 1,
             "maximum": 20,
             "scope": "window"
+          },
+          "spotbugs.analysis.includeFilterPaths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "uniqueItems": true,
+            "markdownDescription": "SpotBugs XML include filter file paths (`-include`). Supports absolute paths and workspace-relative paths.",
+            "scope": "window"
+          },
+          "spotbugs.analysis.excludeFilterPaths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "uniqueItems": true,
+            "markdownDescription": "SpotBugs XML exclude filter file paths (`-exclude`). Supports absolute paths and workspace-relative paths.",
+            "scope": "window"
+          },
+          "spotbugs.analysis.excludeBaselineBugsPaths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "uniqueItems": true,
+            "markdownDescription": "SpotBugs XML baseline bug collection file paths (`-excludeBugs`). Supports absolute paths and workspace-relative paths.",
+            "scope": "window"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -88,8 +88,15 @@
             "minimum": 1,
             "maximum": 20,
             "scope": "window"
-          },
-          "spotbugs.analysis.includeFilterPaths": {
+          }
+        }
+      },
+      {
+        "type": "object",
+        "title": "SpotBugs: Filters",
+        "order": 1,
+        "properties": {
+          "spotbugs.filters.includePaths": {
             "type": "array",
             "items": {
               "type": "string",
@@ -100,7 +107,7 @@
             "markdownDescription": "SpotBugs XML include filter file paths (`-include`). Supports absolute paths and workspace-relative paths.",
             "scope": "window"
           },
-          "spotbugs.analysis.excludeFilterPaths": {
+          "spotbugs.filters.excludePaths": {
             "type": "array",
             "items": {
               "type": "string",
@@ -111,7 +118,7 @@
             "markdownDescription": "SpotBugs XML exclude filter file paths (`-exclude`). Supports absolute paths and workspace-relative paths.",
             "scope": "window"
           },
-          "spotbugs.analysis.excludeBaselineBugsPaths": {
+          "spotbugs.filters.excludeBaselineBugsPaths": {
             "type": "array",
             "items": {
               "type": "string",

--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -3,10 +3,8 @@ export const SETTINGS_SECTION = 'spotbugs';
 export const settingKeys = {
   analysisEffort: 'analysis.effort',
   analysisPriorityThreshold: 'analysis.priorityThreshold',
-  analysisIncludeFilterPaths: 'analysis.includeFilterPaths',
-  analysisExcludeFilterPaths: 'analysis.excludeFilterPaths',
-  analysisExcludeBaselineBugsPaths: 'analysis.excludeBaselineBugsPaths',
-  // Legacy key kept as read-only fallback for backward compatibility.
-  filtersExcludeFilterPath: 'filters.excludeFilterPath',
+  filtersIncludePaths: 'filters.includePaths',
+  filtersExcludePaths: 'filters.excludePaths',
+  filtersExcludeBaselineBugsPaths: 'filters.excludeBaselineBugsPaths',
   pluginsPaths: 'plugins.paths',
 } as const;

--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -3,6 +3,10 @@ export const SETTINGS_SECTION = 'spotbugs';
 export const settingKeys = {
   analysisEffort: 'analysis.effort',
   analysisPriorityThreshold: 'analysis.priorityThreshold',
+  analysisIncludeFilterPaths: 'analysis.includeFilterPaths',
+  analysisExcludeFilterPaths: 'analysis.excludeFilterPaths',
+  analysisExcludeBaselineBugsPaths: 'analysis.excludeBaselineBugsPaths',
+  // Legacy key kept as read-only fallback for backward compatibility.
   filtersExcludeFilterPath: 'filters.excludeFilterPath',
   pluginsPaths: 'plugins.paths',
 } as const;

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -9,7 +9,7 @@ export interface AnalysisSettings {
   includeFilterPaths?: string[];
   excludeFilterPaths?: string[];
   excludeBaselineBugsPaths?: string[];
-  // Legacy field kept for compatibility with older Java runner schema.
+  // Legacy payload field kept for compatibility with older Java runner schema.
   excludeFilterPath?: string;
   plugins?: string[];
 }
@@ -23,7 +23,7 @@ export class Config {
   public includeFilterPaths?: string[];
   public excludeFilterPaths?: string[];
   public excludeBaselineBugsPaths?: string[];
-  // Legacy key/value kept as fallback only.
+  // Legacy payload field kept for compatibility with older Java runner schema.
   public excludeFilterPath?: string;
   public plugins?: string[];
 
@@ -43,26 +43,17 @@ export class Config {
     this.priorityThreshold = typeof pt === 'number' ? pt : undefined;
 
     this.includeFilterPaths = this.readXmlPathArray(
-      settingKeys.analysisIncludeFilterPaths,
-      config.get<unknown>(settingKeys.analysisIncludeFilterPaths)
+      settingKeys.filtersIncludePaths,
+      config.get<unknown>(settingKeys.filtersIncludePaths)
     );
     this.excludeFilterPaths = this.readXmlPathArray(
-      settingKeys.analysisExcludeFilterPaths,
-      config.get<unknown>(settingKeys.analysisExcludeFilterPaths)
+      settingKeys.filtersExcludePaths,
+      config.get<unknown>(settingKeys.filtersExcludePaths)
     );
     this.excludeBaselineBugsPaths = this.readXmlPathArray(
-      settingKeys.analysisExcludeBaselineBugsPaths,
-      config.get<unknown>(settingKeys.analysisExcludeBaselineBugsPaths)
+      settingKeys.filtersExcludeBaselineBugsPaths,
+      config.get<unknown>(settingKeys.filtersExcludeBaselineBugsPaths)
     );
-
-    // Legacy key fallback (read-only): used only when new exclude list is unset.
-    const legacyExcludeFilterPath = this.normalizeString(
-      config.get<string | undefined>(settingKeys.filtersExcludeFilterPath)
-    );
-    this.excludeFilterPath = legacyExcludeFilterPath;
-    if (!this.excludeFilterPaths && legacyExcludeFilterPath) {
-      this.excludeFilterPaths = [legacyExcludeFilterPath];
-    }
 
     this.plugins = this.readStringArray(config.get<unknown>(settingKeys.pluginsPaths));
   }
@@ -74,14 +65,6 @@ export class Config {
     const folder = workspace.workspaceFolders?.[0];
     if (!folder) return p; // leave as-is if no workspace
     return path.resolve(Uri.parse(folder.uri.toString()).fsPath, p);
-  }
-
-  private normalizeString(value: string | undefined): string | undefined {
-    if (typeof value !== 'string') {
-      return undefined;
-    }
-    const trimmed = value.trim();
-    return trimmed.length > 0 ? trimmed : undefined;
   }
 
   private readStringArray(raw: unknown): string[] | undefined {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,6 +1,7 @@
 import { workspace, ExtensionContext, Uri } from 'vscode';
 import * as path from 'path';
 import { SETTINGS_SECTION, settingKeys } from '../constants/settings';
+import { Logger } from './logger';
 
 export interface AnalysisSettings {
   effort: string;
@@ -41,13 +42,16 @@ export class Config {
     const pt = config.get<number | undefined>(settingKeys.analysisPriorityThreshold);
     this.priorityThreshold = typeof pt === 'number' ? pt : undefined;
 
-    this.includeFilterPaths = this.readStringArray(
+    this.includeFilterPaths = this.readXmlPathArray(
+      settingKeys.analysisIncludeFilterPaths,
       config.get<unknown>(settingKeys.analysisIncludeFilterPaths)
     );
-    this.excludeFilterPaths = this.readStringArray(
+    this.excludeFilterPaths = this.readXmlPathArray(
+      settingKeys.analysisExcludeFilterPaths,
       config.get<unknown>(settingKeys.analysisExcludeFilterPaths)
     );
-    this.excludeBaselineBugsPaths = this.readStringArray(
+    this.excludeBaselineBugsPaths = this.readXmlPathArray(
+      settingKeys.analysisExcludeBaselineBugsPaths,
       config.get<unknown>(settingKeys.analysisExcludeBaselineBugsPaths)
     );
 
@@ -96,6 +100,24 @@ export class Config {
     }
     const values = Array.from(deduped);
     return values.length > 0 ? values : undefined;
+  }
+
+  private readXmlPathArray(settingKey: string, raw: unknown): string[] | undefined {
+    const values = this.readStringArray(raw);
+    if (!values) {
+      return undefined;
+    }
+    const xmlOnly: string[] = [];
+    for (const value of values) {
+      if (/\.xml$/i.test(value)) {
+        xmlOnly.push(value);
+      } else {
+        Logger.log(
+          `Ignoring non-XML value in ${SETTINGS_SECTION}.${settingKey}: "${value}" (expected *.xml)`
+        );
+      }
+    }
+    return xmlOnly.length > 0 ? xmlOnly : undefined;
   }
 
   private resolvePathsToAbsolute(paths: string[] | undefined): string[] | undefined {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -5,6 +5,10 @@ import { SETTINGS_SECTION, settingKeys } from '../constants/settings';
 export interface AnalysisSettings {
   effort: string;
   priorityThreshold?: number;
+  includeFilterPaths?: string[];
+  excludeFilterPaths?: string[];
+  excludeBaselineBugsPaths?: string[];
+  // Legacy field kept for compatibility with older Java runner schema.
   excludeFilterPath?: string;
   plugins?: string[];
 }
@@ -15,6 +19,10 @@ export class Config {
   public effort!: string;
   // Future-ready fields (optional; only sent when defined)
   public priorityThreshold?: number;
+  public includeFilterPaths?: string[];
+  public excludeFilterPaths?: string[];
+  public excludeBaselineBugsPaths?: string[];
+  // Legacy key/value kept as fallback only.
   public excludeFilterPath?: string;
   public plugins?: string[];
 
@@ -30,20 +38,29 @@ export class Config {
     const effort = config.get<string>(settingKeys.analysisEffort) ?? 'default';
     this.effort = (effort || 'default').toLowerCase();
 
-    // M2: read optional future fields if present (no UI contribution yet)
     const pt = config.get<number | undefined>(settingKeys.analysisPriorityThreshold);
     this.priorityThreshold = typeof pt === 'number' ? pt : undefined;
 
-    const filterPath = config.get<string | undefined>(settingKeys.filtersExcludeFilterPath);
-    this.excludeFilterPath = filterPath && filterPath.trim().length > 0 ? filterPath : undefined;
+    this.includeFilterPaths = this.readStringArray(
+      config.get<unknown>(settingKeys.analysisIncludeFilterPaths)
+    );
+    this.excludeFilterPaths = this.readStringArray(
+      config.get<unknown>(settingKeys.analysisExcludeFilterPaths)
+    );
+    this.excludeBaselineBugsPaths = this.readStringArray(
+      config.get<unknown>(settingKeys.analysisExcludeBaselineBugsPaths)
+    );
 
-    const plugs = config.get<unknown>(settingKeys.pluginsPaths) as unknown;
-    if (Array.isArray(plugs)) {
-      const arr = plugs.filter((v) => typeof v === 'string' && v.trim().length > 0) as string[];
-      this.plugins = arr.length > 0 ? arr : undefined;
-    } else {
-      this.plugins = undefined;
+    // Legacy key fallback (read-only): used only when new exclude list is unset.
+    const legacyExcludeFilterPath = this.normalizeString(
+      config.get<string | undefined>(settingKeys.filtersExcludeFilterPath)
+    );
+    this.excludeFilterPath = legacyExcludeFilterPath;
+    if (!this.excludeFilterPaths && legacyExcludeFilterPath) {
+      this.excludeFilterPaths = [legacyExcludeFilterPath];
     }
+
+    this.plugins = this.readStringArray(config.get<unknown>(settingKeys.pluginsPaths));
   }
 
   // Resolve a workspace-relative path to absolute (best-effort)
@@ -55,6 +72,47 @@ export class Config {
     return path.resolve(Uri.parse(folder.uri.toString()).fsPath, p);
   }
 
+  private normalizeString(value: string | undefined): string | undefined {
+    if (typeof value !== 'string') {
+      return undefined;
+    }
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  private readStringArray(raw: unknown): string[] | undefined {
+    if (!Array.isArray(raw)) {
+      return undefined;
+    }
+    const deduped = new Set<string>();
+    for (const entry of raw) {
+      if (typeof entry !== 'string') {
+        continue;
+      }
+      const trimmed = entry.trim();
+      if (trimmed.length > 0) {
+        deduped.add(trimmed);
+      }
+    }
+    const values = Array.from(deduped);
+    return values.length > 0 ? values : undefined;
+  }
+
+  private resolvePathsToAbsolute(paths: string[] | undefined): string[] | undefined {
+    if (!Array.isArray(paths) || paths.length === 0) {
+      return undefined;
+    }
+    const resolved = new Set<string>();
+    for (const entry of paths) {
+      const absolute = this.resolveToAbsolute(entry);
+      if (absolute && absolute.trim().length > 0) {
+        resolved.add(absolute);
+      }
+    }
+    const values = Array.from(resolved);
+    return values.length > 0 ? values : undefined;
+  }
+
   public getAnalysisSettings(): AnalysisSettings {
     const settings: AnalysisSettings = {
       effort: this.effort,
@@ -62,8 +120,19 @@ export class Config {
     if (typeof this.priorityThreshold === 'number') {
       settings.priorityThreshold = this.priorityThreshold;
     }
-    if (this.excludeFilterPath) {
-      settings.excludeFilterPath = this.resolveToAbsolute(this.excludeFilterPath);
+    const includeFilterPaths = this.resolvePathsToAbsolute(this.includeFilterPaths);
+    if (includeFilterPaths) {
+      settings.includeFilterPaths = includeFilterPaths;
+    }
+    const excludeFilterPaths = this.resolvePathsToAbsolute(this.excludeFilterPaths);
+    if (excludeFilterPaths) {
+      settings.excludeFilterPaths = excludeFilterPaths;
+      // Backward compatibility for older Java runner payload schema.
+      settings.excludeFilterPath = excludeFilterPaths[0];
+    }
+    const excludeBaselineBugsPaths = this.resolvePathsToAbsolute(this.excludeBaselineBugsPaths);
+    if (excludeBaselineBugsPaths) {
+      settings.excludeBaselineBugsPaths = excludeBaselineBugsPaths;
     }
     if (Array.isArray(this.plugins) && this.plugins.length > 0) {
       settings.plugins = this.plugins.slice();

--- a/src/lsp/analysisRequestBuilder.ts
+++ b/src/lsp/analysisRequestBuilder.ts
@@ -18,6 +18,18 @@ export function buildAnalysisRequestPayload(
   if (typeof settings.priorityThreshold === 'number') {
     payload.priorityThreshold = settings.priorityThreshold;
   }
+  if (Array.isArray(settings.includeFilterPaths) && settings.includeFilterPaths.length > 0) {
+    payload.includeFilterPaths = settings.includeFilterPaths.slice();
+  }
+  if (Array.isArray(settings.excludeFilterPaths) && settings.excludeFilterPaths.length > 0) {
+    payload.excludeFilterPaths = settings.excludeFilterPaths.slice();
+  }
+  if (
+    Array.isArray(settings.excludeBaselineBugsPaths) &&
+    settings.excludeBaselineBugsPaths.length > 0
+  ) {
+    payload.excludeBaselineBugsPaths = settings.excludeBaselineBugsPaths.slice();
+  }
   if (settings.excludeFilterPath) {
     payload.excludeFilterPath = settings.excludeFilterPath;
   }
@@ -27,4 +39,3 @@ export function buildAnalysisRequestPayload(
 
   return payload;
 }
-

--- a/src/model/analysisProtocol.ts
+++ b/src/model/analysisProtocol.ts
@@ -6,6 +6,10 @@ export interface AnalysisRequestPayload {
   classpaths?: string[] | null;
   sourcepaths?: string[] | null;
   priorityThreshold?: number;
+  includeFilterPaths?: string[];
+  excludeFilterPaths?: string[];
+  excludeBaselineBugsPaths?: string[];
+  // Legacy field kept for backward compatibility with older runner schema.
   excludeFilterPath?: string;
   plugins?: string[];
 }

--- a/src/services/analysisService.ts
+++ b/src/services/analysisService.ts
@@ -10,6 +10,7 @@ import { runSpotBugsAnalysis } from '../lsp/spotbugsClient';
 import { parseAnalysisResponse } from '../lsp/spotbugsParser';
 import { buildAnalysisRequestPayload } from '../lsp/analysisRequestBuilder';
 import { mapBugsToFindings } from '../lsp/spotbugsMapper';
+import { validateFilterFilesPreflight } from './filterFileValidation';
 import {
   resolveFileAnalysisTarget,
   resolveProjectAnalysisTarget,
@@ -145,7 +146,25 @@ async function runAnalysis(
   context: AnalysisContext
 ): Promise<AnalysisOutcome> {
   const targetPath = context.targetPath;
-  const payload = buildAnalysisRequestPayload(config.getAnalysisSettings(), {
+  const settings = config.getAnalysisSettings();
+  const preflightFilterError = await validateFilterFilesPreflight(settings);
+  if (preflightFilterError) {
+    const combined = formatAnalysisErrors([preflightFilterError]);
+    Logger.error(`SpotBugs filter configuration error: ${combined}`);
+    return {
+      findings: [],
+      errors: [preflightFilterError],
+      targetPath,
+      failure: {
+        kind: 'analysis-error',
+        level: 'error',
+        code: preflightFilterError.code,
+        message: `SpotBugs analysis failed: ${combined}`,
+      },
+    };
+  }
+
+  const payload = buildAnalysisRequestPayload(settings, {
     classpaths: context.classpaths ?? null,
     sourcepaths: context.sourcepaths ?? null,
   });
@@ -194,6 +213,7 @@ async function runAnalysis(
     Logger.error(`SpotBugs analysis error: ${combined}`);
     const hasResults = bugs.length > 0;
     if (!hasResults) {
+      const firstErrorCode = errors.find((error) => !!error.code)?.code;
       return {
         findings: [],
         errors,
@@ -203,6 +223,7 @@ async function runAnalysis(
         failure: {
           kind: 'analysis-error',
           level: 'error',
+          code: firstErrorCode,
           message: `SpotBugs analysis failed: ${combined}`,
         },
       };

--- a/src/services/filterFileValidation.ts
+++ b/src/services/filterFileValidation.ts
@@ -1,0 +1,98 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { AnalysisSettings } from '../core/config';
+import type { AnalysisError } from '../model/analysisProtocol';
+
+type FilterKind = 'include' | 'exclude' | 'baseline';
+
+const CODE_FILTER_NOT_FOUND = 'CFG_FILTER_NOT_FOUND';
+const CODE_FILTER_NOT_FILE = 'CFG_FILTER_NOT_FILE';
+const CODE_FILTER_UNREADABLE = 'CFG_FILTER_UNREADABLE';
+
+export async function validateFilterFilesPreflight(
+  settings: AnalysisSettings
+): Promise<AnalysisError | undefined> {
+  const includeError = await validateFilterGroup('include', settings.includeFilterPaths);
+  if (includeError) {
+    return includeError;
+  }
+  const excludeError = await validateFilterGroup('exclude', settings.excludeFilterPaths);
+  if (excludeError) {
+    return excludeError;
+  }
+  return validateFilterGroup('baseline', settings.excludeBaselineBugsPaths);
+}
+
+async function validateFilterGroup(
+  kind: FilterKind,
+  paths: string[] | undefined
+): Promise<AnalysisError | undefined> {
+  if (!Array.isArray(paths) || paths.length === 0) {
+    return undefined;
+  }
+  for (const rawPath of paths) {
+    const absolutePath = toAbsolutePath(rawPath);
+    let stat: fs.Stats | undefined;
+    try {
+      stat = await safeStat(absolutePath);
+    } catch (error) {
+      return {
+        code: CODE_FILTER_UNREADABLE,
+        message: `${kind} filter file is not readable: ${absolutePath} (${rootCauseMessage(error)})`,
+      };
+    }
+    if (!stat) {
+      return {
+        code: CODE_FILTER_NOT_FOUND,
+        message: `${kind} filter file not found: ${absolutePath}`,
+      };
+    }
+    if (!stat.isFile()) {
+      return {
+        code: CODE_FILTER_NOT_FILE,
+        message: `${kind} filter file is not a regular file: ${absolutePath}`,
+      };
+    }
+    try {
+      await fs.promises.access(absolutePath, fs.constants.R_OK);
+    } catch (error) {
+      return {
+        code: CODE_FILTER_UNREADABLE,
+        message: `${kind} filter file is not readable: ${absolutePath} (${rootCauseMessage(error)})`,
+      };
+    }
+  }
+  return undefined;
+}
+
+async function safeStat(absolutePath: string): Promise<fs.Stats | undefined> {
+  try {
+    return await fs.promises.stat(absolutePath);
+  } catch (error) {
+    const errno = error as NodeJS.ErrnoException;
+    if (errno && errno.code === 'ENOENT') {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+function toAbsolutePath(rawPath: string): string {
+  const trimmed = rawPath.trim();
+  if (path.isAbsolute(trimmed)) {
+    return trimmed;
+  }
+  return path.resolve(trimmed);
+}
+
+function rootCauseMessage(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return 'Unknown error';
+  }
+  let root: Error = error;
+  while (root.cause instanceof Error) {
+    root = root.cause;
+  }
+  const message = root.message?.trim();
+  return message && message.length > 0 ? message : root.name;
+}

--- a/src/test/analysisRequestBuilder.unit.test.ts
+++ b/src/test/analysisRequestBuilder.unit.test.ts
@@ -1,0 +1,85 @@
+import * as assert from 'assert';
+import { buildAnalysisRequestPayload } from '../lsp/analysisRequestBuilder';
+import type { AnalysisSettings } from '../core/config';
+
+function makeSettings(overrides: Partial<AnalysisSettings> = {}): AnalysisSettings {
+  return {
+    effort: 'default',
+    ...overrides,
+  };
+}
+
+describe('analysisRequestBuilder', () => {
+  it('includes include/exclude/excludeBaseline filter paths in payload', () => {
+    const include = ['/tmp/spotbugs/include.xml'];
+    const exclude = ['/tmp/spotbugs/exclude.xml'];
+    const baseline = ['/tmp/spotbugs/baseline.xml'];
+
+    const payload = buildAnalysisRequestPayload(
+      makeSettings({
+        includeFilterPaths: include,
+        excludeFilterPaths: exclude,
+        excludeBaselineBugsPaths: baseline,
+      }),
+      {
+        classpaths: ['/workspace/build/classes'],
+        sourcepaths: ['/workspace/src/main/java'],
+      }
+    );
+
+    assert.deepStrictEqual(payload.includeFilterPaths, include);
+    assert.deepStrictEqual(payload.excludeFilterPaths, exclude);
+    assert.deepStrictEqual(payload.excludeBaselineBugsPaths, baseline);
+  });
+
+  it('omits filter fields when arrays are empty', () => {
+    const payload = buildAnalysisRequestPayload(
+      makeSettings({
+        includeFilterPaths: [],
+        excludeFilterPaths: [],
+        excludeBaselineBugsPaths: [],
+      }),
+      {}
+    );
+
+    assert.strictEqual('includeFilterPaths' in payload, false);
+    assert.strictEqual('excludeFilterPaths' in payload, false);
+    assert.strictEqual('excludeBaselineBugsPaths' in payload, false);
+  });
+
+  it('keeps legacy excludeFilterPath for backward compatibility', () => {
+    const payload = buildAnalysisRequestPayload(
+      makeSettings({
+        excludeFilterPaths: ['/tmp/spotbugs/exclude.xml'],
+        excludeFilterPath: '/tmp/spotbugs/exclude.xml',
+      }),
+      {}
+    );
+
+    assert.deepStrictEqual(payload.excludeFilterPaths, ['/tmp/spotbugs/exclude.xml']);
+    assert.strictEqual(payload.excludeFilterPath, '/tmp/spotbugs/exclude.xml');
+  });
+
+  it('copies filter arrays to prevent payload mutation from caller arrays', () => {
+    const include = ['/tmp/spotbugs/include.xml'];
+    const exclude = ['/tmp/spotbugs/exclude.xml'];
+    const baseline = ['/tmp/spotbugs/baseline.xml'];
+
+    const payload = buildAnalysisRequestPayload(
+      makeSettings({
+        includeFilterPaths: include,
+        excludeFilterPaths: exclude,
+        excludeBaselineBugsPaths: baseline,
+      }),
+      {}
+    );
+
+    include.push('/tmp/spotbugs/include2.xml');
+    exclude.push('/tmp/spotbugs/exclude2.xml');
+    baseline.push('/tmp/spotbugs/baseline2.xml');
+
+    assert.deepStrictEqual(payload.includeFilterPaths, ['/tmp/spotbugs/include.xml']);
+    assert.deepStrictEqual(payload.excludeFilterPaths, ['/tmp/spotbugs/exclude.xml']);
+    assert.deepStrictEqual(payload.excludeBaselineBugsPaths, ['/tmp/spotbugs/baseline.xml']);
+  });
+});

--- a/src/test/bugFormatter.unit.test.ts
+++ b/src/test/bugFormatter.unit.test.ts
@@ -1,0 +1,36 @@
+import * as assert from 'assert';
+import { formatFindingSummary } from '../formatters/findingFormatting';
+import { Bug } from '../model/bug';
+
+function makeBug(overrides: Partial<Bug>): Bug {
+  return {
+    type: 'NP',
+    rank: 10,
+    priority: 'M',
+    category: 'BAD_PRACTICE',
+    abbrev: 'NP',
+    message: 'NP: Something in Foo',
+    sourceFile: 'Foo.java',
+    startLine: 10,
+    endLine: 10,
+    realSourcePath: 'com/foo/Foo.java',
+    ...overrides,
+  };
+}
+
+describe('formatFindingSummary', () => {
+  it('strips pattern prefix and " in " suffix', () => {
+    const bug = makeBug({ message: 'NP: Null pointer in foo.Bar' });
+    assert.strictEqual(formatFindingSummary(bug), '[NP] Null pointer');
+  });
+
+  it('uses plain message when no prefix exists', () => {
+    const bug = makeBug({ abbrev: 'UR', type: 'UR', message: 'Uninitialized read in foo.Baz' });
+    assert.strictEqual(formatFindingSummary(bug), '[UR] Uninitialized read');
+  });
+
+  it('falls back to bug type when message is empty', () => {
+    const bug = makeBug({ abbrev: '', type: 'DMI', message: '   ' });
+    assert.strictEqual(formatFindingSummary(bug), '[DMI] DMI');
+  });
+});

--- a/src/test/extension.vscode.test.ts
+++ b/src/test/extension.vscode.test.ts
@@ -1,0 +1,26 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { SpotBugsCommands } from '../constants/commands';
+
+suite('Extension activation', () => {
+  test('registers SpotBugs commands', async () => {
+    const extensionId = 'shblue21.vscode-spotbugs';
+    const extension = vscode.extensions.getExtension(extensionId);
+    assert.ok(extension, `Extension ${extensionId} not found`);
+
+    await extension!.activate();
+    const registered = await vscode.commands.getCommands(true);
+
+    const expected = [
+      SpotBugsCommands.RUN_ANALYSIS,
+      SpotBugsCommands.RUN_WORKSPACE,
+      SpotBugsCommands.OPEN_BUG_LOCATION,
+      SpotBugsCommands.EXPORT_SARIF,
+      SpotBugsCommands.RESET_RESULTS,
+    ];
+
+    for (const cmd of expected) {
+      assert.ok(registered.includes(cmd), `Missing command: ${cmd}`);
+    }
+  });
+});

--- a/src/test/filterFileValidation.unit.test.ts
+++ b/src/test/filterFileValidation.unit.test.ts
@@ -1,0 +1,81 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { AnalysisSettings } from '../core/config';
+import { validateFilterFilesPreflight } from '../services/filterFileValidation';
+
+function makeSettings(overrides: Partial<AnalysisSettings> = {}): AnalysisSettings {
+  return {
+    effort: 'default',
+    ...overrides,
+  };
+}
+
+async function makeTempDir(): Promise<string> {
+  return fs.promises.mkdtemp(path.join(os.tmpdir(), 'spotbugs-filter-test-'));
+}
+
+async function writeFile(filePath: string, content: string): Promise<void> {
+  await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.promises.writeFile(filePath, content);
+}
+
+async function cleanup(dir: string): Promise<void> {
+  await fs.promises.rm(dir, { recursive: true, force: true });
+}
+
+describe('filterFileValidation', () => {
+  it('returns CFG_FILTER_NOT_FOUND when filter file does not exist', async () => {
+    const missingPath = path.join(
+      os.tmpdir(),
+      `spotbugs-missing-${process.pid}-${Date.now()}-include.xml`
+    );
+    const error = await validateFilterFilesPreflight(
+      makeSettings({ includeFilterPaths: [missingPath] })
+    );
+
+    assert.ok(error);
+    assert.strictEqual(error?.code, 'CFG_FILTER_NOT_FOUND');
+    assert.ok((error?.message ?? '').includes('include filter file not found'));
+  });
+
+  it('returns CFG_FILTER_NOT_FILE when filter path points to a directory', async () => {
+    const dir = await makeTempDir();
+    try {
+      const error = await validateFilterFilesPreflight(
+        makeSettings({ excludeFilterPaths: [dir] })
+      );
+
+      assert.ok(error);
+      assert.strictEqual(error?.code, 'CFG_FILTER_NOT_FILE');
+      assert.ok((error?.message ?? '').includes('exclude filter file is not a regular file'));
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('passes when configured filter files are readable regular files', async () => {
+    const dir = await makeTempDir();
+    try {
+      const includePath = path.join(dir, 'include.xml');
+      const excludePath = path.join(dir, 'exclude.xml');
+      const baselinePath = path.join(dir, 'baseline.xml');
+      await writeFile(includePath, '<FindBugsFilter/>');
+      await writeFile(excludePath, '<FindBugsFilter/>');
+      await writeFile(baselinePath, '<BugCollection/>');
+
+      const error = await validateFilterFilesPreflight(
+        makeSettings({
+          includeFilterPaths: [includePath],
+          excludeFilterPaths: [excludePath],
+          excludeBaselineBugsPaths: [baselinePath],
+        })
+      );
+
+      assert.strictEqual(error, undefined);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+});

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -1,0 +1,41 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as Mocha from 'mocha';
+
+export function run(): Promise<void> {
+  const mocha = new Mocha({ ui: 'bdd', color: true });
+  const testsRoot = path.resolve(__dirname);
+  const files = collectTestFiles(testsRoot);
+
+  for (const file of files) {
+    mocha.addFile(file);
+  }
+
+  return new Promise((resolve, reject) => {
+    try {
+      mocha.run((failures) => {
+        if (failures > 0) {
+          reject(new Error(`${failures} test(s) failed.`));
+          return;
+        }
+        resolve();
+      });
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+function collectTestFiles(dir: string): string[] {
+  const results: string[] = [];
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectTestFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.vscode.test.js')) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}

--- a/src/test/outputResolver.unit.test.ts
+++ b/src/test/outputResolver.unit.test.ts
@@ -1,0 +1,55 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  findOutputFolderFromProject,
+  hasClassTargets,
+  isBytecodeTarget,
+} from '../workspace/outputResolver';
+
+async function makeTempDir(): Promise<string> {
+  return fs.promises.mkdtemp(path.join(os.tmpdir(), 'spotbugs-test-'));
+}
+
+async function writeFile(filePath: string): Promise<void> {
+  await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.promises.writeFile(filePath, '');
+}
+
+async function cleanup(dir: string): Promise<void> {
+  await fs.promises.rm(dir, { recursive: true, force: true });
+}
+
+describe('outputResolver', () => {
+  it('detects bytecode target extensions', () => {
+    assert.strictEqual(isBytecodeTarget('Foo.class'), true);
+    assert.strictEqual(isBytecodeTarget('Foo.jar'), true);
+    assert.strictEqual(isBytecodeTarget('Foo.zip'), true);
+    assert.strictEqual(isBytecodeTarget('Foo.java'), false);
+  });
+
+  it('detects class files under a directory', async () => {
+    const dir = await makeTempDir();
+    try {
+      const classFile = path.join(dir, 'classes', 'Foo.class');
+      await writeFile(classFile);
+      const has = await hasClassTargets(dir);
+      assert.strictEqual(has, true);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('finds default output folders with class files', async () => {
+    const dir = await makeTempDir();
+    try {
+      const outputDir = path.join(dir, 'build', 'classes', 'java', 'main');
+      await writeFile(path.join(outputDir, 'Foo.class'));
+      const found = await findOutputFolderFromProject(dir);
+      assert.strictEqual(found, outputDir);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+});

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -1,0 +1,21 @@
+import * as path from 'path';
+import { runTests } from '@vscode/test-electron';
+
+async function main(): Promise<void> {
+  try {
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../');
+    const extensionTestsPath = path.resolve(__dirname, './index');
+
+    await runTests({ extensionDevelopmentPath, extensionTestsPath });
+  } catch (error) {
+    console.error('Failed to run VS Code tests');
+    if (error instanceof Error) {
+      console.error(error.message);
+    } else {
+      console.error(String(error));
+    }
+    process.exit(1);
+  }
+}
+
+main();

--- a/src/test/spotbugsParser.unit.test.ts
+++ b/src/test/spotbugsParser.unit.test.ts
@@ -1,0 +1,48 @@
+import * as assert from 'assert';
+import { parseAnalysisResponse } from '../lsp/spotbugsParser';
+
+describe('spotbugsParser', () => {
+  it('returns invalid-json error for malformed payloads', () => {
+    const result = parseAnalysisResponse('{');
+    assert.strictEqual(result.ok, false);
+    if (!result.ok) {
+      assert.strictEqual(result.error.kind, 'invalid-json');
+      assert.strictEqual(result.error.message, 'Invalid response payload.');
+    }
+  });
+
+  it('returns analysis-error when payload contains top-level error', () => {
+    const result = parseAnalysisResponse(JSON.stringify({ error: 'boom' }));
+    assert.strictEqual(result.ok, false);
+    if (!result.ok) {
+      assert.strictEqual(result.error.kind, 'analysis-error');
+      assert.strictEqual(result.error.message, 'boom');
+    }
+  });
+
+  it('parses array responses as bugs', () => {
+    const result = parseAnalysisResponse(JSON.stringify([{ type: 'NP' }]));
+    assert.strictEqual(result.ok, true);
+    if (result.ok) {
+      assert.strictEqual(result.value.bugs.length, 1);
+    }
+  });
+
+  it('parses envelope responses with errors and stats', () => {
+    const result = parseAnalysisResponse(
+      JSON.stringify({
+        schemaVersion: 1,
+        results: [{ type: 'UR' }],
+        errors: [{ code: 'X', message: 'warn' }],
+        stats: { target: '/tmp/Foo', durationMs: 12 },
+      })
+    );
+    assert.strictEqual(result.ok, true);
+    if (result.ok) {
+      assert.strictEqual(result.value.schemaVersion, 1);
+      assert.strictEqual(result.value.bugs.length, 1);
+      assert.strictEqual(result.value.errors?.length, 1);
+      assert.strictEqual(result.value.stats?.target, '/tmp/Foo');
+    }
+  });
+});

--- a/src/test/spotbugsParser.unit.test.ts
+++ b/src/test/spotbugsParser.unit.test.ts
@@ -42,6 +42,8 @@ describe('spotbugsParser', () => {
       assert.strictEqual(result.value.schemaVersion, 1);
       assert.strictEqual(result.value.bugs.length, 1);
       assert.strictEqual(result.value.errors?.length, 1);
+      assert.strictEqual(result.value.errors?.[0]?.code, 'X');
+      assert.strictEqual(result.value.errors?.[0]?.message, 'warn');
       assert.strictEqual(result.value.stats?.target, '/tmp/Foo');
     }
   });


### PR DESCRIPTION
## Summary

- Add include, exclude, and baseline filter settings across TypeScript and Java.
- Validate filter files and return structured configuration errors.