### PR TITLE
feat: add client-side filters to the SpotBugs tree view

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,6 +147,11 @@
         "title": "Open Bug Location"
       },
       {
+        "command": "spotbugs.filterResults",
+        "title": "Filter SpotBugs Findings",
+        "icon": "$(filter)"
+      },
+      {
         "command": "spotbugs.exportSarif",
         "title": "Export SpotBugs Findings (SARIF)",
         "icon": "$(file-code)"
@@ -170,9 +175,14 @@
           "group": "navigation@1"
         },
         {
-          "command": "spotbugs.resetResults",
+          "command": "spotbugs.filterResults",
           "when": "view == spotbugs-view",
           "group": "navigation@2"
+        },
+        {
+          "command": "spotbugs.resetResults",
+          "when": "view == spotbugs-view",
+          "group": "navigation@3"
         }
       ],
       "explorer/context": [

--- a/src/commands/filter.ts
+++ b/src/commands/filter.ts
@@ -1,0 +1,114 @@
+import { QuickPickItem, window } from 'vscode';
+import { SpotBugsTreeDataProvider } from '../ui/spotbugsTreeDataProvider';
+import {
+  FindingFilterKind,
+  getFindingFilterDisplayLabel,
+  getFindingFilterKindLabel,
+  getFindingFilterKinds,
+} from '../ui/findingFilters';
+
+type FilterKindPickItem =
+  | (QuickPickItem & { action: 'kind'; filterKind: FindingFilterKind })
+  | (QuickPickItem & { action: 'clear-all' });
+
+type FilterValuePickItem =
+  | (QuickPickItem & { action: 'set'; value: string })
+  | (QuickPickItem & { action: 'clear-kind' });
+
+export async function selectFindingFilter(
+  provider: SpotBugsTreeDataProvider
+): Promise<void> {
+  const cachedFindings = provider.getCachedFindings();
+  if (cachedFindings.length === 0) {
+    await window.showInformationMessage('No cached SpotBugs findings available to filter.');
+    return;
+  }
+
+  const activeFilters = provider.getActiveFilters();
+  const kindItems: FilterKindPickItem[] = getFindingFilterKinds().flatMap((filterKind) => {
+    const options = provider.getFilterOptions(filterKind);
+    const currentValue = activeFilters[filterKind];
+    if (options.length === 0 && !currentValue) {
+      return [];
+    }
+
+    const description = currentValue
+      ? `Current: ${getFindingFilterDisplayLabel(cachedFindings, filterKind, currentValue)}`
+      : undefined;
+    const detail = `${options.length} available value${options.length === 1 ? '' : 's'}`;
+    return [
+      {
+        action: 'kind' as const,
+        filterKind,
+        label: getFindingFilterKindLabel(filterKind),
+        description,
+        detail,
+      },
+    ];
+  });
+
+  if (Object.keys(activeFilters).length > 0) {
+    kindItems.push({
+      action: 'clear-all',
+      label: 'Clear all filters',
+      description: 'Restore the full cached result set',
+    });
+  }
+
+  const selectedKind = await window.showQuickPick<FilterKindPickItem>(kindItems, {
+    title: 'SpotBugs Filters',
+    placeHolder: 'Choose a filter kind to update',
+  });
+
+  if (!selectedKind) {
+    return;
+  }
+
+  if (selectedKind.action === 'clear-all') {
+    provider.clearFilters();
+    return;
+  }
+
+  const kind = selectedKind.filterKind;
+  const options = provider.getFilterOptions(kind);
+  const valueItems: FilterValuePickItem[] = [];
+  const currentValue = activeFilters[kind];
+
+  if (currentValue) {
+    valueItems.push({
+      action: 'clear-kind',
+      label: `Clear ${getFindingFilterKindLabel(kind)} filter`,
+      description: getFindingFilterDisplayLabel(cachedFindings, kind, currentValue),
+    });
+  }
+
+  valueItems.push(
+    ...options.map((option) => ({
+      action: 'set' as const,
+      value: option.value,
+      label: option.label,
+      description: formatFindingCount(option.count),
+      detail: option.detail,
+    }))
+  );
+
+  const selectedValue = await window.showQuickPick<FilterValuePickItem>(valueItems, {
+    title: `SpotBugs Filter: ${getFindingFilterKindLabel(kind)}`,
+    placeHolder: `Choose a ${getFindingFilterKindLabel(kind).toLowerCase()} value`,
+  });
+
+  if (!selectedValue) {
+    return;
+  }
+
+  if (selectedValue.action === 'clear-kind') {
+    provider.clearFilter(kind);
+    return;
+  }
+
+  provider.setFilter(kind, selectedValue.value);
+}
+
+function formatFindingCount(count: number): string {
+  return `${count} finding${count === 1 ? '' : 's'}`;
+}

--- a/src/constants/commands.ts
+++ b/src/constants/commands.ts
@@ -11,6 +11,7 @@ export namespace SpotBugsCommands {
   export const RUN_ANALYSIS: string = 'spotbugs.run';
   export const RUN_WORKSPACE: string = 'spotbugs.runWorkspace';
   export const OPEN_BUG_LOCATION: string = 'spotbugs.openBugLocation';
+  export const FILTER_RESULTS: string = 'spotbugs.filterResults';
   export const EXPORT_SARIF: string = 'spotbugs.exportSarif';
   export const RESET_RESULTS: string = 'spotbugs.resetResults';
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import { openBugLocation } from './commands/navigation';
 import { Config } from './core/config';
 import { Logger } from './core/logger';
 import { defaultNotifier } from './core/notifier';
+import { selectFindingFilter } from './commands/filter';
 import { exportSarifReport } from './commands/export';
 import { resetResults } from './commands/reset';
 import { SpotBugsDiagnosticsManager } from './services/diagnosticsManager';
@@ -74,6 +75,13 @@ async function doActivate(
         SpotBugsCommands.OPEN_BUG_LOCATION,
         async (bug) => {
           await openBugLocation(bug);
+        }
+      ),
+
+      instrumentOperationAsVsCodeCommand(
+        SpotBugsCommands.FILTER_RESULTS,
+        async () => {
+          await selectFindingFilter(spotbugsTreeDataProvider);
         }
       ),
 

--- a/src/test/extension.vscode.test.ts
+++ b/src/test/extension.vscode.test.ts
@@ -15,6 +15,7 @@ suite('Extension activation', () => {
       SpotBugsCommands.RUN_ANALYSIS,
       SpotBugsCommands.RUN_WORKSPACE,
       SpotBugsCommands.OPEN_BUG_LOCATION,
+      SpotBugsCommands.FILTER_RESULTS,
       SpotBugsCommands.EXPORT_SARIF,
       SpotBugsCommands.RESET_RESULTS,
     ];

--- a/src/test/findingFilters.unit.test.ts
+++ b/src/test/findingFilters.unit.test.ts
@@ -1,0 +1,131 @@
+import * as assert from 'assert';
+import {
+  applyFindingFilters,
+  createFilteredEmptyState,
+  getFindingFilterOptions,
+} from '../ui/findingFilters';
+import { Finding } from '../model/finding';
+
+function makeFinding(overrides: Partial<Finding>): Finding {
+  return {
+    patternId: 'NP',
+    type: 'NP',
+    rank: 10,
+    priority: 'M',
+    category: 'BAD_PRACTICE',
+    abbrev: 'NP',
+    message: 'NP: Null pointer in foo.Bar',
+    className: 'com.acme.Foo',
+    location: {
+      sourceFile: 'Foo.java',
+      realSourcePath: 'com/acme/Foo.java',
+      fullPath: '/workspace/com/acme/Foo.java',
+      startLine: 10,
+      endLine: 10,
+    },
+    ...overrides,
+  };
+}
+
+describe('findingFilters', () => {
+  const findings: Finding[] = [
+    makeFinding({ rank: 2 }),
+    makeFinding({
+      rank: 4,
+      className: 'com.other.Foo',
+      location: {
+        sourceFile: 'Foo.java',
+        realSourcePath: 'com/other/Foo.java',
+        fullPath: '/workspace/com/other/Foo.java',
+      },
+    }),
+    makeFinding({
+      patternId: 'UR',
+      type: 'UR',
+      rank: 6,
+      category: 'CORRECTNESS',
+      abbrev: 'UR',
+      message: 'UR: Unread value in foo.Bar',
+      className: 'com.acme.Bar',
+      location: {
+        sourceFile: 'Bar.java',
+        realSourcePath: 'com/acme/Bar.java',
+      },
+    }),
+    makeFinding({
+      patternId: 'DMI',
+      type: 'DMI',
+      rank: 14,
+      category: 'PERFORMANCE',
+      abbrev: 'DMI',
+      message: 'DMI: Inefficient call in helper.Util',
+      className: 'Helper',
+      location: {
+        sourceFile: 'Helper.java',
+        realSourcePath: 'Helper.java',
+      },
+    }),
+  ];
+
+  it('extracts ordered severity options with counts', () => {
+    const options = getFindingFilterOptions(findings, {}, 'severity');
+    assert.deepStrictEqual(
+      options.map((option) => ({ label: option.label, count: option.count })),
+      [
+        { label: 'Error', count: 2 },
+        { label: 'Warning', count: 1 },
+        { label: 'Info', count: 1 },
+      ]
+    );
+  });
+
+  it('extracts package and rule options from cached findings', () => {
+    const packageOptions = getFindingFilterOptions(findings, {}, 'package');
+    assert.deepStrictEqual(
+      packageOptions.map((option) => option.label),
+      ['<default package>', 'com.acme', 'com.other']
+    );
+
+    const ruleOptions = getFindingFilterOptions(findings, {}, 'rule');
+    assert.deepStrictEqual(
+      ruleOptions.map((option) => ({ value: option.value, label: option.label, count: option.count })),
+      [
+        { value: 'DMI', label: '[DMI] Inefficient call', count: 1 },
+        { value: 'NP', label: '[NP] Null pointer', count: 2 },
+        { value: 'UR', label: '[UR] Unread value', count: 1 },
+      ]
+    );
+  });
+
+  it('narrows available values using other active filters', () => {
+    const options = getFindingFilterOptions(findings, { severity: 'Error' }, 'package');
+    assert.deepStrictEqual(
+      options.map((option) => option.label),
+      ['com.acme', 'com.other']
+    );
+  });
+
+  it('applies multiple filter kinds to the cached findings', () => {
+    const filtered = applyFindingFilters(findings, {
+      severity: 'Warning',
+      package: 'com.acme',
+      class: 'com.acme.Bar',
+      rule: 'UR',
+      path: 'com/acme/Bar.java',
+      category: 'CORRECTNESS',
+    });
+
+    assert.strictEqual(filtered.length, 1);
+    assert.strictEqual(filtered[0].className, 'com.acme.Bar');
+  });
+
+  it('describes the active filters in the zero-result empty state', () => {
+    const emptyState = createFilteredEmptyState(findings, {
+      severity: 'Error',
+      rule: 'NP',
+    });
+
+    assert.strictEqual(emptyState.label, 'No cached findings match the current filters.');
+    assert.strictEqual(emptyState.description, 'Severity: Error • Rule: [NP] Null pointer');
+  });
+});

--- a/src/ui/findingFilters.ts
+++ b/src/ui/findingFilters.ts
@@ -1,0 +1,276 @@
+import { formatFindingPatternLabel, rankToSeverity } from '../formatters/findingFormatting';
+import { Finding } from '../model/finding';
+
+export type FindingFilterKind =
+  | 'severity'
+  | 'category'
+  | 'package'
+  | 'class'
+  | 'path'
+  | 'rule';
+
+export type FindingFilterState = Partial<Record<FindingFilterKind, string>>;
+
+export interface FindingFilterOption {
+  value: string;
+  label: string;
+  count: number;
+  detail?: string;
+}
+
+const FILTER_KIND_LABELS: Record<FindingFilterKind, string> = {
+  severity: 'Severity',
+  category: 'Category',
+  package: 'Package',
+  class: 'Class',
+  path: 'Path',
+  rule: 'Rule',
+};
+
+const FILTER_KIND_ORDER: FindingFilterKind[] = [
+  'severity',
+  'category',
+  'package',
+  'class',
+  'path',
+  'rule',
+];
+
+const SEVERITY_LABELS: Record<'error' | 'warning' | 'info', string> = {
+  error: 'Error',
+  warning: 'Warning',
+  info: 'Info',
+};
+
+const SEVERITY_ORDER = ['Error', 'Warning', 'Info'];
+const DEFAULT_PACKAGE_LABEL = '<default package>';
+
+export function getFindingFilterKinds(): FindingFilterKind[] {
+  return FILTER_KIND_ORDER.slice();
+}
+
+export function getFindingFilterKindLabel(kind: FindingFilterKind): string {
+  return FILTER_KIND_LABELS[kind];
+}
+
+export function applyFindingFilters(
+  findings: Finding[],
+  filters: FindingFilterState
+): Finding[] {
+  return findings.filter((finding) =>
+    FILTER_KIND_ORDER.every((kind) => {
+      const expected = filters[kind];
+      if (!expected) {
+        return true;
+      }
+      return getFindingFilterValue(finding, kind) === expected;
+    })
+  );
+}
+
+export function getFindingFilterOptions(
+  findings: Finding[],
+  filters: FindingFilterState,
+  kind: FindingFilterKind
+): FindingFilterOption[] {
+  const scopedFindings = applyFindingFilters(findings, omitFindingFilter(filters, kind));
+  const counts = new Map<string, { label: string; count: number; detail?: string }>();
+
+  for (const finding of scopedFindings) {
+    const option = toFindingFilterOption(kind, finding);
+    if (!option) {
+      continue;
+    }
+
+    const existing = counts.get(option.value);
+    if (existing) {
+      existing.count += 1;
+      continue;
+    }
+
+    counts.set(option.value, {
+      label: option.label,
+      count: 1,
+      detail: option.detail,
+    });
+  }
+
+  return sortFindingFilterOptions(kind, counts);
+}
+
+export function describeFindingFilters(
+  findings: Finding[],
+  filters: FindingFilterState
+): string | undefined {
+  const parts = FILTER_KIND_ORDER.flatMap((kind) => {
+    const value = filters[kind];
+    if (!value) {
+      return [];
+    }
+    return [`${getFindingFilterKindLabel(kind)}: ${getFindingFilterLabel(findings, kind, value)}`];
+  });
+
+  if (parts.length === 0) {
+    return undefined;
+  }
+
+  return parts.join(' • ');
+}
+
+export function getFindingFilterDisplayLabel(
+  findings: Finding[],
+  kind: FindingFilterKind,
+  value: string
+): string {
+  return getFindingFilterLabel(findings, kind, value);
+}
+
+export function createFilteredEmptyState(
+  findings: Finding[],
+  filters: FindingFilterState
+): { label: string; description?: string } {
+  return {
+    label: 'No cached findings match the current filters.',
+    description: describeFindingFilters(findings, filters),
+  };
+}
+
+function getFindingFilterValue(
+  finding: Finding,
+  kind: FindingFilterKind
+): string | undefined {
+  return toFindingFilterOption(kind, finding)?.value;
+}
+
+function getFindingFilterLabel(
+  findings: Finding[],
+  kind: FindingFilterKind,
+  value: string
+): string {
+  const matching = getFindingFilterOptions(findings, {}, kind).find((option) => option.value === value);
+  return matching?.label || value;
+}
+
+function omitFindingFilter(
+  filters: FindingFilterState,
+  kindToOmit: FindingFilterKind
+): FindingFilterState {
+  const next: FindingFilterState = {};
+  for (const kind of FILTER_KIND_ORDER) {
+    if (kind === kindToOmit) {
+      continue;
+    }
+    const value = filters[kind];
+    if (value) {
+      next[kind] = value;
+    }
+  }
+  return next;
+}
+
+function toFindingFilterOption(
+  kind: FindingFilterKind,
+  finding: Finding
+): Omit<FindingFilterOption, 'count'> | undefined {
+  if (kind === 'severity') {
+    const severity = rankToSeverity(finding.rank);
+    return {
+      value: SEVERITY_LABELS[severity],
+      label: SEVERITY_LABELS[severity],
+      detail:
+        severity === 'error'
+          ? 'Rank 1-4'
+          : severity === 'warning'
+            ? 'Rank 5-9'
+            : 'Rank 10+ or unknown',
+    };
+  }
+
+  if (kind === 'category') {
+    const category = finding.category || 'Uncategorized';
+    return { value: category, label: category };
+  }
+
+  if (kind === 'package') {
+    const packageName = extractPackageName(finding);
+    if (!packageName) {
+      return undefined;
+    }
+    return { value: packageName, label: packageName };
+  }
+
+  if (kind === 'class') {
+    const className = finding.className;
+    if (!className) {
+      return undefined;
+    }
+    return { value: className, label: className };
+  }
+
+  if (kind === 'path') {
+    const filePath =
+      finding.location.fullPath || finding.location.realSourcePath || finding.location.sourceFile;
+    if (!filePath) {
+      return undefined;
+    }
+    return { value: filePath, label: filePath };
+  }
+
+  const ruleValue = finding.patternId;
+  if (!ruleValue) {
+    return undefined;
+  }
+  return {
+    value: ruleValue,
+    label: formatFindingPatternLabel(finding),
+    detail: ruleValue,
+  };
+}
+
+function extractPackageName(finding: Finding): string | undefined {
+  if (finding.className) {
+    const lastDot = finding.className.lastIndexOf('.');
+    if (lastDot < 0) {
+      return DEFAULT_PACKAGE_LABEL;
+    }
+    return finding.className.substring(0, lastDot);
+  }
+
+  const relativePath = finding.location.realSourcePath;
+  if (!relativePath) {
+    return undefined;
+  }
+
+  const normalized = relativePath.replace(/\\/g, '/');
+  const slashIndex = normalized.lastIndexOf('/');
+  if (slashIndex < 0) {
+    return DEFAULT_PACKAGE_LABEL;
+  }
+  return normalized.substring(0, slashIndex).replace(/\//g, '.');
+}
+
+function sortFindingFilterOptions(
+  kind: FindingFilterKind,
+  counts: Map<string, { label: string; count: number; detail?: string }>
+): FindingFilterOption[] {
+  const options = Array.from(counts.entries()).map(([value, entry]) => ({
+    value,
+    label: entry.label,
+    count: entry.count,
+    detail: entry.detail,
+  }));
+
+  if (kind === 'severity') {
+    return options.sort(
+      (a, b) => SEVERITY_ORDER.indexOf(a.value) - SEVERITY_ORDER.indexOf(b.value)
+    );
+  }
+
+  return options.sort((a, b) => {
+    const labelCompare = a.label.localeCompare(b.label);
+    if (labelCompare !== 0) {
+      return labelCompare;
+    }
+    return a.value.localeCompare(b.value);
+  });
+}

--- a/src/ui/spotbugsTreeDataProvider.ts
+++ b/src/ui/spotbugsTreeDataProvider.ts
@@ -10,6 +10,14 @@ import {
 } from './findingTreeItem';
 import * as path from 'path';
 import { groupFindingsByCategoryAndPattern } from './treeModel';
+import {
+  applyFindingFilters,
+  createFilteredEmptyState,
+  type FindingFilterKind,
+  type FindingFilterOption,
+  type FindingFilterState,
+  getFindingFilterOptions,
+} from './findingFilters';
 
 export class SpotBugsTreeDataProvider implements TreeDataProvider<TreeItem> {
   private _onDidChangeTreeData: EventEmitter<TreeItem | undefined | null> =
@@ -19,7 +27,9 @@ export class SpotBugsTreeDataProvider implements TreeDataProvider<TreeItem> {
 
   private viewItems: TreeItem[] = [];
   private projectItems: Map<string, ProjectStatusItem> = new Map();
-  private lastResults: Finding[] = [];
+  private cachedResults: Finding[] = [];
+  private visibleResults: Finding[] = [];
+  private activeFilters: FindingFilterState = {};
 
   constructor() {
     this.showInitialMessage();
@@ -42,14 +52,20 @@ export class SpotBugsTreeDataProvider implements TreeDataProvider<TreeItem> {
   }
 
   public showInitialMessage(): void {
-    this.viewItems = [new TreeItem('Ready to analyze. Click the search icon to start.')];
-    this.lastResults = [];
+    this.projectItems.clear();
+    this.cachedResults = [];
+    this.visibleResults = [];
+    this.activeFilters = {};
+    this.viewItems = [this.createMessageItem('Ready to analyze. Click the search icon to start.')];
     this._onDidChangeTreeData.fire(undefined);
   }
 
   public showLoading(): void {
-    this.viewItems = [new TreeItem('Analyzing...')];
-    this.lastResults = [];
+    this.projectItems.clear();
+    this.cachedResults = [];
+    this.visibleResults = [];
+    this.activeFilters = {};
+    this.viewItems = [this.createMessageItem('Analyzing...')];
     this._onDidChangeTreeData.fire(undefined);
   }
 
@@ -63,7 +79,9 @@ export class SpotBugsTreeDataProvider implements TreeDataProvider<TreeItem> {
       this.projectItems.set(uriString, item);
     }
     this.viewItems = items;
-    this.lastResults = [];
+    this.cachedResults = [];
+    this.visibleResults = [];
+    this.activeFilters = {};
     this._onDidChangeTreeData.fire(undefined);
   }
 
@@ -89,24 +107,57 @@ export class SpotBugsTreeDataProvider implements TreeDataProvider<TreeItem> {
   }
 
   public showResults(findings: Finding[]): void {
-    if (!findings || findings.length === 0) {
-      this.viewItems = [new TreeItem('No issues found.')];
-      this.lastResults = [];
-    } else {
-      const categories = groupFindingsByCategoryAndPattern(findings);
-      this.viewItems = categories.map((category) => {
-        const patterns = category.patterns.map(
-          (pattern) => new PatternGroupItem(pattern.label, pattern.findings)
-        );
-        return new CategoryGroupItem(category.name, patterns, category.total);
-      });
-      this.lastResults = findings.slice();
-    }
+    this.projectItems.clear();
+    this.cachedResults = findings ? findings.slice() : [];
+    this.refreshResultsView();
     this._onDidChangeTreeData.fire(undefined);
   }
 
+  public getCachedFindings(): Finding[] {
+    return this.cachedResults.slice();
+  }
+
   public getAllFindings(): Finding[] {
-    return this.lastResults.slice();
+    return this.visibleResults.slice();
+  }
+
+  public getActiveFilters(): FindingFilterState {
+    return { ...this.activeFilters };
+  }
+
+  public getFilterOptions(kind: FindingFilterKind): FindingFilterOption[] {
+    return getFindingFilterOptions(this.cachedResults, this.activeFilters, kind);
+  }
+
+  public setFilter(kind: FindingFilterKind, value: string): void {
+    this.activeFilters = {
+      ...this.activeFilters,
+      [kind]: value,
+    };
+    this.refreshResultsView();
+    this._onDidChangeTreeData.fire(undefined);
+  }
+
+  public clearFilter(kind: FindingFilterKind): void {
+    if (!this.activeFilters[kind]) {
+      return;
+    }
+
+    const nextFilters = { ...this.activeFilters };
+    delete nextFilters[kind];
+    this.activeFilters = nextFilters;
+    this.refreshResultsView();
+    this._onDidChangeTreeData.fire(undefined);
+  }
+
+  public clearFilters(): void {
+    if (Object.keys(this.activeFilters).length === 0) {
+      return;
+    }
+
+    this.activeFilters = {};
+    this.refreshResultsView();
+    this._onDidChangeTreeData.fire(undefined);
   }
 
   public getFindingsForNode(element: TreeItem): Finding[] {
@@ -120,5 +171,37 @@ export class SpotBugsTreeDataProvider implements TreeDataProvider<TreeItem> {
       return [element.finding];
     }
     return [];
+  }
+
+  private refreshResultsView(): void {
+    if (this.cachedResults.length === 0) {
+      this.viewItems = [this.createMessageItem('No issues found.')];
+      this.visibleResults = [];
+      return;
+    }
+
+    const filteredFindings = applyFindingFilters(this.cachedResults, this.activeFilters);
+    this.visibleResults = filteredFindings.slice();
+
+    if (filteredFindings.length === 0) {
+      const emptyState = createFilteredEmptyState(this.cachedResults, this.activeFilters);
+      this.viewItems = [this.createMessageItem(emptyState.label, emptyState.description)];
+      return;
+    }
+
+    const categories = groupFindingsByCategoryAndPattern(filteredFindings);
+    this.viewItems = categories.map((category) => {
+      const patterns = category.patterns.map(
+        (pattern) => new PatternGroupItem(pattern.label, pattern.findings)
+      );
+      return new CategoryGroupItem(category.name, patterns, category.total);
+    });
+  }
+
+  private createMessageItem(label: string, description?: string): TreeItem {
+    const item = new TreeItem(label);
+    item.description = description;
+    item.contextValue = 'spotbugs.message';
+    return item;
   }
 }


### PR DESCRIPTION
## Summary

- Add client-side filtering controls to the Results tree.
- Apply filters to cached findings without rerunning analysis.