### PR TITLE
feat: add query-based filtering for cached SpotBugs tree results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ server/com.spotbugs.runner-0.0.1.jar
 *.tsbuildinfo
 
 **/dependency-reduced-pom.xml
+
+.vscode-test/**

--- a/src/commands/filter.ts
+++ b/src/commands/filter.ts
@@ -1,19 +1,10 @@
-import { QuickPickItem, window } from 'vscode';
+import { window } from 'vscode';
 import { SpotBugsTreeDataProvider } from '../ui/spotbugsTreeDataProvider';
 import {
-  FindingFilterKind,
-  getFindingFilterDisplayLabel,
-  getFindingFilterKindLabel,
-  getFindingFilterKinds,
+  formatFindingFilterQuery,
+  parseFindingFilterQuery,
+  validateFindingFilterQuery,
 } from '../ui/findingFilters';
-
-type FilterKindPickItem =
-  | (QuickPickItem & { action: 'kind'; filterKind: FindingFilterKind })
-  | (QuickPickItem & { action: 'clear-all' });
-
-type FilterValuePickItem =
-  | (QuickPickItem & { action: 'set'; value: string })
-  | (QuickPickItem & { action: 'clear-kind' });
 
 export async function selectFindingFilter(
   provider: SpotBugsTreeDataProvider
@@ -24,91 +15,30 @@ export async function selectFindingFilter(
     return;
   }
 
-  const activeFilters = provider.getActiveFilters();
-  const kindItems: FilterKindPickItem[] = getFindingFilterKinds().flatMap((filterKind) => {
-    const options = provider.getFilterOptions(filterKind);
-    const currentValue = activeFilters[filterKind];
-    if (options.length === 0 && !currentValue) {
-      return [];
-    }
-
-    const description = currentValue
-      ? `Current: ${getFindingFilterDisplayLabel(cachedFindings, filterKind, currentValue)}`
-      : undefined;
-    const detail = `${options.length} available value${options.length === 1 ? '' : 's'}`;
-    return [
-      {
-        action: 'kind' as const,
-        filterKind,
-        label: getFindingFilterKindLabel(filterKind),
-        description,
-        detail,
-      },
-    ];
-  });
-
-  if (Object.keys(activeFilters).length > 0) {
-    kindItems.push({
-      action: 'clear-all',
-      label: 'Clear all filters',
-      description: 'Restore the full cached result set',
-    });
-  }
-
-  const selectedKind = await window.showQuickPick<FilterKindPickItem>(kindItems, {
+  const input = await window.showInputBox({
     title: 'SpotBugs Filters',
-    placeHolder: 'Choose a filter kind to update',
+    prompt:
+      'Filter cached findings with key:value terms. Supported keys: severity, category, package, class, path, rule. Leave empty to clear filters.',
+    placeHolder:
+      'severity:error category:BAD_PRACTICE package:com.acme class:Foo path:src/main/java rule:NP',
+    value: formatFindingFilterQuery(provider.getActiveFilters()),
+    ignoreFocusOut: true,
+    validateInput: (value) => validateFindingFilterQuery(value),
   });
 
-  if (!selectedKind) {
+  if (input === undefined) {
     return;
   }
 
-  if (selectedKind.action === 'clear-all') {
+  if (!input.trim()) {
     provider.clearFilters();
     return;
   }
 
-  const kind = selectedKind.filterKind;
-  const options = provider.getFilterOptions(kind);
-  const valueItems: FilterValuePickItem[] = [];
-  const currentValue = activeFilters[kind];
-
-  if (currentValue) {
-    valueItems.push({
-      action: 'clear-kind',
-      label: `Clear ${getFindingFilterKindLabel(kind)} filter`,
-      description: getFindingFilterDisplayLabel(cachedFindings, kind, currentValue),
-    });
+  try {
+    provider.setFilters(parseFindingFilterQuery(input));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await window.showErrorMessage(`Unable to apply SpotBugs filters: ${message}`);
   }
-
-  valueItems.push(
-    ...options.map((option) => ({
-      action: 'set' as const,
-      value: option.value,
-      label: option.label,
-      description: formatFindingCount(option.count),
-      detail: option.detail,
-    }))
-  );
-
-  const selectedValue = await window.showQuickPick<FilterValuePickItem>(valueItems, {
-    title: `SpotBugs Filter: ${getFindingFilterKindLabel(kind)}`,
-    placeHolder: `Choose a ${getFindingFilterKindLabel(kind).toLowerCase()} value`,
-  });
-
-  if (!selectedValue) {
-    return;
-  }
-
-  if (selectedValue.action === 'clear-kind') {
-    provider.clearFilter(kind);
-    return;
-  }
-
-  provider.setFilter(kind, selectedValue.value);
-}
-
-function formatFindingCount(count: number): string {
-  return `${count} finding${count === 1 ? '' : 's'}`;
 }

--- a/src/test/findingFilters.unit.test.ts
+++ b/src/test/findingFilters.unit.test.ts
@@ -2,7 +2,10 @@ import * as assert from 'assert';
 import {
   applyFindingFilters,
   createFilteredEmptyState,
+  formatFindingFilterQuery,
   getFindingFilterOptions,
+  parseFindingFilterQuery,
+  validateFindingFilterQuery,
 } from '../ui/findingFilters';
 import { Finding } from '../model/finding';
 
@@ -117,6 +120,63 @@ describe('findingFilters', () => {
 
     assert.strictEqual(filtered.length, 1);
     assert.strictEqual(filtered[0].className, 'com.acme.Bar');
+  });
+
+  it('supports partial case-insensitive matching for text filters', () => {
+    const filtered = applyFindingFilters(findings, {
+      severity: 'warn',
+      category: 'correct',
+      package: 'ACME',
+      class: 'bar',
+      path: 'bar.java',
+      rule: 'unread',
+    });
+
+    assert.strictEqual(filtered.length, 1);
+    assert.strictEqual(filtered[0].className, 'com.acme.Bar');
+  });
+
+  it('normalizes severity aliases and path separators in query values', () => {
+    const filtered = applyFindingFilters(findings, {
+      severity: 'medium',
+      path: 'com\\acme\\Bar.java',
+    });
+
+    assert.strictEqual(filtered.length, 1);
+    assert.strictEqual(filtered[0].className, 'com.acme.Bar');
+  });
+
+  it('parses combined key:value queries and preserves quoted values', () => {
+    const parsed = parseFindingFilterQuery(
+      'severity:high category:CORRECTNESS path:"/workspace/My Project/com/acme/Bar.java" rule:UR'
+    );
+
+    assert.deepStrictEqual(parsed, {
+      severity: 'Error',
+      category: 'CORRECTNESS',
+      path: '/workspace/My Project/com/acme/Bar.java',
+      rule: 'UR',
+    });
+  });
+
+  it('formats active filters back into an input-box query string', () => {
+    const query = formatFindingFilterQuery({
+      severity: 'Error',
+      path: '/workspace/My Project/com/acme/Foo.java',
+      rule: 'NP',
+    });
+
+    assert.strictEqual(
+      query,
+      'severity:Error path:"/workspace/My Project/com/acme/Foo.java" rule:NP'
+    );
+  });
+
+  it('reports invalid query syntax for unsupported keys', () => {
+    assert.strictEqual(
+      validateFindingFilterQuery('owner:me'),
+      'Unsupported filter key "owner". Supported keys: severity, category, package, class, path, rule.'
+    );
   });
 
   it('describes the active filters in the zero-result empty state', () => {

--- a/src/test/findingFilters.unit.test.ts
+++ b/src/test/findingFilters.unit.test.ts
@@ -57,7 +57,7 @@ describe('findingFilters', () => {
     }),
     makeFinding({
       patternId: 'DMI',
-      type: 'DMI',
+      type: 'DMI_INVOKING_TOSTRING_ON_ARRAY',
       rank: 14,
       category: 'PERFORMANCE',
       abbrev: 'DMI',
@@ -136,6 +136,15 @@ describe('findingFilters', () => {
     assert.strictEqual(filtered[0].className, 'com.acme.Bar');
   });
 
+  it('matches rule filters against the full SpotBugs type when available', () => {
+    const filtered = applyFindingFilters(findings, {
+      rule: 'DMI_INVOKING_TOSTRING',
+    });
+
+    assert.strictEqual(filtered.length, 1);
+    assert.strictEqual(filtered[0].className, 'Helper');
+  });
+
   it('normalizes severity aliases and path separators in query values', () => {
     const filtered = applyFindingFilters(findings, {
       severity: 'medium',
@@ -156,6 +165,14 @@ describe('findingFilters', () => {
       category: 'CORRECTNESS',
       path: '/workspace/My Project/com/acme/Bar.java',
       rule: 'UR',
+    });
+  });
+
+  it('preserves backslashes in quoted Windows path queries', () => {
+    const parsed = parseFindingFilterQuery('path:"C:\\Users\\Foo Bar.java"');
+
+    assert.deepStrictEqual(parsed, {
+      path: 'C:\\Users\\Foo Bar.java',
     });
   });
 

--- a/src/ui/findingFilters.ts
+++ b/src/ui/findingFilters.ts
@@ -41,9 +41,16 @@ const SEVERITY_LABELS: Record<'error' | 'warning' | 'info', string> = {
   warning: 'Warning',
   info: 'Info',
 };
+const SEVERITY_ALIASES: Record<string, string> = {
+  high: 'Error',
+  medium: 'Warning',
+  med: 'Warning',
+  low: 'Info',
+};
 
 const SEVERITY_ORDER = ['Error', 'Warning', 'Info'];
 const DEFAULT_PACKAGE_LABEL = '<default package>';
+const FINDING_FILTER_QUERY_KEYS = new Set<FindingFilterKind>(FILTER_KIND_ORDER);
 
 export function getFindingFilterKinds(): FindingFilterKind[] {
   return FILTER_KIND_ORDER.slice();
@@ -63,9 +70,74 @@ export function applyFindingFilters(
       if (!expected) {
         return true;
       }
-      return getFindingFilterValue(finding, kind) === expected;
+      return findingMatchesFilter(finding, kind, expected);
     })
   );
+}
+
+export function parseFindingFilterQuery(query: string): FindingFilterState {
+  const filters: FindingFilterState = {};
+  const input = query.trim();
+
+  if (!input) {
+    return filters;
+  }
+
+  let index = 0;
+  while (index < input.length) {
+    index = skipWhitespace(input, index);
+    if (index >= input.length) {
+      break;
+    }
+
+    const keyStart = index;
+    while (index < input.length && /[A-Za-z]/.test(input[index])) {
+      index += 1;
+    }
+
+    if (keyStart === index || input[index] !== ':') {
+      throw new Error(
+        `Invalid filter syntax near "${input.slice(keyStart)}". Use key:value terms.`
+      );
+    }
+
+    const rawKey = input.slice(keyStart, index).toLowerCase();
+    if (!isFindingFilterKind(rawKey)) {
+      throw new Error(
+        `Unsupported filter key "${rawKey}". Supported keys: ${FILTER_KIND_ORDER.join(', ')}.`
+      );
+    }
+
+    index += 1;
+    if (index >= input.length) {
+      throw new Error(`Missing value for "${rawKey}:" filter.`);
+    }
+
+    const { value, nextIndex } = readFilterQueryValue(input, index, rawKey);
+    filters[rawKey] = value;
+    index = nextIndex;
+  }
+
+  return filters;
+}
+
+export function validateFindingFilterQuery(query: string): string | undefined {
+  try {
+    parseFindingFilterQuery(query);
+    return undefined;
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+}
+
+export function formatFindingFilterQuery(filters: FindingFilterState): string {
+  return FILTER_KIND_ORDER.flatMap((kind) => {
+    const value = filters[kind];
+    if (!value) {
+      return [];
+    }
+    return [`${kind}:${quoteFindingFilterValue(value)}`];
+  }).join(' ');
 }
 
 export function getFindingFilterOptions(
@@ -142,6 +214,38 @@ function getFindingFilterValue(
   return toFindingFilterOption(kind, finding)?.value;
 }
 
+function findingMatchesFilter(
+  finding: Finding,
+  kind: FindingFilterKind,
+  expected: string
+): boolean {
+  const normalizedExpected = normalizeFindingFilterInput(kind, expected);
+  if (!normalizedExpected) {
+    return true;
+  }
+
+  if (kind === 'severity') {
+    const value = getFindingFilterValue(finding, kind);
+    return value !== undefined && equalsIgnoreCase(value, normalizedExpected);
+  }
+
+  const option = toFindingFilterOption(kind, finding);
+  if (!option) {
+    return false;
+  }
+
+  const haystacks = [option.value, option.label, option.detail].filter(
+    (candidate): candidate is string => Boolean(candidate)
+  );
+
+  const normalizedHaystacks =
+    kind === 'path' ? haystacks.map((candidate) => normalizePathSeparators(candidate)) : haystacks;
+  const comparableExpected =
+    kind === 'path' ? normalizePathSeparators(normalizedExpected) : normalizedExpected;
+
+  return normalizedHaystacks.some((candidate) => containsIgnoreCase(candidate, comparableExpected));
+}
+
 function getFindingFilterLabel(
   findings: Finding[],
   kind: FindingFilterKind,
@@ -166,6 +270,40 @@ function omitFindingFilter(
     }
   }
   return next;
+}
+
+function normalizeFindingFilterInput(
+  kind: FindingFilterKind,
+  value: string
+): string | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  if (kind !== 'severity') {
+    return trimmed;
+  }
+
+  const alias = SEVERITY_ALIASES[trimmed.toLowerCase()];
+  if (alias) {
+    return alias;
+  }
+
+  const exact = SEVERITY_ORDER.find((label) => equalsIgnoreCase(label, trimmed));
+  if (exact) {
+    return exact;
+  }
+
+  const prefixMatches = SEVERITY_ORDER.filter((label) =>
+    label.toLowerCase().startsWith(trimmed.toLowerCase())
+  );
+
+  if (prefixMatches.length === 1) {
+    return prefixMatches[0];
+  }
+
+  return trimmed;
 }
 
 function toFindingFilterOption(
@@ -273,4 +411,90 @@ function sortFindingFilterOptions(
     }
     return a.value.localeCompare(b.value);
   });
+}
+
+function isFindingFilterKind(value: string): value is FindingFilterKind {
+  return FINDING_FILTER_QUERY_KEYS.has(value as FindingFilterKind);
+}
+
+function skipWhitespace(input: string, index: number): number {
+  let next = index;
+  while (next < input.length && /\s/.test(input[next])) {
+    next += 1;
+  }
+  return next;
+}
+
+function readFilterQueryValue(
+  input: string,
+  index: number,
+  key: FindingFilterKind
+): { value: string; nextIndex: number } {
+  if (input[index] === '"' || input[index] === "'") {
+    return readQuotedFilterQueryValue(input, index, key);
+  }
+
+  let nextIndex = index;
+  while (nextIndex < input.length && !/\s/.test(input[nextIndex])) {
+    nextIndex += 1;
+  }
+
+  const rawValue = input.slice(index, nextIndex);
+  const value = normalizeFindingFilterInput(key, rawValue);
+  if (!value) {
+    throw new Error(`Missing value for "${key}:" filter.`);
+  }
+
+  return { value, nextIndex };
+}
+
+function readQuotedFilterQueryValue(
+  input: string,
+  index: number,
+  key: FindingFilterKind
+): { value: string; nextIndex: number } {
+  const quote = input[index];
+  let cursor = index + 1;
+  let value = '';
+
+  while (cursor < input.length) {
+    const char = input[cursor];
+    if (char === '\\' && cursor + 1 < input.length) {
+      value += input[cursor + 1];
+      cursor += 2;
+      continue;
+    }
+    if (char === quote) {
+      const normalized = normalizeFindingFilterInput(key, value);
+      if (!normalized) {
+        throw new Error(`Missing value for "${key}:" filter.`);
+      }
+      return { value: normalized, nextIndex: cursor + 1 };
+    }
+    value += char;
+    cursor += 1;
+  }
+
+  throw new Error(`Unterminated quoted value for "${key}:" filter.`);
+}
+
+function quoteFindingFilterValue(value: string): string {
+  if (!/[\s"]/u.test(value)) {
+    return value;
+  }
+
+  const escaped = value.replace(/["\\]/g, '\\$&');
+  return `"${escaped}"`;
+}
+
+function containsIgnoreCase(haystack: string, needle: string): boolean {
+  return haystack.toLowerCase().includes(needle.toLowerCase());
+}
+
+function equalsIgnoreCase(left: string, right: string): boolean {
+  return left.localeCompare(right, undefined, { sensitivity: 'accent' }) === 0;
+}
+
+function normalizePathSeparators(value: string): string {
+  return value.replace(/\\/g, '/');
 }

--- a/src/ui/findingFilters.ts
+++ b/src/ui/findingFilters.ts
@@ -234,9 +234,7 @@ function findingMatchesFilter(
     return false;
   }
 
-  const haystacks = [option.value, option.label, option.detail].filter(
-    (candidate): candidate is string => Boolean(candidate)
-  );
+  const haystacks = getFindingFilterMatchTerms(finding, kind, option);
 
   const normalizedHaystacks =
     kind === 'path' ? haystacks.map((candidate) => normalizePathSeparators(candidate)) : haystacks;
@@ -460,9 +458,12 @@ function readQuotedFilterQueryValue(
   while (cursor < input.length) {
     const char = input[cursor];
     if (char === '\\' && cursor + 1 < input.length) {
-      value += input[cursor + 1];
-      cursor += 2;
-      continue;
+      const nextChar = input[cursor + 1];
+      if (nextChar === quote || nextChar === '\\') {
+        value += nextChar;
+        cursor += 2;
+        continue;
+      }
     }
     if (char === quote) {
       const normalized = normalizeFindingFilterInput(key, value);
@@ -497,4 +498,18 @@ function equalsIgnoreCase(left: string, right: string): boolean {
 
 function normalizePathSeparators(value: string): string {
   return value.replace(/\\/g, '/');
+}
+
+function getFindingFilterMatchTerms(
+  finding: Finding,
+  kind: FindingFilterKind,
+  option: Omit<FindingFilterOption, 'count'>
+): string[] {
+  const terms = [option.value, option.label, option.detail];
+
+  if (kind === 'rule' && finding.type) {
+    terms.push(finding.type);
+  }
+
+  return terms.filter((candidate): candidate is string => Boolean(candidate));
 }

--- a/src/ui/spotbugsTreeDataProvider.ts
+++ b/src/ui/spotbugsTreeDataProvider.ts
@@ -138,6 +138,12 @@ export class SpotBugsTreeDataProvider implements TreeDataProvider<TreeItem> {
     this._onDidChangeTreeData.fire(undefined);
   }
 
+  public setFilters(filters: FindingFilterState): void {
+    this.activeFilters = { ...filters };
+    this.refreshResultsView();
+    this._onDidChangeTreeData.fire(undefined);
+  }
+
   public clearFilter(kind: FindingFilterKind): void {
     if (!this.activeFilters[kind]) {
       return;


### PR DESCRIPTION
## Summary

- Add query-based filtering for cached Results findings.
- Match full rule types and preserve Windows source paths.