### PR TITLE
Rewrites legacy SpotBugs docs anchors

### DIFF
--- a/src/services/spotbugsDiagnosticSupport.ts
+++ b/src/services/spotbugsDiagnosticSupport.ts
@@ -1,8 +1,9 @@
 import { Diagnostic, Uri } from 'vscode';
 import { Finding } from '../model/finding';
-
-const GENERIC_SPOTBUGS_DOCS_URI =
-  'https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html';
+import {
+  GENERIC_SPOTBUGS_DOCS_URI,
+  rewriteLegacySpotBugsHelpUrl,
+} from './spotbugsDocumentationLinks';
 
 export const SPOTBUGS_DIAGNOSTIC_SOURCE = 'SpotBugs';
 
@@ -26,7 +27,7 @@ export function hasFindingLocalDescription(finding: Finding): boolean {
 export function getFindingRuleDocumentationUri(
   finding: Finding
 ): Uri | undefined {
-  return tryParseUri(finding.helpUri);
+  return tryParseUri(finding.helpUri, finding.type);
 }
 
 export function getFindingDocumentationUri(
@@ -42,14 +43,21 @@ export function isSpotBugsDiagnostic(diagnostic: Diagnostic): boolean {
   return diagnostic.source === SPOTBUGS_DIAGNOSTIC_SOURCE;
 }
 
-function tryParseUri(raw?: string): Uri | undefined {
+function tryParseUri(raw?: string, bugType?: string): Uri | undefined {
   const value = raw?.trim();
   if (!value) {
     return undefined;
   }
+
   try {
-    return Uri.parse(value);
+    const url = new URL(value);
+    rewriteLegacySpotBugsHelpUrl(url, bugType);
+    return Uri.parse(url.toString());
   } catch {
-    return undefined;
+    try {
+      return Uri.parse(value);
+    } catch {
+      return undefined;
+    }
   }
 }

--- a/src/services/spotbugsDocumentationLinks.ts
+++ b/src/services/spotbugsDocumentationLinks.ts
@@ -1,0 +1,55 @@
+export const GENERIC_SPOTBUGS_DOCS_URI =
+  'https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html';
+
+const SPOTBUGS_DOCS_HOSTNAME = 'spotbugs.readthedocs.io';
+const SPOTBUGS_BUG_DESCRIPTIONS_PATH_SUFFIX = '/bugDescriptions.html';
+const LEGACY_SPOTBUGS_ANCHOR_PATTERN = /^[A-Z0-9_]+$/;
+
+export function rewriteLegacySpotBugsHelpUrl(url: URL, bugType?: string): URL {
+  const normalizedBugType = normalizeLegacyBugType(bugType);
+  if (!normalizedBugType || !isSpotBugsBugDescriptionsUrl(url)) {
+    return url;
+  }
+
+  const fragment = normalizeLegacyBugType(readHashFragment(url.hash));
+  if (
+    !fragment ||
+    fragment !== normalizedBugType ||
+    !LEGACY_SPOTBUGS_ANCHOR_PATTERN.test(fragment)
+  ) {
+    return url;
+  }
+
+  url.hash = toSlugAnchor(fragment);
+  return url;
+}
+
+function isSpotBugsBugDescriptionsUrl(url: URL): boolean {
+  return (
+    (url.protocol === 'http:' || url.protocol === 'https:') &&
+    url.hostname === SPOTBUGS_DOCS_HOSTNAME &&
+    url.pathname.endsWith(SPOTBUGS_BUG_DESCRIPTIONS_PATH_SUFFIX)
+  );
+}
+
+function normalizeLegacyBugType(value?: string): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.toUpperCase() : undefined;
+}
+
+function readHashFragment(hash: string): string | undefined {
+  if (!hash || hash === '#') {
+    return undefined;
+  }
+
+  const raw = hash.slice(1);
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function toSlugAnchor(value: string): string {
+  return value.toLowerCase().replace(/_/g, '-');
+}

--- a/src/test/diagnosticsRuleDocs.vscode.test.ts
+++ b/src/test/diagnosticsRuleDocs.vscode.test.ts
@@ -9,12 +9,13 @@ import { SpotBugsDiagnosticsManager } from '../services/diagnosticsManager';
 import { SpotBugsDiagnosticCodeActionProvider } from '../services/spotbugsDiagnosticCodeActionProvider';
 
 const cleanupPaths = new Set<string>();
+const helpUri =
+  'https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#NP_ALWAYS_NULL';
+const rewrittenHelpUri =
+  'https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#np-always-null';
+const detailHtml = '<p>Local SpotBugs detail.</p>';
 
 describe('SpotBugs diagnostic explanations', () => {
-  const helpUri =
-    'https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#NP_ALWAYS_NULL';
-  const detailHtml = '<p>Local SpotBugs detail.</p>';
-
   afterEach(async () => {
     for (const targetPath of cleanupPaths) {
       await fs.rm(targetPath, { recursive: true, force: true });
@@ -67,7 +68,7 @@ describe('SpotBugs diagnostic explanations', () => {
       assert.deepStrictEqual(actions[0].diagnostics, [diagnostic]);
       assert.strictEqual(actions[1].title, 'Open SpotBugs rule docs');
       assert.strictEqual(actions[1].command?.command, 'vscode.open');
-      assert.strictEqual(actions[1].command?.arguments?.[0].toString(), helpUri);
+      assert.strictEqual(actions[1].command?.arguments?.[0].toString(), rewrittenHelpUri);
       assert.deepStrictEqual(actions[1].diagnostics, [diagnostic]);
     } finally {
       manager.dispose();
@@ -86,8 +87,22 @@ describe('SpotBugs diagnostic explanations', () => {
       assert.ok(code && typeof code === 'object' && 'target' in code);
       if (code && typeof code === 'object' && 'target' in code) {
         assert.strictEqual(code.value, 'NP_ALWAYS_NULL');
-        assert.strictEqual(code.target.toString(), helpUri);
+        assert.strictEqual(code.target.toString(), rewrittenHelpUri);
       }
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  it('keeps the raw finding helpUri unchanged after rewriting UI docs targets', async () => {
+    const manager = new SpotBugsDiagnosticsManager();
+    try {
+      const document = await openTempJavaDocument();
+      manager.replaceAll([createFinding(document.uri, { helpUri })]);
+
+      const [finding] = manager.getFindingsAt(document.uri, new vscode.Position(0, 0));
+      assert.ok(finding);
+      assert.strictEqual(finding.helpUri, helpUri);
     } finally {
       manager.dispose();
     }

--- a/src/test/findingDescriptionPanel.unit.test.ts
+++ b/src/test/findingDescriptionPanel.unit.test.ts
@@ -6,16 +6,22 @@ import {
 import { Finding } from '../model/finding';
 
 describe('findingDescriptionPanel', () => {
-  it('renders local HTML detail and keeps external docs secondary', () => {
+  it('renders local HTML detail and rewrites external docs to the slug anchor', () => {
     const html = renderFindingDescriptionHtml(
       makeFinding({
         detailHtml: '<p>Local detail body.</p>',
-        helpUri: 'https://example.test/rule',
+        helpUri:
+          'https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#NP_ALWAYS_NULL',
       })
     );
 
     assert.ok(html.includes('<p>Local detail body.</p>'));
     assert.ok(html.includes('Open external SpotBugs docs'));
+    assert.ok(
+      html.includes(
+        'https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#np-always-null'
+      )
+    );
   });
 
   it('removes disallowed tags, event handlers, and javascript links', () => {
@@ -31,20 +37,25 @@ describe('findingDescriptionPanel', () => {
     assert.ok(sanitized.includes('<a>Bad link</a>'));
   });
 
-  it('preserves allowlisted formatting tags and safe https links', () => {
+  it('preserves allowlisted formatting tags and rewrites matching SpotBugs detail links', () => {
     const sanitized = sanitizeFindingDetailHtml(
       [
         '<p>Intro with <code>code()</code>.</p>',
         '<pre>line 1\nline 2</pre>',
-        '<a href="https://example.test/rule" title="Rule docs">Docs</a>',
-      ].join('')
+        '<a href="https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#NP_ALWAYS_NULL" title="Rule docs">Docs</a>',
+        '<a href="https://example.test/rule">External</a>',
+      ].join(''),
+      'NP_ALWAYS_NULL'
     );
 
     assert.ok(sanitized.includes('<p>Intro with <code>code()</code>.</p>'));
     assert.ok(sanitized.includes('<pre>line 1\nline 2</pre>'));
     assert.ok(
-      sanitized.includes('<a href="https://example.test/rule" title="Rule docs">Docs</a>')
+      sanitized.includes(
+        '<a href="https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#np-always-null" title="Rule docs">Docs</a>'
+      )
     );
+    assert.ok(sanitized.includes('<a href="https://example.test/rule">External</a>'));
   });
 
   it('falls back to plain text detail when sanitized html becomes empty', () => {

--- a/src/ui/findingDescriptionRenderer.ts
+++ b/src/ui/findingDescriptionRenderer.ts
@@ -1,10 +1,12 @@
 import { formatFindingSummary } from '../formatters/findingFormatting';
 import { Finding } from '../model/finding';
+import {
+  GENERIC_SPOTBUGS_DOCS_URI,
+  rewriteLegacySpotBugsHelpUrl,
+} from '../services/spotbugsDocumentationLinks';
 import * as sanitizeHtml from 'sanitize-html';
 
 const PANEL_TITLE = 'SpotBugs Details';
-const GENERIC_SPOTBUGS_DOCS_URI =
-  'https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html';
 const DETAIL_HTML_ALLOWED_TAGS = [
   'p',
   'br',
@@ -28,35 +30,13 @@ const DETAIL_HTML_ALLOWED_TAGS = [
 ];
 const DETAIL_HTML_ALLOWED_SCHEMES = ['http', 'https', 'mailto'];
 const DETAIL_HTML_ALLOWED_PROTOCOLS = new Set(['http:', 'https:', 'mailto:']);
-const FINDING_DETAIL_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
-  allowedTags: DETAIL_HTML_ALLOWED_TAGS,
-  allowedAttributes: {
-    a: ['href', 'title'],
-  },
-  allowedSchemes: DETAIL_HTML_ALLOWED_SCHEMES,
-  allowedSchemesAppliedToAttributes: ['href'],
-  allowProtocolRelative: false,
-  disallowedTagsMode: 'discard',
-  transformTags: {
-    a: (_tagName, attribs) => {
-      const sanitizedHref = getAllowedDetailHref(attribs.href);
-      const sanitizedTitle = attribs.title?.trim();
-
-      return {
-        tagName: 'a',
-        attribs: {
-          ...(sanitizedHref ? { href: sanitizedHref } : {}),
-          ...(sanitizedTitle ? { title: sanitizedTitle } : {}),
-        },
-      };
-    },
-  },
-};
 
 export function renderFindingDescriptionHtml(finding: Finding): string {
   const title = getFindingDescriptionTitle(finding);
   const summary = formatFindingSummary(finding);
-  const docsHref = getExternalDocsHref(finding.helpUri) ?? GENERIC_SPOTBUGS_DOCS_URI;
+  const docsHref =
+    getExternalDocsHref(finding.helpUri, finding.type) ??
+    GENERIC_SPOTBUGS_DOCS_URI;
   const body = renderDescriptionBody(finding);
   const metadata = [
     finding.type ? ['Pattern', finding.type] : undefined,
@@ -192,14 +172,17 @@ export function renderFindingDescriptionHtml(finding: Finding): string {
 </html>`;
 }
 
-export function sanitizeFindingDetailHtml(raw: string): string {
-  return sanitizeHtml(raw, FINDING_DETAIL_SANITIZE_OPTIONS).trim();
+export function sanitizeFindingDetailHtml(
+  raw: string,
+  currentBugType?: string
+): string {
+  return sanitizeHtml(raw, getFindingDetailSanitizeOptions(currentBugType)).trim();
 }
 
 function renderDescriptionBody(finding: Finding): string {
   const detailHtml = finding.detailHtml?.trim();
   if (detailHtml) {
-    const sanitized = sanitizeFindingDetailHtml(detailHtml);
+    const sanitized = sanitizeFindingDetailHtml(detailHtml, finding.type);
     if (sanitized) {
       return sanitized;
     }
@@ -230,17 +213,53 @@ function escapeAttribute(value: string): string {
   return escapeHtml(value);
 }
 
-function getAllowedDetailHref(raw?: string): string | undefined {
-  return getAllowedAbsoluteUrl(raw, DETAIL_HTML_ALLOWED_PROTOCOLS);
+function getFindingDetailSanitizeOptions(
+  currentBugType?: string
+): sanitizeHtml.IOptions {
+  return {
+    allowedTags: DETAIL_HTML_ALLOWED_TAGS,
+    allowedAttributes: {
+      a: ['href', 'title'],
+    },
+    allowedSchemes: DETAIL_HTML_ALLOWED_SCHEMES,
+    allowedSchemesAppliedToAttributes: ['href'],
+    allowProtocolRelative: false,
+    disallowedTagsMode: 'discard',
+    transformTags: {
+      a: (_tagName, attribs) => {
+        const sanitizedHref = getAllowedDetailHref(attribs.href, currentBugType);
+        const sanitizedTitle = attribs.title?.trim();
+
+        return {
+          tagName: 'a',
+          attribs: {
+            ...(sanitizedHref ? { href: sanitizedHref } : {}),
+            ...(sanitizedTitle ? { title: sanitizedTitle } : {}),
+          },
+        };
+      },
+    },
+  };
 }
 
-function getExternalDocsHref(raw?: string): string | undefined {
-  return getAllowedAbsoluteUrl(raw, new Set(['http:', 'https:']));
+function getAllowedDetailHref(
+  raw?: string,
+  currentBugType?: string
+): string | undefined {
+  return getAllowedAbsoluteUrl(raw, DETAIL_HTML_ALLOWED_PROTOCOLS, currentBugType);
+}
+
+function getExternalDocsHref(
+  raw?: string,
+  currentBugType?: string
+): string | undefined {
+  return getAllowedAbsoluteUrl(raw, new Set(['http:', 'https:']), currentBugType);
 }
 
 function getAllowedAbsoluteUrl(
   raw: string | undefined,
-  allowedProtocols: ReadonlySet<string>
+  allowedProtocols: ReadonlySet<string>,
+  currentBugType?: string
 ): string | undefined {
   const trimmed = raw?.trim();
   if (!trimmed) {
@@ -250,6 +269,7 @@ function getAllowedAbsoluteUrl(
   try {
     const url = new URL(trimmed);
     if (allowedProtocols.has(url.protocol)) {
+      rewriteLegacySpotBugsHelpUrl(url, currentBugType);
       return url.toString();
     }
   } catch {


### PR DESCRIPTION
## Summary

- Rewrite legacy SpotBugs documentation anchors to current links.
- Apply the normalized links in diagnostics and finding details.