### PR TITLE
feat(classpath): split analysis classpath roles and add extra aux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Analyze Java code with SpotBugs directly in VS Code. View findings in a dedicate
 
 - `spotbugs.analysis.effort`: SpotBugs effort level (`min`, `default`, `max`). Default: `default`.
 - `spotbugs.analysis.priorityThreshold`: Report bugs with rank less than or equal to this value (1 = most severe, 20 = least). Default: `9`.
+- `spotbugs.analysis.extraAuxClasspaths`: Additional SpotBugs aux classpath entries appended after Java LS runtime classpath entries. Supports absolute and workspace-relative jar/directory paths.
+
+Source target resolution stays separate from aux classpath configuration. SpotBugs uses Java LS runtime classpaths plus any `extraAuxClasspaths` entries for aux analysis, and falls back to the runner's system classpath only when neither source provides any entries.
 
 ### Filters
 

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/api/CommandResponse.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/api/CommandResponse.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Map;
 
 public class CommandResponse {
-    private static final int SCHEMA_VERSION = 1;
+    private static final int SCHEMA_VERSION = 2;
 
     private final int schemaVersion;
     private final Object results;

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/api/ConfigSchema.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/api/ConfigSchema.java
@@ -10,7 +10,9 @@ import java.util.List;
 public class ConfigSchema {
     private Integer schemaVersion;            // optional, for future growth
     private String effort;                    // "min" | "default" | "max"
-    private List<String> classpaths;          // optional
+    private List<String> targetResolutionRoots; // optional
+    private List<String> runtimeClasspaths;   // optional
+    private List<String> extraAuxClasspaths;  // optional
     private List<String> sourcepaths;         // optional
     private Integer priorityThreshold;        // optional
     private List<String> includeFilterPaths;  // optional
@@ -21,7 +23,9 @@ public class ConfigSchema {
 
     public Integer getSchemaVersion() { return schemaVersion; }
     public String getEffort() { return effort; }
-    public List<String> getClasspaths() { return classpaths; }
+    public List<String> getTargetResolutionRoots() { return targetResolutionRoots; }
+    public List<String> getRuntimeClasspaths() { return runtimeClasspaths; }
+    public List<String> getExtraAuxClasspaths() { return extraAuxClasspaths; }
     public List<String> getSourcepaths() { return sourcepaths; }
     public Integer getPriorityThreshold() { return priorityThreshold; }
     public List<String> getIncludeFilterPaths() { return includeFilterPaths; }

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/AnalyzerService.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/AnalyzerService.java
@@ -16,9 +16,13 @@ public class AnalyzerService {
 
     private final FindBugs2 findBugs;
     private final UserPreferences userPreferences;
-    private List<String> projectClasspaths;
+    private List<String> targetResolutionRoots;
+    private List<String> runtimeClasspaths;
+    private List<String> extraAuxClasspaths;
     private AnalysisConfig config;
     private int lastTargetCount = 0;
+    private int lastTargetResolutionRootCount = 0;
+    private int lastAuxClasspathCount = 0;
 
     public AnalyzerService() {
         this.userPreferences = UserPreferences.createDefaultUserPreferences();
@@ -30,12 +34,27 @@ public class AnalyzerService {
         this.config = cfg;
         // Apply user preferences via dedicated applier
         new PreferencesApplier().apply(this.userPreferences, this.findBugs, cfg);
-        // Keep classpaths locally for project setup
-        this.projectClasspaths = cfg != null ? cfg.getClasspaths() : java.util.Collections.emptyList();
+        this.targetResolutionRoots = cfg != null
+                ? cfg.getTargetResolutionRoots()
+                : java.util.Collections.emptyList();
+        this.runtimeClasspaths = cfg != null
+                ? cfg.getRuntimeClasspaths()
+                : java.util.Collections.emptyList();
+        this.extraAuxClasspaths = cfg != null
+                ? cfg.getExtraAuxClasspaths()
+                : java.util.Collections.emptyList();
     }
 
     public int getLastTargetCount() {
         return lastTargetCount;
+    }
+
+    public int getLastTargetResolutionRootCount() {
+        return lastTargetResolutionRootCount;
+    }
+
+    public int getLastAuxClasspathCount() {
+        return lastAuxClasspathCount;
     }
 
     public List<BugInfo> analyzeToBugs(String... filePaths) {
@@ -100,15 +119,18 @@ public class AnalyzerService {
     private PreparedAnalysis prepareAnalysis(IProgressMonitor monitor, String... filePaths) throws java.io.IOException {
         checkCanceled(monitor);
         this.lastTargetCount = 0;
+        this.lastTargetResolutionRootCount = 0;
+        this.lastAuxClasspathCount = 0;
         if (filePaths == null || filePaths.length == 0) {
             return null;
         }
 
         Project project = new Project();
         ClasspathConfigurer cpCfg = new ClasspathConfigurer();
-        List<java.io.File> cpDirs = cpCfg.directoriesFrom(this.projectClasspaths);
+        List<java.io.File> targetResolutionRootDirs = cpCfg.directoriesFrom(this.targetResolutionRoots);
+        this.lastTargetResolutionRootCount = targetResolutionRootDirs.size();
         TargetResolver resolver = new TargetResolver();
-        List<String> targets = resolver.resolveTargets(filePaths, cpDirs, monitor);
+        List<String> targets = resolver.resolveTargets(filePaths, targetResolutionRootDirs, monitor);
         this.lastTargetCount = targets.size();
         if (targets.isEmpty()) {
             return null;
@@ -117,7 +139,12 @@ public class AnalyzerService {
         for (String t : targets) {
             project.addFile(t);
         }
-        cpCfg.apply(project, this.projectClasspaths);
+        ClasspathConfigurer.AppliedAuxClasspath appliedAuxClasspath = cpCfg.apply(
+                project,
+                this.runtimeClasspaths,
+                this.extraAuxClasspaths
+        );
+        this.lastAuxClasspathCount = appliedAuxClasspath.getEntryCount();
         Integer reporterPriority = computeReporterPriorityThreshold(
                 this.config != null ? this.config.getPriorityThreshold() : null
         );

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/ClasspathConfigurer.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/ClasspathConfigurer.java
@@ -2,39 +2,107 @@ package com.spotbugs.vscode.runner.internal;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import edu.umd.cs.findbugs.Project;
 
 /**
- * Applies project or system classpath entries to a FindBugs Project.
+ * Applies aux classpath entries to a FindBugs Project and prepares directory roots
+ * for source-to-bytecode target resolution.
  */
 public class ClasspathConfigurer {
 
-    public void apply(Project project, List<String> projectClasspaths) {
-        if (projectClasspaths != null && !projectClasspaths.isEmpty()) {
-            for (String entry : projectClasspaths) {
-                project.addAuxClasspathEntry(entry);
+    public AppliedAuxClasspath apply(
+            Project project,
+            List<String> runtimeClasspaths,
+            List<String> extraAuxClasspaths
+    ) {
+        List<String> auxEntries = buildEffectiveAuxClasspath(runtimeClasspaths, extraAuxClasspaths);
+        for (String entry : auxEntries) {
+            project.addAuxClasspathEntry(entry);
+        }
+        return new AppliedAuxClasspath(auxEntries.size());
+    }
+
+    public List<File> directoriesFrom(List<String> targetResolutionRoots) {
+        List<File> dirs = new ArrayList<>();
+        if (targetResolutionRoots == null) return dirs;
+        for (String root : targetResolutionRoots) {
+            if (root == null) continue;
+            File f = new File(root);
+            if (f.exists() && f.isDirectory()) dirs.add(f);
+        }
+        return dirs;
+    }
+
+    private List<String> buildEffectiveAuxClasspath(
+            List<String> runtimeClasspaths,
+            List<String> extraAuxClasspaths
+    ) {
+        List<String> explicitEntries = mergeExplicitAuxEntries(runtimeClasspaths, extraAuxClasspaths);
+        if (!explicitEntries.isEmpty()) {
+            return explicitEntries;
+        }
+        return systemClasspathEntries();
+    }
+
+    private List<String> mergeExplicitAuxEntries(
+            List<String> runtimeClasspaths,
+            List<String> extraAuxClasspaths
+    ) {
+        Set<String> deduped = new LinkedHashSet<>();
+        addEntries(deduped, runtimeClasspaths);
+        addEntries(deduped, extraAuxClasspaths);
+        return new ArrayList<>(deduped);
+    }
+
+    private void addEntries(Set<String> out, List<String> entries) {
+        if (entries == null) {
+            return;
+        }
+        for (String entry : entries) {
+            if (entry == null) {
+                continue;
             }
-        } else {
-            String classPath = System.getProperty("java.class.path");
-            if (classPath != null) {
-                String[] pathElements = classPath.split(System.getProperty("path.separator"));
-                for (String element : pathElements) {
-                    project.addAuxClasspathEntry(element);
-                }
+            String trimmed = entry.trim();
+            if (!trimmed.isEmpty()) {
+                out.add(trimmed);
             }
         }
     }
 
-    public List<File> directoriesFrom(List<String> classpaths) {
-        List<File> dirs = new ArrayList<>();
-        if (classpaths == null) return dirs;
-        for (String cp : classpaths) {
-            if (cp == null) continue;
-            File f = new File(cp);
-            if (f.exists() && f.isDirectory()) dirs.add(f);
+    private List<String> systemClasspathEntries() {
+        Set<String> deduped = new LinkedHashSet<>();
+        String classPath = System.getProperty("java.class.path");
+        String pathSeparator = System.getProperty("path.separator");
+        if (classPath == null || pathSeparator == null || pathSeparator.isEmpty()) {
+            return new ArrayList<>(deduped);
         }
-        return dirs;
+
+        String[] pathElements = classPath.split(java.util.regex.Pattern.quote(pathSeparator));
+        for (String element : pathElements) {
+            if (element == null) {
+                continue;
+            }
+            String trimmed = element.trim();
+            if (!trimmed.isEmpty()) {
+                deduped.add(trimmed);
+            }
+        }
+        return new ArrayList<>(deduped);
+    }
+
+    public static final class AppliedAuxClasspath {
+        private final int entryCount;
+
+        AppliedAuxClasspath(int entryCount) {
+            this.entryCount = entryCount;
+        }
+
+        public int getEntryCount() {
+            return entryCount;
+        }
     }
 }

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/TargetResolver.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/TargetResolver.java
@@ -11,15 +11,15 @@ import org.eclipse.core.runtime.IProgressMonitor;
 
 /**
  * Resolves input paths (.java/.class/.jar/directories) into concrete analysis targets
- * (.class and .jar files). Uses classpath directories to map sources to outputs.
+ * (.class and .jar files). Uses target-resolution root directories to map sources to outputs.
  */
 public class TargetResolver {
 
-    public List<String> resolveTargets(String[] inputs, List<File> classpathDirs) throws IOException {
-        return resolveTargets(inputs, classpathDirs, null);
+    public List<String> resolveTargets(String[] inputs, List<File> targetResolutionRootDirs) throws IOException {
+        return resolveTargets(inputs, targetResolutionRootDirs, null);
     }
 
-    public List<String> resolveTargets(String[] inputs, List<File> classpathDirs, IProgressMonitor monitor) throws IOException {
+    public List<String> resolveTargets(String[] inputs, List<File> targetResolutionRootDirs, IProgressMonitor monitor) throws IOException {
         List<String> targets = new ArrayList<>();
         Set<String> seen = new HashSet<>();
         if (inputs == null) {
@@ -33,8 +33,8 @@ public class TargetResolver {
             File f = new File(p);
             if (f.isDirectory()) {
                 // If a source directory is selected, map it to an output directory first.
-                if (!collectOutputClassesForSourceDirectory(p, classpathDirs, targets, seen, monitor)) {
-                    collectTargetsRecursively(f, classpathDirs, targets, seen, monitor);
+                if (!collectOutputClassesForSourceDirectory(p, targetResolutionRootDirs, targets, seen, monitor)) {
+                    collectTargetsRecursively(f, targetResolutionRootDirs, targets, seen, monitor);
                 }
                 continue;
             }
@@ -43,25 +43,25 @@ public class TargetResolver {
                 continue;
             }
             if (p.endsWith(".java")) {
-                addTargetsForJavaFile(p, classpathDirs, targets, seen, monitor);
+                addTargetsForJavaFile(p, targetResolutionRootDirs, targets, seen, monitor);
                 continue;
             }
             // Unknown type: add existing file or scan directory
             if (f.exists()) {
                 if (f.isFile()) addIfNew(f.getAbsolutePath(), targets, seen);
-                else if (f.isDirectory()) collectTargetsRecursively(f, classpathDirs, targets, seen, monitor);
+                else if (f.isDirectory()) collectTargetsRecursively(f, targetResolutionRootDirs, targets, seen, monitor);
             }
         }
         return targets;
     }
 
-    private void collectTargetsRecursively(File dir, List<File> classpathDirs, List<String> out, Set<String> seen, IProgressMonitor monitor) throws IOException {
+    private void collectTargetsRecursively(File dir, List<File> targetResolutionRootDirs, List<String> out, Set<String> seen, IProgressMonitor monitor) throws IOException {
         File[] children = dir.listFiles();
         if (children == null) return;
         for (File c : children) {
             checkCanceled(monitor);
             if (c.isDirectory()) {
-                collectTargetsRecursively(c, classpathDirs, out, seen, monitor);
+                collectTargetsRecursively(c, targetResolutionRootDirs, out, seen, monitor);
                 continue;
             }
             if (!c.isFile()) {
@@ -73,7 +73,7 @@ public class TargetResolver {
                 continue;
             }
             if (name.endsWith(".java")) {
-                addTargetsForJavaFile(c.getAbsolutePath(), classpathDirs, out, seen, monitor);
+                addTargetsForJavaFile(c.getAbsolutePath(), targetResolutionRootDirs, out, seen, monitor);
                 continue;
             }
         }
@@ -100,7 +100,7 @@ public class TargetResolver {
 
     private boolean collectOutputClassesForSourceDirectory(
             String sourceDir,
-            List<File> classpathDirs,
+            List<File> targetResolutionRootDirs,
             List<String> out,
             Set<String> seen,
             IProgressMonitor monitor
@@ -109,19 +109,19 @@ public class TargetResolver {
         if (rel == null) {
             return false;
         }
-        if (classpathDirs == null || classpathDirs.isEmpty()) {
+        if (targetResolutionRootDirs == null || targetResolutionRootDirs.isEmpty()) {
             return false;
         }
 
         boolean added = false;
         String relDir = normalizePath(rel);
-        for (File dir : classpathDirs) {
+        for (File dir : targetResolutionRootDirs) {
             checkCanceled(monitor);
             if (dir == null) continue;
             File candidate = relDir.isEmpty() ? dir : new File(dir, relDir);
             if (candidate.exists() && candidate.isDirectory()) {
                 int before = out.size();
-                collectTargetsRecursively(candidate, classpathDirs, out, seen, monitor);
+                collectTargetsRecursively(candidate, targetResolutionRootDirs, out, seen, monitor);
                 if (out.size() > before) {
                     added = true;
                 }
@@ -132,16 +132,16 @@ public class TargetResolver {
 
     private boolean addTargetsForJavaFile(
             String javaPath,
-            List<File> classpathDirs,
+            List<File> targetResolutionRootDirs,
             List<String> out,
             Set<String> seen,
             IProgressMonitor monitor
     ) throws IOException {
         boolean added = false;
         String rel = deriveRelativePathFromSource(javaPath);
-        if (rel != null && classpathDirs != null && !classpathDirs.isEmpty()) {
+        if (rel != null && targetResolutionRootDirs != null && !targetResolutionRootDirs.isEmpty()) {
             String classRel = normalizePath(rel).replace(".java", ".class");
-            for (File dir : classpathDirs) {
+            for (File dir : targetResolutionRootDirs) {
                 checkCanceled(monitor);
                 if (dir == null) continue;
                 File candidate = new File(dir, classRel);
@@ -153,10 +153,10 @@ public class TargetResolver {
             }
         }
 
-        if (!added && classpathDirs != null && !classpathDirs.isEmpty()) {
+        if (!added && targetResolutionRootDirs != null && !targetResolutionRootDirs.isEmpty()) {
             // Fallback: basename scan (may be ambiguous when multiple classes share the same simple name)
             String baseName = stripExtension(new File(javaPath).getName());
-            for (File dir : classpathDirs) {
+            for (File dir : targetResolutionRootDirs) {
                 checkCanceled(monitor);
                 if (dir == null) continue;
                 if (collectClassFilesByBasename(dir, baseName, out, seen, monitor)) {

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisAction.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisAction.java
@@ -63,7 +63,10 @@ public final class RunAnalysisAction extends AbstractCommandAction {
         stats.put("durationMs", Long.valueOf(elapsed));
         stats.put("findingCount", Integer.valueOf(results.size()));
         stats.put("spotbugsVersion", Version.VERSION_STRING);
-        stats.put("classpathCount", Integer.valueOf(config.getClasspaths().size()));
+        stats.put("targetResolutionRootCount", Integer.valueOf(analyzer.getLastTargetResolutionRootCount()));
+        stats.put("runtimeClasspathCount", Integer.valueOf(config.getRuntimeClasspaths().size()));
+        stats.put("extraAuxClasspathCount", Integer.valueOf(config.getExtraAuxClasspaths().size()));
+        stats.put("auxClasspathCount", Integer.valueOf(analyzer.getLastAuxClasspathCount()));
         stats.put("targetCount", Integer.valueOf(analyzer.getLastTargetCount()));
         stats.put("pluginCount", Integer.valueOf(config.getPlugins().size()));
 

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/config/AnalysisConfig.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/config/AnalysisConfig.java
@@ -11,7 +11,9 @@ import java.util.List;
 public class AnalysisConfig {
 
     private final Effort effort;
-    private final List<String> classpaths;
+    private final List<String> targetResolutionRoots;
+    private final List<String> runtimeClasspaths;
+    private final List<String> extraAuxClasspaths;
     private final List<String> sourcepaths;
     private final Integer priorityThreshold; // optional
     private final List<String> includeFilterPaths; // optional
@@ -22,9 +24,15 @@ public class AnalysisConfig {
 
     private AnalysisConfig(Builder b) {
         this.effort = b.effort == null ? Effort.DEFAULT : b.effort;
-        this.classpaths = b.classpaths == null
+        this.targetResolutionRoots = b.targetResolutionRoots == null
                 ? Collections.emptyList()
-                : Collections.unmodifiableList(new ArrayList<>(b.classpaths));
+                : Collections.unmodifiableList(new ArrayList<>(b.targetResolutionRoots));
+        this.runtimeClasspaths = b.runtimeClasspaths == null
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(new ArrayList<>(b.runtimeClasspaths));
+        this.extraAuxClasspaths = b.extraAuxClasspaths == null
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(new ArrayList<>(b.extraAuxClasspaths));
         this.sourcepaths = b.sourcepaths == null
                 ? Collections.emptyList()
                 : Collections.unmodifiableList(new ArrayList<>(b.sourcepaths));
@@ -45,7 +53,9 @@ public class AnalysisConfig {
     }
 
     public Effort getEffort() { return effort; }
-    public List<String> getClasspaths() { return classpaths; }
+    public List<String> getTargetResolutionRoots() { return targetResolutionRoots; }
+    public List<String> getRuntimeClasspaths() { return runtimeClasspaths; }
+    public List<String> getExtraAuxClasspaths() { return extraAuxClasspaths; }
     public List<String> getSourcepaths() { return sourcepaths; }
     public Integer getPriorityThreshold() { return priorityThreshold; }
     public List<String> getIncludeFilterPaths() { return includeFilterPaths; }
@@ -59,7 +69,9 @@ public class AnalysisConfig {
 
     static final class Builder {
         private Effort effort;
-        private List<String> classpaths;
+        private List<String> targetResolutionRoots;
+        private List<String> runtimeClasspaths;
+        private List<String> extraAuxClasspaths;
         private List<String> sourcepaths;
         private Integer priorityThreshold;
         private List<String> includeFilterPaths;
@@ -69,7 +81,9 @@ public class AnalysisConfig {
         private List<String> plugins;
 
         Builder effort(Effort e) { this.effort = e; return this; }
-        Builder classpaths(List<String> cp) { this.classpaths = cp; return this; }
+        Builder targetResolutionRoots(List<String> roots) { this.targetResolutionRoots = roots; return this; }
+        Builder runtimeClasspaths(List<String> cp) { this.runtimeClasspaths = cp; return this; }
+        Builder extraAuxClasspaths(List<String> cp) { this.extraAuxClasspaths = cp; return this; }
         Builder sourcepaths(List<String> sp) { this.sourcepaths = sp; return this; }
         Builder priorityThreshold(Integer p) { this.priorityThreshold = p; return this; }
         Builder includeFilterPaths(List<String> p) { this.includeFilterPaths = p; return this; }

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/config/ConfigValidator.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/config/ConfigValidator.java
@@ -19,8 +19,9 @@ public class ConfigValidator {
         // Effort normalization (default on unknown)
         Effort effort = Effort.fromString(schema.getEffort());
 
-        // Classpaths: drop null/empty and dedupe while preserving order
-        List<String> cps = normalizeList(schema.getClasspaths());
+        List<String> targetResolutionRoots = normalizeList(schema.getTargetResolutionRoots());
+        List<String> runtimeClasspaths = normalizeList(schema.getRuntimeClasspaths());
+        List<String> extraAuxClasspaths = normalizeList(schema.getExtraAuxClasspaths());
         List<String> sps = normalizeList(schema.getSourcepaths());
 
         // Optional fields: normalize empties to null
@@ -47,11 +48,17 @@ public class ConfigValidator {
         if (baselineFilterError != null) {
             return ConfigValidationResult.error(baselineFilterError.getCode(), baselineFilterError.getMessage());
         }
+        ConfigError extraAuxClasspathError = FilterFileValidator.validateExtraAuxClasspaths(extraAuxClasspaths);
+        if (extraAuxClasspathError != null) {
+            return ConfigValidationResult.error(extraAuxClasspathError.getCode(), extraAuxClasspathError.getMessage());
+        }
 
         AnalysisConfig cfg = AnalysisConfig
             .newBuilder()
             .effort(effort)
-            .classpaths(cps)
+            .targetResolutionRoots(targetResolutionRoots)
+            .runtimeClasspaths(runtimeClasspaths)
+            .extraAuxClasspaths(extraAuxClasspaths)
             .sourcepaths(sps)
             .priorityThreshold(priorityThreshold)
             .includeFilterPaths(includeFilterPaths)

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/config/FilterFileValidator.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/config/FilterFileValidator.java
@@ -19,6 +19,9 @@ final class FilterFileValidator {
     private static final String CODE_FILTER_UNREADABLE = "CFG_FILTER_UNREADABLE";
     private static final String CODE_FILTER_XML_INVALID = "CFG_FILTER_XML_INVALID";
     private static final String CODE_BASELINE_XML_INVALID = "CFG_BASELINE_XML_INVALID";
+    private static final String CODE_AUX_CLASSPATH_NOT_FOUND = "CFG_AUX_CLASSPATH_NOT_FOUND";
+    private static final String CODE_AUX_CLASSPATH_INVALID_ENTRY = "CFG_AUX_CLASSPATH_INVALID_ENTRY";
+    private static final String CODE_AUX_CLASSPATH_UNREADABLE = "CFG_AUX_CLASSPATH_UNREADABLE";
 
     private FilterFileValidator() {
     }
@@ -33,6 +36,19 @@ final class FilterFileValidator {
 
     static ConfigError validateBaselineFilters(List<String> baselineFilterPaths) {
         return validateFilterList(baselineFilterPaths, "baseline", true);
+    }
+
+    static ConfigError validateExtraAuxClasspaths(List<String> extraAuxClasspaths) {
+        if (extraAuxClasspaths == null || extraAuxClasspaths.isEmpty()) {
+            return null;
+        }
+        for (String rawPath : extraAuxClasspaths) {
+            ConfigError error = validateSingleExtraAuxClasspath(rawPath);
+            if (error != null) {
+                return error;
+            }
+        }
+        return null;
     }
 
     private static ConfigError validateFilterList(List<String> paths, String kind, boolean baseline) {
@@ -75,6 +91,29 @@ final class FilterFileValidator {
 
     private static ConfigError error(String code, String message) {
         return new ConfigError(code, message);
+    }
+
+    private static ConfigError validateSingleExtraAuxClasspath(String rawPath) {
+        String absolutePath = new File(rawPath).getAbsolutePath();
+        File entry = new File(absolutePath);
+        if (!entry.exists()) {
+            return error(CODE_AUX_CLASSPATH_NOT_FOUND, "extra aux classpath entry not found: " + absolutePath);
+        }
+        if (!entry.isDirectory() && !(entry.isFile() && isArchivePath(entry.getName()))) {
+            return error(
+                CODE_AUX_CLASSPATH_INVALID_ENTRY,
+                "extra aux classpath entry must be a directory or .jar/.zip file: " + absolutePath
+            );
+        }
+        if (!entry.canRead()) {
+            return error(CODE_AUX_CLASSPATH_UNREADABLE, "extra aux classpath entry is not readable: " + absolutePath);
+        }
+        return null;
+    }
+
+    private static boolean isArchivePath(String fileName) {
+        String lower = fileName == null ? "" : fileName.toLowerCase();
+        return lower.endsWith(".jar") || lower.endsWith(".zip");
     }
 
     private static String rootCauseMessage(Throwable throwable) {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,16 @@
             "minimum": 1,
             "maximum": 20,
             "scope": "window"
+          },
+          "spotbugs.analysis.extraAuxClasspaths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [],
+            "uniqueItems": true,
+            "markdownDescription": "Additional SpotBugs aux classpath entries appended after Java Language Server runtime classpath entries. Supports absolute paths and workspace-relative paths for jar files or directories.",
+            "scope": "window"
           }
         }
       },

--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -3,6 +3,7 @@ export const SETTINGS_SECTION = 'spotbugs';
 export const settingKeys = {
   analysisEffort: 'analysis.effort',
   analysisPriorityThreshold: 'analysis.priorityThreshold',
+  analysisExtraAuxClasspaths: 'analysis.extraAuxClasspaths',
   filtersIncludePaths: 'filters.includePaths',
   filtersExcludePaths: 'filters.excludePaths',
   filtersExcludeBaselineBugsPaths: 'filters.excludeBaselineBugsPaths',

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -6,6 +6,7 @@ import { Logger } from './logger';
 export interface AnalysisSettings {
   effort: string;
   priorityThreshold?: number;
+  extraAuxClasspaths?: string[];
   includeFilterPaths?: string[];
   excludeFilterPaths?: string[];
   excludeBaselineBugsPaths?: string[];
@@ -20,6 +21,7 @@ export class Config {
   public effort!: string;
   // Future-ready fields (optional; only sent when defined)
   public priorityThreshold?: number;
+  public extraAuxClasspaths?: string[];
   public includeFilterPaths?: string[];
   public excludeFilterPaths?: string[];
   public excludeBaselineBugsPaths?: string[];
@@ -41,6 +43,9 @@ export class Config {
 
     const pt = config.get<number | undefined>(settingKeys.analysisPriorityThreshold);
     this.priorityThreshold = typeof pt === 'number' ? pt : undefined;
+    this.extraAuxClasspaths = this.readStringArray(
+      config.get<unknown>(settingKeys.analysisExtraAuxClasspaths)
+    );
 
     this.includeFilterPaths = this.readXmlPathArray(
       settingKeys.filtersIncludePaths,
@@ -59,12 +64,13 @@ export class Config {
   }
 
   // Resolve a workspace-relative path to absolute (best-effort)
-  private resolveToAbsolute(p?: string): string | undefined {
+  private resolveToAbsolute(p?: string, resource?: Uri): string | undefined {
     if (!p) return undefined;
     if (path.isAbsolute(p)) return p;
-    const folder = workspace.workspaceFolders?.[0];
-    if (!folder) return p; // leave as-is if no workspace
-    return path.resolve(Uri.parse(folder.uri.toString()).fsPath, p);
+
+    const basePath = this.getResolutionBasePath(resource);
+    if (!basePath) return p; // leave as-is if no workspace
+    return path.resolve(basePath, p);
   }
 
   private readStringArray(raw: unknown): string[] | undefined {
@@ -103,13 +109,32 @@ export class Config {
     return xmlOnly.length > 0 ? xmlOnly : undefined;
   }
 
-  private resolvePathsToAbsolute(paths: string[] | undefined): string[] | undefined {
+  private getResolutionBasePath(resource?: Uri): string | undefined {
+    const folder = resource ? workspace.getWorkspaceFolder(resource) : undefined;
+    if (folder) {
+      return folder.uri.fsPath;
+    }
+
+    if (resource?.scheme === 'file') {
+      const candidate = resource.fsPath;
+      if (candidate) {
+        return path.extname(candidate) ? path.dirname(candidate) : candidate;
+      }
+    }
+
+    return workspace.workspaceFolders?.[0]?.uri.fsPath;
+  }
+
+  private resolvePathsToAbsolute(
+    paths: string[] | undefined,
+    resource?: Uri
+  ): string[] | undefined {
     if (!Array.isArray(paths) || paths.length === 0) {
       return undefined;
     }
     const resolved = new Set<string>();
     for (const entry of paths) {
-      const absolute = this.resolveToAbsolute(entry);
+      const absolute = this.resolveToAbsolute(entry, resource);
       if (absolute && absolute.trim().length > 0) {
         resolved.add(absolute);
       }
@@ -118,24 +143,31 @@ export class Config {
     return values.length > 0 ? values : undefined;
   }
 
-  public getAnalysisSettings(): AnalysisSettings {
+  public getAnalysisSettings(resource?: Uri): AnalysisSettings {
     const settings: AnalysisSettings = {
       effort: this.effort,
     };
     if (typeof this.priorityThreshold === 'number') {
       settings.priorityThreshold = this.priorityThreshold;
     }
-    const includeFilterPaths = this.resolvePathsToAbsolute(this.includeFilterPaths);
+    const extraAuxClasspaths = this.resolvePathsToAbsolute(this.extraAuxClasspaths, resource);
+    if (extraAuxClasspaths) {
+      settings.extraAuxClasspaths = extraAuxClasspaths;
+    }
+    const includeFilterPaths = this.resolvePathsToAbsolute(this.includeFilterPaths, resource);
     if (includeFilterPaths) {
       settings.includeFilterPaths = includeFilterPaths;
     }
-    const excludeFilterPaths = this.resolvePathsToAbsolute(this.excludeFilterPaths);
+    const excludeFilterPaths = this.resolvePathsToAbsolute(this.excludeFilterPaths, resource);
     if (excludeFilterPaths) {
       settings.excludeFilterPaths = excludeFilterPaths;
       // Backward compatibility for older Java runner payload schema.
       settings.excludeFilterPath = excludeFilterPaths[0];
     }
-    const excludeBaselineBugsPaths = this.resolvePathsToAbsolute(this.excludeBaselineBugsPaths);
+    const excludeBaselineBugsPaths = this.resolvePathsToAbsolute(
+      this.excludeBaselineBugsPaths,
+      resource
+    );
     if (excludeBaselineBugsPaths) {
       settings.excludeBaselineBugsPaths = excludeBaselineBugsPaths;
     }

--- a/src/lsp/analysisRequestBuilder.ts
+++ b/src/lsp/analysisRequestBuilder.ts
@@ -1,18 +1,31 @@
-import { AnalysisRequestPayload } from '../model/analysisProtocol';
+import {
+  ANALYSIS_PROTOCOL_SCHEMA_VERSION,
+  AnalysisRequestPayload,
+} from '../model/analysisProtocol';
 import { AnalysisSettings } from '../core/config';
 
 export function buildAnalysisRequestPayload(
   settings: AnalysisSettings,
   options: {
-    classpaths?: string[] | null;
+    targetResolutionRoots?: string[] | null;
+    runtimeClasspaths?: string[] | null;
+    extraAuxClasspaths?: string[] | null;
     sourcepaths?: string[] | null;
   }
 ): AnalysisRequestPayload {
   const payload: AnalysisRequestPayload = {
-    schemaVersion: 1,
+    schemaVersion: ANALYSIS_PROTOCOL_SCHEMA_VERSION,
     effort: settings.effort,
-    classpaths: options.classpaths ?? null,
-    sourcepaths: options.sourcepaths ?? null,
+    targetResolutionRoots: Array.isArray(options.targetResolutionRoots)
+      ? options.targetResolutionRoots.slice()
+      : null,
+    runtimeClasspaths: Array.isArray(options.runtimeClasspaths)
+      ? options.runtimeClasspaths.slice()
+      : null,
+    extraAuxClasspaths: Array.isArray(options.extraAuxClasspaths)
+      ? options.extraAuxClasspaths.slice()
+      : null,
+    sourcepaths: Array.isArray(options.sourcepaths) ? options.sourcepaths.slice() : null,
   };
 
   if (typeof settings.priorityThreshold === 'number') {
@@ -34,7 +47,7 @@ export function buildAnalysisRequestPayload(
     payload.excludeFilterPath = settings.excludeFilterPath;
   }
   if (Array.isArray(settings.plugins) && settings.plugins.length > 0) {
-    payload.plugins = settings.plugins;
+    payload.plugins = settings.plugins.slice();
   }
 
   return payload;

--- a/src/model/analysisProtocol.ts
+++ b/src/model/analysisProtocol.ts
@@ -1,9 +1,13 @@
 import { Bug } from './bug';
 
+export const ANALYSIS_PROTOCOL_SCHEMA_VERSION = 2;
+
 export interface AnalysisRequestPayload {
   schemaVersion: number;
   effort: string;
-  classpaths?: string[] | null;
+  targetResolutionRoots?: string[] | null;
+  runtimeClasspaths?: string[] | null;
+  extraAuxClasspaths?: string[] | null;
   sourcepaths?: string[] | null;
   priorityThreshold?: number;
   includeFilterPaths?: string[];
@@ -29,7 +33,10 @@ export interface AnalysisStats {
   durationMs?: number;
   findingCount?: number;
   spotbugsVersion?: string;
-  classpathCount?: number;
+  targetResolutionRootCount?: number;
+  runtimeClasspathCount?: number;
+  extraAuxClasspathCount?: number;
+  auxClasspathCount?: number;
   targetCount?: number;
   pluginCount?: number;
 }

--- a/src/orchestration/analysisNotices.ts
+++ b/src/orchestration/analysisNotices.ts
@@ -51,18 +51,20 @@ function buildHintNotices(targetPath: string, outcome: AnalysisOutcome): Analysi
   const isBytecodeTarget =
     target.endsWith('.class') || target.endsWith('.jar') || target.endsWith('.zip');
   const looksLikeSourceTarget = target.endsWith('.java') || target.includes('/src/');
-  const classpathCount =
-    typeof outcome.stats?.classpathCount === 'number' ? outcome.stats.classpathCount : undefined;
+  const targetResolutionRootCount =
+    typeof outcome.stats?.targetResolutionRootCount === 'number'
+      ? outcome.stats.targetResolutionRootCount
+      : undefined;
   const targetCount =
     typeof outcome.stats?.targetCount === 'number' ? outcome.stats.targetCount : undefined;
 
   if (!isBytecodeTarget) {
     if (targetCount === 0) {
-      if ((classpathCount ?? 0) === 0) {
+      if ((targetResolutionRootCount ?? 0) === 0) {
         notices.push({
           level: 'warn',
           message:
-            'SpotBugs: No compiled classes found (classpath unavailable). Make sure the target is inside a Java project and build the workspace.',
+            'SpotBugs: No compiled classes found (target-resolution roots unavailable). Make sure the target is inside a Java project and build the workspace.',
         });
       } else {
         notices.push({
@@ -71,11 +73,11 @@ function buildHintNotices(targetPath: string, outcome: AnalysisOutcome): Analysi
             'SpotBugs: No compiled classes found for the selected target. Build the project or select an output folder (e.g. build/classes or target/classes).',
         });
       }
-    } else if (looksLikeSourceTarget && (classpathCount ?? 0) === 0) {
+    } else if (looksLikeSourceTarget && (targetResolutionRootCount ?? 0) === 0) {
       notices.push({
         level: 'warn',
         message:
-          'SpotBugs: Classpath is unavailable for this target; results may be incomplete. Try building the workspace and re-run.',
+          'SpotBugs: Target-resolution roots are unavailable for this target; results may be incomplete. Try building the workspace and re-run.',
       });
     }
   }

--- a/src/orchestration/analysisRunner.ts
+++ b/src/orchestration/analysisRunner.ts
@@ -2,13 +2,10 @@ import { commands, ProgressLocation, Uri, window } from 'vscode';
 import { Config } from '../core/config';
 import { Logger } from '../core/logger';
 import { Notifier, defaultNotifier } from '../core/notifier';
-import {
-  analyzeFile,
-  analyzeWorkspaceFromProjects,
-  getWorkspaceProjects,
-  NO_CLASS_TARGETS_CODE,
-} from '../services/analysisService';
+import { analyzeFile, analyzeWorkspaceFromProjects, getWorkspaceProjects } from '../services/analysisService';
+import type { ProjectResult } from '../services/projectResult';
 import { buildAnalysisNotices } from './analysisNotices';
+import { buildWorkspaceCompletionNotices } from './workspaceSummary';
 import { SpotBugsDiagnosticsManager } from '../services/diagnosticsManager';
 import { buildWorkspaceAuto } from '../services/workspaceBuildService';
 import { SpotBugsTreeDataProvider } from '../ui/spotbugsTreeDataProvider';
@@ -82,7 +79,7 @@ export async function runWorkspaceAnalysis(
   const notifier = args.notifier ?? defaultNotifier;
   try {
     let aggregated: Finding[] = [];
-    let projectResults: { errorCode?: string }[] = [];
+    let projectResults: ProjectResult[] = [];
     let cancelled = false;
 
     await window.withProgress(
@@ -138,32 +135,16 @@ export async function runWorkspaceAnalysis(
     args.tree.showResults(aggregated);
     args.diagnostics.replaceAll(aggregated);
 
-    const noClassTargets = projectResults.filter(
-      (result) => result.errorCode === NO_CLASS_TARGETS_CODE
-    );
-    const allSkipped =
-      projectResults.length > 0 && noClassTargets.length === projectResults.length;
-
-    if (allSkipped) {
-      notifier.warn(
-        'SpotBugs could not build the project. Run a manual build, then try again.'
-      );
-      return;
+    const notices = buildWorkspaceCompletionNotices(projectResults, aggregated.length);
+    for (const notice of notices) {
+      if (notice.level === 'error') {
+        notifier.error(notice.message);
+      } else if (notice.level === 'warn') {
+        notifier.warn(notice.message);
+      } else {
+        notifier.info(notice.message);
+      }
     }
-
-    if (noClassTargets.length > 0) {
-      notifier.warn(
-        `SpotBugs skipped ${noClassTargets.length} project${
-          noClassTargets.length === 1 ? '' : 's'
-        } because the build failed. Run a manual build, then try again.`
-      );
-    }
-
-    const summary =
-      aggregated.length === 0
-        ? 'No issues found.'
-        : `${aggregated.length} issue${aggregated.length === 1 ? '' : 's'} found.`;
-    notifier.info(`SpotBugs: Workspace analysis completed - ${summary}`);
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     Logger.error('An error occurred during workspace analysis', error);

--- a/src/orchestration/workspaceSummary.ts
+++ b/src/orchestration/workspaceSummary.ts
@@ -1,0 +1,85 @@
+import type { AnalysisNotice } from '../model/analysisOutcome';
+import type { ProjectResult } from '../services/projectResult';
+import { NO_CLASS_TARGETS_CODE } from '../workspace/analysisTargetCodes';
+
+export function buildWorkspaceCompletionNotices(
+  projectResults: ProjectResult[],
+  findingCount: number
+): AnalysisNotice[] {
+  const skippedCount = projectResults.filter(
+    (result) => result.errorCode === NO_CLASS_TARGETS_CODE
+  ).length;
+  const failedCount = projectResults.filter(
+    (result) => !!result.error && result.errorCode !== NO_CLASS_TARGETS_CODE
+  ).length;
+  const succeededCount = projectResults.length - skippedCount - failedCount;
+
+  if (projectResults.length > 0 && skippedCount === projectResults.length) {
+    return [
+      {
+        level: 'warn',
+        message: 'SpotBugs could not build the project. Run a manual build, then try again.',
+      },
+    ];
+  }
+
+  if (failedCount > 0) {
+    const skippedSentence =
+      skippedCount > 0
+        ? ` ${formatProjectCount(skippedCount)} skipped because the build failed.`
+        : '';
+
+    if (succeededCount === 0) {
+      return [
+        {
+          level: 'error',
+          message:
+            `SpotBugs: Workspace analysis failed - ${formatProjectCount(failedCount)} failed.` +
+            `${skippedSentence} See the SpotBugs view for project errors.`,
+        },
+      ];
+    }
+
+    const successSummary =
+      findingCount === 0
+        ? 'Successful projects produced no findings.'
+        : `${formatIssueCount(findingCount)} found in successful projects.`;
+
+    return [
+      {
+        level: 'warn',
+        message:
+          `SpotBugs: Workspace analysis completed with failures - ${formatProjectCount(
+            failedCount
+          )} failed.` + `${skippedSentence} ${successSummary}`,
+      },
+    ];
+  }
+
+  const notices: AnalysisNotice[] = [];
+  if (skippedCount > 0) {
+    notices.push({
+      level: 'warn',
+      message:
+        `SpotBugs skipped ${formatProjectCount(skippedCount)} because the build failed. ` +
+        'Run a manual build, then try again.',
+    });
+  }
+
+  notices.push({
+    level: 'info',
+    message:
+      findingCount === 0
+        ? 'SpotBugs: Workspace analysis completed - No issues found.'
+        : `SpotBugs: Workspace analysis completed - ${formatIssueCount(findingCount)} found.`,
+  });
+  return notices;
+}
+
+function formatProjectCount(count: number): string {
+  return `${count} project${count === 1 ? '' : 's'}`;
+}
+
+function formatIssueCount(count: number): string {
+  return `${count} issue${count === 1 ? '' : 's'}`;
+}

--- a/src/services/analysisService.ts
+++ b/src/services/analysisService.ts
@@ -30,7 +30,7 @@ type AnalysisContext = {
   sourcepaths?: string[] | null;
 };
 
-export { NO_CLASS_TARGETS_CODE } from '../workspace/analysisTargetResolver';
+export { NO_CLASS_TARGETS_CODE } from '../workspace/analysisTargetCodes';
 export type { ProjectResult } from './projectResult';
 
 export interface WorkspaceResult {

--- a/src/services/analysisService.ts
+++ b/src/services/analysisService.ts
@@ -1,16 +1,21 @@
 import { CancellationToken, Uri } from 'vscode';
 import { Logger } from '../core/logger';
 import { Config } from '../core/config';
-import { Finding } from '../model/finding';
 import { AnalysisOutcome } from '../model/analysisOutcome';
 import { formatAnalysisErrors } from '../model/analysisErrors';
+import { ANALYSIS_PROTOCOL_SCHEMA_VERSION } from '../model/analysisProtocol';
 import { ProjectRef } from '../workspace/classpathService';
 import { addFullPaths } from '../workspace/pathResolver';
 import { runSpotBugsAnalysis } from '../lsp/spotbugsClient';
 import { parseAnalysisResponse } from '../lsp/spotbugsParser';
 import { buildAnalysisRequestPayload } from '../lsp/analysisRequestBuilder';
 import { mapBugsToFindings } from '../lsp/spotbugsMapper';
-import { validateFilterFilesPreflight } from './filterFileValidation';
+import type { ProjectResult } from './projectResult';
+import { projectResultFromOutcome } from './projectResult';
+import {
+  validateExtraAuxClasspathPreflight,
+  validateFilterFilesPreflight,
+} from './filterFileValidation';
 import {
   resolveFileAnalysisTarget,
   resolveProjectAnalysisTarget,
@@ -20,17 +25,13 @@ import { getWorkspaceProjectUris } from '../workspace/projectDiscovery';
 type AnalysisContext = {
   targetPath: string;
   preferredProject?: Uri;
-  classpaths?: string[] | null;
+  targetResolutionRoots?: string[] | null;
+  runtimeClasspaths?: string[] | null;
   sourcepaths?: string[] | null;
 };
 
 export { NO_CLASS_TARGETS_CODE } from '../workspace/analysisTargetResolver';
-export interface ProjectResult {
-  projectUri: string;
-  findings: Finding[];
-  error?: string;
-  errorCode?: string;
-}
+export type { ProjectResult } from './projectResult';
 
 export interface WorkspaceResult {
   results: ProjectResult[];
@@ -134,7 +135,7 @@ async function analyzeProject(
     }
 
     const outcome = await runAnalysis(config, resolution.target);
-    return { projectUri: projectUriString, findings: outcome.findings };
+    return projectResultFromOutcome(projectUriString, outcome);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return { projectUri: projectUriString, findings: [], error: message };
@@ -146,7 +147,7 @@ async function runAnalysis(
   context: AnalysisContext
 ): Promise<AnalysisOutcome> {
   const targetPath = context.targetPath;
-  const settings = config.getAnalysisSettings();
+  const settings = config.getAnalysisSettings(context.preferredProject);
   const preflightFilterError = await validateFilterFilesPreflight(settings);
   if (preflightFilterError) {
     const combined = formatAnalysisErrors([preflightFilterError]);
@@ -163,9 +164,27 @@ async function runAnalysis(
       },
     };
   }
+  const preflightAuxClasspathError = await validateExtraAuxClasspathPreflight(settings);
+  if (preflightAuxClasspathError) {
+    const combined = formatAnalysisErrors([preflightAuxClasspathError]);
+    Logger.error(`SpotBugs extra aux classpath configuration error: ${combined}`);
+    return {
+      findings: [],
+      errors: [preflightAuxClasspathError],
+      targetPath,
+      failure: {
+        kind: 'analysis-error',
+        level: 'error',
+        code: preflightAuxClasspathError.code,
+        message: `SpotBugs analysis failed: ${combined}`,
+      },
+    };
+  }
 
   const payload = buildAnalysisRequestPayload(settings, {
-    classpaths: context.classpaths ?? null,
+    targetResolutionRoots: context.targetResolutionRoots ?? null,
+    runtimeClasspaths: context.runtimeClasspaths ?? null,
+    extraAuxClasspaths: settings.extraAuxClasspaths ?? null,
     sourcepaths: context.sourcepaths ?? null,
   });
   const result = await runSpotBugsAnalysis({
@@ -205,7 +224,10 @@ async function runAnalysis(
 
   const { bugs, errors, stats, schemaVersion } = parsed.value;
 
-  if (typeof schemaVersion === 'number' && schemaVersion !== 1) {
+  if (
+    typeof schemaVersion === 'number' &&
+    schemaVersion !== ANALYSIS_PROTOCOL_SCHEMA_VERSION
+  ) {
     Logger.log(`Unexpected analysis response schemaVersion=${schemaVersion}`);
   }
   if (Array.isArray(errors) && errors.length > 0) {
@@ -243,8 +265,17 @@ async function runAnalysis(
   if (typeof stats?.spotbugsVersion === 'string') {
     logParts.push(`spotbugsVersion=${stats.spotbugsVersion}`);
   }
-  if (typeof stats?.classpathCount === 'number') {
-    logParts.push(`classpathCount=${stats.classpathCount}`);
+  if (typeof stats?.targetResolutionRootCount === 'number') {
+    logParts.push(`targetResolutionRootCount=${stats.targetResolutionRootCount}`);
+  }
+  if (typeof stats?.runtimeClasspathCount === 'number') {
+    logParts.push(`runtimeClasspathCount=${stats.runtimeClasspathCount}`);
+  }
+  if (typeof stats?.extraAuxClasspathCount === 'number') {
+    logParts.push(`extraAuxClasspathCount=${stats.extraAuxClasspathCount}`);
+  }
+  if (typeof stats?.auxClasspathCount === 'number') {
+    logParts.push(`auxClasspathCount=${stats.auxClasspathCount}`);
   }
   if (typeof stats?.targetCount === 'number') {
     logParts.push(`targetCount=${stats.targetCount}`);

--- a/src/services/filterFileValidation.ts
+++ b/src/services/filterFileValidation.ts
@@ -8,6 +8,9 @@ type FilterKind = 'include' | 'exclude' | 'baseline';
 const CODE_FILTER_NOT_FOUND = 'CFG_FILTER_NOT_FOUND';
 const CODE_FILTER_NOT_FILE = 'CFG_FILTER_NOT_FILE';
 const CODE_FILTER_UNREADABLE = 'CFG_FILTER_UNREADABLE';
+const CODE_AUX_CLASSPATH_NOT_FOUND = 'CFG_AUX_CLASSPATH_NOT_FOUND';
+const CODE_AUX_CLASSPATH_INVALID_ENTRY = 'CFG_AUX_CLASSPATH_INVALID_ENTRY';
+const CODE_AUX_CLASSPATH_UNREADABLE = 'CFG_AUX_CLASSPATH_UNREADABLE';
 
 export async function validateFilterFilesPreflight(
   settings: AnalysisSettings
@@ -21,6 +24,50 @@ export async function validateFilterFilesPreflight(
     return excludeError;
   }
   return validateFilterGroup('baseline', settings.excludeBaselineBugsPaths);
+}
+
+export async function validateExtraAuxClasspathPreflight(
+  settings: AnalysisSettings
+): Promise<AnalysisError | undefined> {
+  const paths = settings.extraAuxClasspaths;
+  if (!Array.isArray(paths) || paths.length === 0) {
+    return undefined;
+  }
+
+  for (const rawPath of paths) {
+    const absolutePath = toAbsolutePath(rawPath);
+    let stat: fs.Stats | undefined;
+    try {
+      stat = await safeStat(absolutePath);
+    } catch (error) {
+      return {
+        code: CODE_AUX_CLASSPATH_UNREADABLE,
+        message: `extra aux classpath entry is not readable: ${absolutePath} (${rootCauseMessage(error)})`,
+      };
+    }
+    if (!stat) {
+      return {
+        code: CODE_AUX_CLASSPATH_NOT_FOUND,
+        message: `extra aux classpath entry not found: ${absolutePath}`,
+      };
+    }
+    if (!stat.isDirectory() && !(stat.isFile() && isArchivePath(absolutePath))) {
+      return {
+        code: CODE_AUX_CLASSPATH_INVALID_ENTRY,
+        message: `extra aux classpath entry must be a directory or .jar/.zip file: ${absolutePath}`,
+      };
+    }
+    try {
+      await fs.promises.access(absolutePath, fs.constants.R_OK);
+    } catch (error) {
+      return {
+        code: CODE_AUX_CLASSPATH_UNREADABLE,
+        message: `extra aux classpath entry is not readable: ${absolutePath} (${rootCauseMessage(error)})`,
+      };
+    }
+  }
+
+  return undefined;
 }
 
 async function validateFilterGroup(
@@ -83,6 +130,11 @@ function toAbsolutePath(rawPath: string): string {
     return trimmed;
   }
   return path.resolve(trimmed);
+}
+
+function isArchivePath(filePath: string): boolean {
+  const ext = path.extname(filePath).toLowerCase();
+  return ext === '.jar' || ext === '.zip';
 }
 
 function rootCauseMessage(error: unknown): string {

--- a/src/services/projectResult.ts
+++ b/src/services/projectResult.ts
@@ -1,0 +1,40 @@
+import { formatAnalysisErrors } from '../model/analysisErrors';
+import type { AnalysisOutcome } from '../model/analysisOutcome';
+import type { Finding } from '../model/finding';
+
+export interface ProjectResult {
+  projectUri: string;
+  findings: Finding[];
+  error?: string;
+  errorCode?: string;
+}
+
+export function projectResultFromOutcome(
+  projectUri: string,
+  outcome: AnalysisOutcome
+): ProjectResult {
+  if (outcome.failure) {
+    return {
+      projectUri,
+      findings: outcome.findings,
+      error: outcome.failure.message,
+      errorCode: outcome.failure.code,
+    };
+  }
+
+  if (Array.isArray(outcome.errors) && outcome.errors.length > 0 && outcome.findings.length === 0) {
+    const combined = formatAnalysisErrors(outcome.errors);
+    const firstErrorCode = outcome.errors.find((error) => !!error.code)?.code;
+    return {
+      projectUri,
+      findings: outcome.findings,
+      error: `SpotBugs analysis failed: ${combined}`,
+      errorCode: firstErrorCode,
+    };
+  }
+
+  return {
+    projectUri,
+    findings: outcome.findings,
+  };
+}

--- a/src/test/analysisRequestBuilder.unit.test.ts
+++ b/src/test/analysisRequestBuilder.unit.test.ts
@@ -14,27 +14,37 @@ describe('analysisRequestBuilder', () => {
     const include = ['/tmp/spotbugs/include.xml'];
     const exclude = ['/tmp/spotbugs/exclude.xml'];
     const baseline = ['/tmp/spotbugs/baseline.xml'];
+    const extraAux = ['/tmp/spotbugs/lib.jar'];
+    const runtimeClasspaths = ['/workspace/build/classes', '/workspace/lib/dependency.jar'];
+    const targetResolutionRoots = ['/workspace/build/classes'];
 
     const payload = buildAnalysisRequestPayload(
       makeSettings({
+        extraAuxClasspaths: extraAux,
         includeFilterPaths: include,
         excludeFilterPaths: exclude,
         excludeBaselineBugsPaths: baseline,
       }),
       {
-        classpaths: ['/workspace/build/classes'],
+        targetResolutionRoots,
+        runtimeClasspaths,
+        extraAuxClasspaths: extraAux,
         sourcepaths: ['/workspace/src/main/java'],
       }
     );
 
+    assert.deepStrictEqual(payload.targetResolutionRoots, targetResolutionRoots);
+    assert.deepStrictEqual(payload.runtimeClasspaths, runtimeClasspaths);
+    assert.deepStrictEqual(payload.extraAuxClasspaths, extraAux);
     assert.deepStrictEqual(payload.includeFilterPaths, include);
     assert.deepStrictEqual(payload.excludeFilterPaths, exclude);
     assert.deepStrictEqual(payload.excludeBaselineBugsPaths, baseline);
   });
 
-  it('omits filter fields when arrays are empty', () => {
+  it('omits optional fields when arrays are empty', () => {
     const payload = buildAnalysisRequestPayload(
       makeSettings({
+        extraAuxClasspaths: [],
         includeFilterPaths: [],
         excludeFilterPaths: [],
         excludeBaselineBugsPaths: [],
@@ -42,6 +52,12 @@ describe('analysisRequestBuilder', () => {
       {}
     );
 
+    assert.strictEqual('targetResolutionRoots' in payload, true);
+    assert.strictEqual(payload.targetResolutionRoots, null);
+    assert.strictEqual('runtimeClasspaths' in payload, true);
+    assert.strictEqual(payload.runtimeClasspaths, null);
+    assert.strictEqual('extraAuxClasspaths' in payload, true);
+    assert.strictEqual(payload.extraAuxClasspaths, null);
     assert.strictEqual('includeFilterPaths' in payload, false);
     assert.strictEqual('excludeFilterPaths' in payload, false);
     assert.strictEqual('excludeBaselineBugsPaths' in payload, false);
@@ -64,20 +80,34 @@ describe('analysisRequestBuilder', () => {
     const include = ['/tmp/spotbugs/include.xml'];
     const exclude = ['/tmp/spotbugs/exclude.xml'];
     const baseline = ['/tmp/spotbugs/baseline.xml'];
+    const extraAux = ['/tmp/spotbugs/lib.jar'];
+    const runtimeClasspaths = ['/workspace/build/classes'];
+    const targetResolutionRoots = ['/workspace/build/classes'];
 
     const payload = buildAnalysisRequestPayload(
       makeSettings({
+        extraAuxClasspaths: extraAux,
         includeFilterPaths: include,
         excludeFilterPaths: exclude,
         excludeBaselineBugsPaths: baseline,
       }),
-      {}
+      {
+        targetResolutionRoots,
+        runtimeClasspaths,
+        extraAuxClasspaths: extraAux,
+      }
     );
 
     include.push('/tmp/spotbugs/include2.xml');
     exclude.push('/tmp/spotbugs/exclude2.xml');
     baseline.push('/tmp/spotbugs/baseline2.xml');
+    extraAux.push('/tmp/spotbugs/lib2.jar');
+    runtimeClasspaths.push('/workspace/lib/dependency.jar');
+    targetResolutionRoots.push('/workspace/bin');
 
+    assert.deepStrictEqual(payload.targetResolutionRoots, ['/workspace/build/classes']);
+    assert.deepStrictEqual(payload.runtimeClasspaths, ['/workspace/build/classes']);
+    assert.deepStrictEqual(payload.extraAuxClasspaths, ['/tmp/spotbugs/lib.jar']);
     assert.deepStrictEqual(payload.includeFilterPaths, ['/tmp/spotbugs/include.xml']);
     assert.deepStrictEqual(payload.excludeFilterPaths, ['/tmp/spotbugs/exclude.xml']);
     assert.deepStrictEqual(payload.excludeBaselineBugsPaths, ['/tmp/spotbugs/baseline.xml']);

--- a/src/test/classpathService.unit.test.ts
+++ b/src/test/classpathService.unit.test.ts
@@ -1,0 +1,34 @@
+import * as assert from 'assert';
+import { deriveTargetResolutionRoots } from '../workspace/classpathLayout';
+
+describe('classpathService', () => {
+  it('prepends the output folder, filters archives, and dedupes roots', () => {
+    const roots = deriveTargetResolutionRoots('/workspace/build/classes', [
+      '/workspace/build/classes',
+      '/workspace/bin',
+      '/deps/lib.jar',
+      '/deps/classes',
+      '/deps/lib.zip',
+      '/workspace/bin',
+    ]);
+
+    assert.deepStrictEqual(roots, [
+      '/workspace/build/classes',
+      '/workspace/bin',
+      '/deps/classes',
+    ]);
+  });
+
+  it('preserves windows-style directory entries while excluding archive paths', () => {
+    const roots = deriveTargetResolutionRoots('C:\\workspace\\build\\classes', [
+      'C:\\deps\\tooling.JAR',
+      'C:\\workspace\\build\\classes',
+      'C:\\workspace\\bin',
+    ]);
+
+    assert.deepStrictEqual(roots, [
+      'C:\\workspace\\build\\classes',
+      'C:\\workspace\\bin',
+    ]);
+  });
+});

--- a/src/test/filterFileValidation.unit.test.ts
+++ b/src/test/filterFileValidation.unit.test.ts
@@ -3,7 +3,10 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import type { AnalysisSettings } from '../core/config';
-import { validateFilterFilesPreflight } from '../services/filterFileValidation';
+import {
+  validateExtraAuxClasspathPreflight,
+  validateFilterFilesPreflight,
+} from '../services/filterFileValidation';
 
 function makeSettings(overrides: Partial<AnalysisSettings> = {}): AnalysisSettings {
   return {
@@ -71,6 +74,60 @@ describe('filterFileValidation', () => {
           excludeFilterPaths: [excludePath],
           excludeBaselineBugsPaths: [baselinePath],
         })
+      );
+
+      assert.strictEqual(error, undefined);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('returns CFG_AUX_CLASSPATH_NOT_FOUND when an extra aux classpath entry is missing', async () => {
+    const missingPath = path.join(
+      os.tmpdir(),
+      `spotbugs-missing-${process.pid}-${Date.now()}-aux.jar`
+    );
+    const error = await validateExtraAuxClasspathPreflight(
+      makeSettings({ extraAuxClasspaths: [missingPath] })
+    );
+
+    assert.ok(error);
+    assert.strictEqual(error?.code, 'CFG_AUX_CLASSPATH_NOT_FOUND');
+    assert.ok((error?.message ?? '').includes('extra aux classpath entry not found'));
+  });
+
+  it('returns CFG_AUX_CLASSPATH_INVALID_ENTRY when an extra aux classpath entry is not a jar/zip or directory', async () => {
+    const dir = await makeTempDir();
+    try {
+      const invalidPath = path.join(dir, 'not-a-classpath.txt');
+      await writeFile(invalidPath, 'plain text');
+
+      const error = await validateExtraAuxClasspathPreflight(
+        makeSettings({ extraAuxClasspaths: [invalidPath] })
+      );
+
+      assert.ok(error);
+      assert.strictEqual(error?.code, 'CFG_AUX_CLASSPATH_INVALID_ENTRY');
+      assert.ok(
+        (error?.message ?? '').includes(
+          'extra aux classpath entry must be a directory or .jar/.zip file'
+        )
+      );
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('passes when extra aux classpath entries are readable jars or directories', async () => {
+    const dir = await makeTempDir();
+    try {
+      const jarPath = path.join(dir, 'lib', 'helper.jar');
+      const classesDir = path.join(dir, 'classes');
+      await writeFile(jarPath, '');
+      await fs.promises.mkdir(classesDir, { recursive: true });
+
+      const error = await validateExtraAuxClasspathPreflight(
+        makeSettings({ extraAuxClasspaths: [jarPath, classesDir] })
       );
 
       assert.strictEqual(error, undefined);

--- a/src/test/projectResult.unit.test.ts
+++ b/src/test/projectResult.unit.test.ts
@@ -1,0 +1,87 @@
+import * as assert from 'assert';
+import { projectResultFromOutcome } from '../services/projectResult';
+import type { AnalysisOutcome } from '../model/analysisOutcome';
+
+function makeOutcome(overrides: Partial<AnalysisOutcome> = {}): AnalysisOutcome {
+  return {
+    findings: [],
+    ...overrides,
+  };
+}
+
+describe('projectResult', () => {
+  it('propagates failure state into the project result', () => {
+    const result = projectResultFromOutcome(
+      'file:///workspace/project',
+      makeOutcome({
+        failure: {
+          kind: 'analysis-error',
+          level: 'error',
+          code: 'CFG_AUX_CLASSPATH_NOT_FOUND',
+          message: 'SpotBugs analysis failed: extra aux classpath entry not found: /tmp/missing.jar',
+        },
+      })
+    );
+
+    assert.deepStrictEqual(result, {
+      projectUri: 'file:///workspace/project',
+      findings: [],
+      error: 'SpotBugs analysis failed: extra aux classpath entry not found: /tmp/missing.jar',
+      errorCode: 'CFG_AUX_CLASSPATH_NOT_FOUND',
+    });
+  });
+
+  it('treats fatal error payloads without findings as project failures', () => {
+    const result = projectResultFromOutcome(
+      'file:///workspace/project',
+      makeOutcome({
+        errors: [
+          {
+            code: 'CFG_AUX_CLASSPATH_INVALID_ENTRY',
+            message: 'extra aux classpath entry must be a directory or .jar/.zip file: /tmp/bad.txt',
+          },
+        ],
+      })
+    );
+
+    assert.deepStrictEqual(result, {
+      projectUri: 'file:///workspace/project',
+      findings: [],
+      error:
+        'SpotBugs analysis failed: [CFG_AUX_CLASSPATH_INVALID_ENTRY] extra aux classpath entry must be a directory or .jar/.zip file: /tmp/bad.txt',
+      errorCode: 'CFG_AUX_CLASSPATH_INVALID_ENTRY',
+    });
+  });
+
+  it('keeps successful outcomes as done results', () => {
+    const result = projectResultFromOutcome(
+      'file:///workspace/project',
+      makeOutcome({
+        findings: [
+          {
+            patternId: 'NP_NULL_ON_SOME_PATH',
+            message: 'possible null dereference',
+            location: {},
+          },
+        ],
+        errors: [
+          {
+            code: 'WARN_PARTIAL',
+            message: 'partial results',
+          },
+        ],
+      })
+    );
+
+    assert.deepStrictEqual(result, {
+      projectUri: 'file:///workspace/project',
+      findings: [
+        {
+          patternId: 'NP_NULL_ON_SOME_PATH',
+          message: 'possible null dereference',
+          location: {},
+        },
+      ],
+    });
+  });
+});

--- a/src/test/spotbugsParser.unit.test.ts
+++ b/src/test/spotbugsParser.unit.test.ts
@@ -31,7 +31,7 @@ describe('spotbugsParser', () => {
   it('parses envelope responses with errors and stats', () => {
     const result = parseAnalysisResponse(
       JSON.stringify({
-        schemaVersion: 1,
+        schemaVersion: 2,
         results: [{ type: 'UR' }],
         errors: [{ code: 'X', message: 'warn' }],
         stats: { target: '/tmp/Foo', durationMs: 12 },
@@ -39,7 +39,7 @@ describe('spotbugsParser', () => {
     );
     assert.strictEqual(result.ok, true);
     if (result.ok) {
-      assert.strictEqual(result.value.schemaVersion, 1);
+      assert.strictEqual(result.value.schemaVersion, 2);
       assert.strictEqual(result.value.bugs.length, 1);
       assert.strictEqual(result.value.errors?.length, 1);
       assert.strictEqual(result.value.errors?.[0]?.code, 'X');

--- a/src/test/workspaceSummary.unit.test.ts
+++ b/src/test/workspaceSummary.unit.test.ts
@@ -1,0 +1,99 @@
+import * as assert from 'assert';
+import { buildWorkspaceCompletionNotices } from '../orchestration/workspaceSummary';
+import { NO_CLASS_TARGETS_CODE } from '../workspace/analysisTargetCodes';
+import type { ProjectResult } from '../services/projectResult';
+
+function makeProjectResult(overrides: Partial<ProjectResult> = {}): ProjectResult {
+  return {
+    projectUri: 'file:///workspace/project',
+    findings: [],
+    ...overrides,
+  };
+}
+
+describe('workspaceSummary', () => {
+  it('returns the existing build warning when all projects are skipped', () => {
+    const notices = buildWorkspaceCompletionNotices(
+      [
+        makeProjectResult({ error: 'build failed', errorCode: NO_CLASS_TARGETS_CODE }),
+        makeProjectResult({ error: 'build failed', errorCode: NO_CLASS_TARGETS_CODE }),
+      ],
+      0
+    );
+
+    assert.deepStrictEqual(notices, [
+      {
+        level: 'warn',
+        message: 'SpotBugs could not build the project. Run a manual build, then try again.',
+      },
+    ]);
+  });
+
+  it('keeps skip warnings plus success summary when only skipped and successful projects exist', () => {
+    const notices = buildWorkspaceCompletionNotices(
+      [
+        makeProjectResult({ findings: [{ patternId: 'X', location: {} }] }),
+        makeProjectResult({ error: 'build failed', errorCode: NO_CLASS_TARGETS_CODE }),
+      ],
+      1
+    );
+
+    assert.deepStrictEqual(notices, [
+      {
+        level: 'warn',
+        message: 'SpotBugs skipped 1 project because the build failed. Run a manual build, then try again.',
+      },
+      {
+        level: 'info',
+        message: 'SpotBugs: Workspace analysis completed - 1 issue found.',
+      },
+    ]);
+  });
+
+  it('returns a warning summary when some projects fail but successful ones still produce results', () => {
+    const notices = buildWorkspaceCompletionNotices(
+      [
+        makeProjectResult({ findings: [{ patternId: 'X', location: {} }] }),
+        makeProjectResult({ error: 'bad aux classpath', errorCode: 'CFG_AUX_CLASSPATH_NOT_FOUND' }),
+      ],
+      1
+    );
+
+    assert.deepStrictEqual(notices, [
+      {
+        level: 'warn',
+        message:
+          'SpotBugs: Workspace analysis completed with failures - 1 project failed. 1 issue found in successful projects.',
+      },
+    ]);
+  });
+
+  it('returns an error summary when no projects succeed and at least one project fails', () => {
+    const notices = buildWorkspaceCompletionNotices(
+      [
+        makeProjectResult({ error: 'bad aux classpath', errorCode: 'CFG_AUX_CLASSPATH_NOT_FOUND' }),
+        makeProjectResult({ error: 'build failed', errorCode: NO_CLASS_TARGETS_CODE }),
+      ],
+      0
+    );
+
+    assert.deepStrictEqual(notices, [
+      {
+        level: 'error',
+        message:
+          'SpotBugs: Workspace analysis failed - 1 project failed. 1 project skipped because the build failed. See the SpotBugs view for project errors.',
+      },
+    ]);
+  });
+
+  it('returns the clean success summary when nothing failed and no findings were produced', () => {
+    const notices = buildWorkspaceCompletionNotices([makeProjectResult()], 0);
+
+    assert.deepStrictEqual(notices, [
+      {
+        level: 'info',
+        message: 'SpotBugs: Workspace analysis completed - No issues found.',
+      },
+    ]);
+  });
+});

--- a/src/workspace/analysisTargetCodes.ts
+++ b/src/workspace/analysisTargetCodes.ts
@@ -1,0 +1,3 @@
+export const NO_CLASS_TARGETS_CODE = 'no-class-targets';
+export const NO_CLASS_TARGETS_MESSAGE =
+  'SpotBugs could not build the project. Run a manual build, then try again.';

--- a/src/workspace/analysisTargetResolver.ts
+++ b/src/workspace/analysisTargetResolver.ts
@@ -16,7 +16,8 @@ export const NO_CLASS_TARGETS_MESSAGE =
 export interface AnalysisTarget {
   targetPath: string;
   preferredProject?: Uri;
-  classpaths?: string[];
+  targetResolutionRoots?: string[];
+  runtimeClasspaths?: string[];
   sourcepaths?: string[];
 }
 
@@ -61,7 +62,8 @@ export function createTargetResolver(overrides: Partial<TargetResolverDeps> = {}
   const deps: TargetResolverDeps = { ...defaultDeps, ...overrides };
 
   type ClasspathInfo = {
-    classpaths?: string[];
+    targetResolutionRoots?: string[];
+    runtimeClasspaths?: string[];
     sourcepaths?: string[];
     outputPath?: string;
   };
@@ -81,19 +83,27 @@ export function createTargetResolver(overrides: Partial<TargetResolverDeps> = {}
     project: Uri,
     options: { logSuccess?: boolean; logEmpty?: boolean; logFailure?: boolean }
   ): Promise<ClasspathInfo> {
-    let classpaths: string[] | undefined;
+    let targetResolutionRoots: string[] | undefined;
+    let runtimeClasspaths: string[] | undefined;
     let sourcepaths: string[] | undefined;
     let outputPath: string | undefined;
 
     try {
       const cp = await deps.getClasspaths(project, { logFailures: options.logFailure });
-      if (cp && Array.isArray(cp.classpaths) && cp.classpaths.length > 0) {
-        classpaths = cp.classpaths;
+      if (cp && Array.isArray(cp.runtimeClasspaths) && cp.runtimeClasspaths.length > 0) {
+        runtimeClasspaths = cp.runtimeClasspaths;
         if (options.logSuccess) {
-          deps.logger.log(`Set ${cp.classpaths.length} classpaths for analysis`);
+          deps.logger.log(
+            `Set ${cp.runtimeClasspaths.length} runtime classpaths and ${cp.targetResolutionRoots.length} target-resolution roots for analysis`
+          );
         }
       } else if (options.logEmpty) {
-        deps.logger.log('No classpaths returned from Java Language Server; using system classpath');
+        deps.logger.log(
+          'No runtime classpaths returned from Java Language Server; target resolution will use output folder fallbacks, and aux analysis may fall back to explicit extras or the system classpath.'
+        );
+      }
+      if (Array.isArray(cp?.targetResolutionRoots) && cp.targetResolutionRoots.length > 0) {
+        targetResolutionRoots = cp.targetResolutionRoots;
       }
       outputPath = cp?.output;
       if (Array.isArray(cp?.sourcepaths)) {
@@ -104,23 +114,23 @@ export function createTargetResolver(overrides: Partial<TargetResolverDeps> = {}
       if (options.logFailure) {
         const message = error instanceof Error ? error.message : String(error);
         deps.logger.log(
-          `Warning: Could not get project classpaths (${message}), using system classpath`
+          `Warning: Could not get project runtime classpaths (${message}); target resolution will use output folder fallbacks, and aux analysis may fall back to explicit extras or the system classpath.`
         );
       }
     }
 
-    return { classpaths, sourcepaths, outputPath };
+    return { targetResolutionRoots, runtimeClasspaths, sourcepaths, outputPath };
   }
 
   async function resolveOutputPath(
-    classpaths: string[] | undefined,
+    targetResolutionRoots: string[] | undefined,
     outputPath: string | undefined,
     classpathsRoot: string,
     projectRoot: string
   ): Promise<string | undefined> {
     let resolved = outputPath;
-    if (!resolved && Array.isArray(classpaths)) {
-      resolved = await deps.deriveOutputFolder(classpaths, classpathsRoot);
+    if (!resolved && Array.isArray(targetResolutionRoots)) {
+      resolved = await deps.deriveOutputFolder(targetResolutionRoots, classpathsRoot);
     }
     if (!resolved) {
       resolved = await deps.findOutputFolderFromProject(projectRoot);
@@ -129,18 +139,19 @@ export function createTargetResolver(overrides: Partial<TargetResolverDeps> = {}
   }
 
   async function resolveFileAnalysisTarget(uri: Uri): Promise<TargetResolution> {
-    const { classpaths, sourcepaths, outputPath } = await readClasspaths(uri, {
+    const { targetResolutionRoots, runtimeClasspaths, sourcepaths, outputPath } =
+      await readClasspaths(uri, {
       logSuccess: true,
       logEmpty: true,
       logFailure: true,
-    });
+      });
 
     const targetPath = uri.fsPath;
     if (!deps.isBytecodeTarget(targetPath)) {
       const workspaceFolder = deps.getWorkspaceFolder(uri);
       const workspacePath = workspaceFolder?.uri.fsPath ?? deps.dirname(targetPath);
       const resolvedOutput = await resolveOutputPath(
-        classpaths,
+        targetResolutionRoots,
         outputPath,
         workspacePath,
         workspacePath
@@ -161,7 +172,8 @@ export function createTargetResolver(overrides: Partial<TargetResolverDeps> = {}
       target: {
         targetPath,
         preferredProject: uri,
-        classpaths,
+        targetResolutionRoots,
+        runtimeClasspaths,
         sourcepaths,
       },
     };
@@ -172,14 +184,15 @@ export function createTargetResolver(overrides: Partial<TargetResolverDeps> = {}
     workspaceFolder: Uri
   ): Promise<TargetResolution> {
     const projectUriString = projectUri.toString();
-    const { classpaths, sourcepaths, outputPath } = await readClasspaths(projectUri, {
-      logEmpty: true,
-      logFailure: true,
-    });
+    const { targetResolutionRoots, runtimeClasspaths, sourcepaths, outputPath } =
+      await readClasspaths(projectUri, {
+        logEmpty: true,
+        logFailure: true,
+      });
     const projectRoot =
       projectUri.scheme === 'file' ? projectUri.fsPath : workspaceFolder.fsPath;
     const resolvedOutput = await resolveOutputPath(
-      classpaths,
+      targetResolutionRoots,
       outputPath,
       workspaceFolder.fsPath,
       projectRoot
@@ -201,7 +214,8 @@ export function createTargetResolver(overrides: Partial<TargetResolverDeps> = {}
       target: {
         targetPath: resolvedOutput,
         preferredProject: projectUri,
-        classpaths,
+        targetResolutionRoots,
+        runtimeClasspaths,
         sourcepaths,
       },
     };

--- a/src/workspace/analysisTargetResolver.ts
+++ b/src/workspace/analysisTargetResolver.ts
@@ -3,15 +3,12 @@ import * as path from 'path';
 import { Logger } from '../core/logger';
 import { deriveOutputFolder, getClasspaths } from './classpathService';
 import { primeSourcepathsCache } from './pathResolver';
+import { NO_CLASS_TARGETS_CODE, NO_CLASS_TARGETS_MESSAGE } from './analysisTargetCodes';
 import {
   findOutputFolderFromProject,
   hasClassTargets,
   isBytecodeTarget,
 } from './outputResolver';
-
-export const NO_CLASS_TARGETS_CODE = 'no-class-targets';
-export const NO_CLASS_TARGETS_MESSAGE =
-  'SpotBugs could not build the project. Run a manual build, then try again.';
 
 export interface AnalysisTarget {
   targetPath: string;

--- a/src/workspace/classpathCommandRunner.ts
+++ b/src/workspace/classpathCommandRunner.ts
@@ -6,7 +6,11 @@ import {
   requestJavaClasspaths,
 } from '../lsp/javaLsGateway';
 import { ClasspathAttempt } from './classpathAttemptSelector';
-import { ClasspathLookupOptions, ClasspathResult } from './classpathService';
+import { deriveTargetResolutionRoots } from './classpathLayout';
+import {
+  ClasspathLookupOptions,
+  ClasspathResult,
+} from './classpathService';
 
 export async function runClasspathAttempts(
   attempts: ClasspathAttempt[],
@@ -145,18 +149,21 @@ async function tryExtensionFallback(
 }
 
 function normalizeClasspathResult(res: JavaLsClasspathResponse): ClasspathResult {
+  const runtimeClasspaths = Array.isArray(res?.classpaths) ? res.classpaths : [];
   return {
     output: res?.output,
-    classpaths: Array.isArray(res?.classpaths) ? res.classpaths : [],
+    runtimeClasspaths,
+    targetResolutionRoots: deriveTargetResolutionRoots(res?.output, runtimeClasspaths),
     sourcepaths: Array.isArray(res?.sourcepaths) ? res.sourcepaths : [],
   };
 }
 
 function logSuccess(label: string, result: ClasspathResult): void {
-  const cps = result.classpaths.length;
+  const runtime = result.runtimeClasspaths.length;
+  const roots = result.targetResolutionRoots.length;
   const sps = result.sourcepaths.length;
   Logger.log(
-    `getClasspaths(${label}) succeeded: output=${result.output ?? 'n/a'}, classpaths=${cps}, sourcepaths=${sps}`
+    `getClasspaths(${label}) succeeded: output=${result.output ?? 'n/a'}, runtimeClasspaths=${runtime}, targetResolutionRoots=${roots}, sourcepaths=${sps}`
   );
 }
 

--- a/src/workspace/classpathLayout.ts
+++ b/src/workspace/classpathLayout.ts
@@ -1,0 +1,40 @@
+import * as path from 'path';
+
+export function deriveTargetResolutionRoots(
+  output: string | undefined,
+  runtimeClasspaths: string[]
+): string[] {
+  const roots: string[] = [];
+
+  if (typeof output === 'string') {
+    const trimmed = output.trim();
+    if (trimmed.length > 0) {
+      roots.push(trimmed);
+    }
+  }
+
+  for (const entry of runtimeClasspaths) {
+    const trimmed = entry.trim();
+    if (!trimmed || isArchivePath(trimmed)) {
+      continue;
+    }
+    roots.push(trimmed);
+  }
+
+  return dedupePreservingOrder(roots);
+}
+
+function isArchivePath(entry: string): boolean {
+  const lower = path.extname(entry).toLowerCase();
+  return lower === '.jar' || lower === '.zip';
+}
+
+function dedupePreservingOrder(values: string[]): string[] {
+  const deduped = new Set<string>();
+  for (const value of values) {
+    if (value) {
+      deduped.add(value);
+    }
+  }
+  return Array.from(deduped);
+}

--- a/src/workspace/classpathService.ts
+++ b/src/workspace/classpathService.ts
@@ -3,10 +3,12 @@ import * as path from 'path';
 import { Uri } from 'vscode';
 import { collectClasspathAttempts } from './classpathAttemptSelector';
 import { runClasspathAttempts } from './classpathCommandRunner';
+import { deriveTargetResolutionRoots } from './classpathLayout';
 
 export interface ClasspathResult {
   output?: string;
-  classpaths: string[];
+  runtimeClasspaths: string[];
+  targetResolutionRoots: string[];
   sourcepaths: string[];
 }
 
@@ -36,16 +38,11 @@ export async function getClasspaths(
 }
 
 export async function deriveOutputFolder(
-  classpaths: string[],
+  targetResolutionRoots: string[],
   workspacePath: string
 ): Promise<string | undefined> {
-  const jarsExcluded = classpaths.filter(
-    (entry) =>
-      !entry.toLowerCase().endsWith('.jar') &&
-      !entry.toLowerCase().endsWith('.zip')
-  );
   const candidates: string[] = [];
-  for (const cp of jarsExcluded) {
+  for (const cp of targetResolutionRoots) {
     for (const suf of PREFERRED_OUTPUT_SUFFIXES) {
       if (cp.includes(suf)) {
         candidates.push(cp);
@@ -53,7 +50,7 @@ export async function deriveOutputFolder(
       }
     }
   }
-  for (const cp of jarsExcluded) {
+  for (const cp of targetResolutionRoots) {
     if (!candidates.includes(cp) && cp.startsWith(workspacePath)) {
       candidates.push(cp);
     }


### PR DESCRIPTION
## Summary

- Separate target bytecode, auxiliary classpath, and sourcepath roles.
- Add extra auxiliary classpath support and structured project failures.