### PR TITLE
fix: suppress degraded-success notices for terminal workspace failures

### DIFF
--- a/src/lsp/javaLsOutcome.ts
+++ b/src/lsp/javaLsOutcome.ts
@@ -1,0 +1,59 @@
+import type { ClasspathResult } from '../workspace/classpathTypes';
+
+export type AnalysisResolutionIssueCode =
+  | 'JAVA_LS_REQUEST_FAILED'
+  | 'JAVA_LS_NO_RESULT'
+  | 'JAVA_LS_EMPTY_PROJECT_LIST'
+  | 'JAVA_LS_EMPTY_RUNTIME_CLASSPATH'
+  | 'JAVA_LS_EXTENSION_FALLBACK_USED'
+  | 'WORKSPACE_FALLBACK_USED'
+  | 'OUTPUT_FALLBACK_USED';
+
+export interface AnalysisResolutionIssue {
+  code: AnalysisResolutionIssueCode;
+  level: 'info' | 'warn';
+  source: 'java-ls' | 'project-discovery' | 'target-resolution';
+  phase:
+    | 'get-classpaths'
+    | 'get-all-projects'
+    | 'workspace-fallback'
+    | 'output-fallback';
+  message: string;
+  attemptLabel?: string;
+  variant?:
+    | 'uri-scope'
+    | 'uri'
+    | 'direct'
+    | 'runtime-arg'
+    | 'no-arg'
+    | 'extension-api';
+  cause?: string;
+}
+
+export type ClasspathLookupOutcome =
+  | {
+      status: 'resolved';
+      classpath: ClasspathResult;
+      issues: AnalysisResolutionIssue[];
+    }
+  | {
+      status: 'unavailable';
+      issues: AnalysisResolutionIssue[];
+    };
+
+export type JavaProjectsOutcome =
+  | {
+      status: 'resolved';
+      projectUris: string[];
+      issues: AnalysisResolutionIssue[];
+    }
+  | {
+      status: 'empty';
+      projectUris: [];
+      issues: AnalysisResolutionIssue[];
+    }
+  | {
+      status: 'unavailable';
+      projectUris: [];
+      issues: AnalysisResolutionIssue[];
+    };

--- a/src/orchestration/analysisNotices.ts
+++ b/src/orchestration/analysisNotices.ts
@@ -1,8 +1,10 @@
+import type { AnalysisResolutionIssue } from '../lsp/javaLsOutcome';
 import { AnalysisNotice, AnalysisOutcome } from '../model/analysisOutcome';
 import { formatAnalysisErrors } from '../model/analysisErrors';
 
 export interface BuildAnalysisNoticeOptions {
   includeHints?: boolean;
+  resolutionIssues?: AnalysisResolutionIssue[];
 }
 
 export function buildAnalysisNotices(
@@ -10,6 +12,11 @@ export function buildAnalysisNotices(
   options: BuildAnalysisNoticeOptions = {}
 ): AnalysisNotice[] {
   const notices: AnalysisNotice[] = [];
+  const hasTerminalFailure =
+    !!outcome.failure ||
+    (Array.isArray(outcome.errors) &&
+      outcome.errors.length > 0 &&
+      outcome.findings.length === 0);
 
   if (outcome.failure) {
     notices.push({
@@ -17,32 +24,76 @@ export function buildAnalysisNotices(
       code: outcome.failure.code,
       message: outcome.failure.message,
     });
-    return notices;
   }
 
   if (Array.isArray(outcome.errors) && outcome.errors.length > 0) {
     const combined = formatAnalysisErrors(outcome.errors);
     if (outcome.findings.length === 0) {
+      if (!outcome.failure) {
+        notices.push({
+          level: 'error',
+          message: `SpotBugs analysis failed: ${combined}`,
+        });
+      }
+    } else {
       notices.push({
-        level: 'error',
-        message: `SpotBugs analysis failed: ${combined}`,
+        level: 'warn',
+        message: `SpotBugs analysis completed with warnings: ${combined}`,
       });
-      return notices;
     }
-    notices.push({
-      level: 'warn',
-      message: `SpotBugs analysis completed with warnings: ${combined}`,
-    });
   }
 
-  if (options.includeHints && outcome.findings.length === 0) {
+  notices.push(
+    ...buildResolutionIssueNotices(options.resolutionIssues ?? [], {
+      terminal: hasTerminalFailure,
+    })
+  );
+
+  if (!hasTerminalFailure && options.includeHints && outcome.findings.length === 0) {
     const targetPath = outcome.targetPath ?? outcome.stats?.target;
     if (targetPath) {
       notices.push(...buildHintNotices(targetPath, outcome));
     }
   }
 
-  return notices;
+  return dedupeNotices(notices);
+}
+
+export function buildResolutionIssueNotices(
+  issues: AnalysisResolutionIssue[],
+  context: {
+    terminal?: boolean;
+  } = {}
+): AnalysisNotice[] {
+  if (issues.length === 0) {
+    return [];
+  }
+
+  const hasSpecificWorkspaceCause = issues.some(
+    (issue) =>
+      issue.phase === 'get-all-projects' &&
+      (issue.code === 'JAVA_LS_EMPTY_PROJECT_LIST' ||
+        issue.code === 'JAVA_LS_REQUEST_FAILED' ||
+        issue.code === 'JAVA_LS_NO_RESULT')
+  );
+  const noResultChangedBehavior = issues.some(
+    (issue) =>
+      issue.code === 'WORKSPACE_FALLBACK_USED' ||
+      issue.code === 'OUTPUT_FALLBACK_USED' ||
+      issue.code === 'JAVA_LS_EMPTY_RUNTIME_CLASSPATH'
+  );
+
+  const notices = issues
+    .map((issue) =>
+      translateResolutionIssue(issue, {
+        hasSpecificWorkspaceCause,
+        noResultChangedBehavior,
+        terminal: context.terminal === true,
+      })
+    )
+    .filter((notice): notice is AnalysisNotice => !!notice);
+
+  return dedupeNotices(notices, semanticNoticeKey);
 }
 
 function buildHintNotices(targetPath: string, outcome: AnalysisOutcome): AnalysisNotice[] {
@@ -83,4 +134,107 @@ function buildHintNotices(targetPath: string, outcome: AnalysisOutcome): Analysi
   }
 
   return notices;
+}
+
+function translateResolutionIssue(
+  issue: AnalysisResolutionIssue,
+  context: {
+    hasSpecificWorkspaceCause: boolean;
+    noResultChangedBehavior: boolean;
+    terminal: boolean;
+  }
+): AnalysisNotice | undefined {
+  switch (issue.code) {
+    case 'JAVA_LS_EXTENSION_FALLBACK_USED':
+      return undefined;
+    case 'JAVA_LS_EMPTY_RUNTIME_CLASSPATH':
+      return {
+        level: 'warn',
+        code: issue.code,
+        message:
+          'SpotBugs: Java runtime classpath information is unavailable; results may be incomplete.',
+      };
+    case 'WORKSPACE_FALLBACK_USED':
+      if (context.hasSpecificWorkspaceCause) {
+        return undefined;
+      }
+      return {
+        level: 'info',
+        code: issue.code,
+        message:
+          'SpotBugs: Java project discovery was unavailable, so workspace-folder analysis was used.',
+      };
+    case 'JAVA_LS_REQUEST_FAILED':
+      return translateJavaLsLookupFallbackNotice(issue, context);
+    case 'JAVA_LS_EMPTY_PROJECT_LIST':
+      return {
+        level: 'info',
+        code: issue.code,
+        message:
+          'SpotBugs: No Java projects were reported by the Java Language Server; workspace-folder analysis was used.',
+      };
+    case 'OUTPUT_FALLBACK_USED':
+      return {
+        level: 'info',
+        code: issue.code,
+        message:
+          'SpotBugs: Java build output metadata was unavailable; output folder fallback was used.',
+      };
+    case 'JAVA_LS_NO_RESULT':
+      return translateJavaLsLookupFallbackNotice(issue, context);
+    default:
+      return undefined;
+  }
+}
+
+function translateJavaLsLookupFallbackNotice(
+  issue: AnalysisResolutionIssue,
+  context: {
+    noResultChangedBehavior: boolean;
+    terminal: boolean;
+  }
+): AnalysisNotice | undefined {
+  if (context.terminal) {
+    return undefined;
+  }
+
+  if (issue.code === 'JAVA_LS_NO_RESULT' && !context.noResultChangedBehavior) {
+    return undefined;
+  }
+
+  return {
+    level: 'warn',
+    code: issue.code,
+    message:
+      'SpotBugs: Java project metadata lookup failed; analysis continued with fallback behavior.',
+  };
+}
+
+function dedupeNotices(
+  notices: AnalysisNotice[],
+  keyBuilder: (notice: AnalysisNotice) => string = exactNoticeKey
+): AnalysisNotice[] {
+  const deduped: AnalysisNotice[] = [];
+  const seen = new Set<string>();
+
+  for (const notice of notices) {
+    const key = keyBuilder(notice);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(notice);
+  }
+
+  return deduped;
+}
+
+function exactNoticeKey(notice: AnalysisNotice): string {
+  return `${notice.level}|${notice.code ?? ''}|${notice.message}`;
+}
+
+function semanticNoticeKey(notice: AnalysisNotice): string {
+  const code =
+    notice.code === 'JAVA_LS_NO_RESULT' ? 'JAVA_LS_REQUEST_FAILED' : notice.code ?? '';
+  return `${notice.level}|${code}|${notice.message}`;
 }

--- a/src/orchestration/analysisRunner.ts
+++ b/src/orchestration/analysisRunner.ts
@@ -2,7 +2,10 @@ import { commands, ProgressLocation, Uri, window } from 'vscode';
 import { Config } from '../core/config';
 import { Logger } from '../core/logger';
 import { Notifier, defaultNotifier } from '../core/notifier';
-import { analyzeFile, analyzeWorkspaceFromProjects, getWorkspaceProjects } from '../services/analysisService';
+import {
+  analyzeFileDetailed,
+  analyzeWorkspaceFromProjectsDetailed,
+} from '../services/analysisService';
 import type { ProjectResult } from '../services/projectResult';
 import { buildAnalysisNotices } from './analysisNotices';
 import { buildWorkspaceCompletionNotices } from './workspaceSummary';
@@ -10,6 +13,7 @@ import { SpotBugsDiagnosticsManager } from '../services/diagnosticsManager';
 import { buildWorkspaceAuto } from '../services/workspaceBuildService';
 import { SpotBugsTreeDataProvider } from '../ui/spotbugsTreeDataProvider';
 import { Finding } from '../model/finding';
+import { getWorkspaceProjectDiscovery } from '../workspace/projectDiscovery';
 import { getPrimaryWorkspaceFolder } from '../workspace/workspaceRoots';
 
 export interface RunFileAnalysisArgs {
@@ -45,11 +49,15 @@ export async function runFileAnalysis(
 
   args.tree.showLoading();
   try {
-    const outcome = await analyzeFile(args.config, fileUri);
+    const result = await analyzeFileDetailed(args.config, fileUri);
+    const outcome = result.outcome;
     const findings = outcome.findings;
     args.tree.showResults(findings);
     args.diagnostics.updateForFile(fileUri, findings);
-    const notices = buildAnalysisNotices(outcome, { includeHints: true });
+    const notices = buildAnalysisNotices(outcome, {
+      includeHints: true,
+      resolutionIssues: result.context.resolutionIssues,
+    });
     for (const notice of notices) {
       if (notice.level === 'error') {
         notifier.error(notice.message);
@@ -80,6 +88,7 @@ export async function runWorkspaceAnalysis(
   try {
     let aggregated: Finding[] = [];
     let projectResults: ProjectResult[] = [];
+    let resolutionIssues: import('../lsp/javaLsOutcome').AnalysisResolutionIssue[] = [];
     let cancelled = false;
 
     await window.withProgress(
@@ -105,13 +114,13 @@ export async function runWorkspaceAnalysis(
           throw new Error('No workspace folder found.');
         }
 
-        const projectUris = await getWorkspaceProjects(wsFolder.uri);
-        args.tree.showWorkspaceProgress(projectUris);
+        const discovery = await getWorkspaceProjectDiscovery(wsFolder.uri);
+        args.tree.showWorkspaceProgress(discovery.projectUris);
 
-        const res = await analyzeWorkspaceFromProjects(
+        const res = await analyzeWorkspaceFromProjectsDetailed(
           args.config,
           wsFolder.uri,
-          projectUris,
+          discovery.projectUris,
           {
             onStart: (u, idx, total) => {
               progress.report({ message: `${idx}/${total} ${u}` });
@@ -124,6 +133,10 @@ export async function runWorkspaceAnalysis(
         );
         projectResults = res.results;
         aggregated = res.results.flatMap((r) => r.findings);
+        resolutionIssues = [
+          ...discovery.issues,
+          ...res.context.resolutionIssues,
+        ];
         cancelled = res.cancelled === true || token.isCancellationRequested;
       }
     );
@@ -134,8 +147,11 @@ export async function runWorkspaceAnalysis(
 
     args.tree.showResults(aggregated);
     args.diagnostics.replaceAll(aggregated);
-
-    const notices = buildWorkspaceCompletionNotices(projectResults, aggregated.length);
+    const notices = buildWorkspaceCompletionNotices(
+      projectResults,
+      aggregated.length,
+      resolutionIssues
+    );
     for (const notice of notices) {
       if (notice.level === 'error') {
         notifier.error(notice.message);

--- a/src/orchestration/workspaceSummary.ts
+++ b/src/orchestration/workspaceSummary.ts
@@ -1,10 +1,13 @@
 import type { AnalysisNotice } from '../model/analysisOutcome';
+import type { AnalysisResolutionIssue } from '../lsp/javaLsOutcome';
+import { buildResolutionIssueNotices } from './analysisNotices';
 import type { ProjectResult } from '../services/projectResult';
 import { NO_CLASS_TARGETS_CODE } from '../workspace/analysisTargetCodes';
 
 export function buildWorkspaceCompletionNotices(
   projectResults: ProjectResult[],
-  findingCount: number
+  findingCount: number,
+  resolutionIssues: AnalysisResolutionIssue[] = []
 ): AnalysisNotice[] {
   const skippedCount = projectResults.filter(
     (result) => result.errorCode === NO_CLASS_TARGETS_CODE
@@ -13,67 +16,72 @@ export function buildWorkspaceCompletionNotices(
     (result) => !!result.error && result.errorCode !== NO_CLASS_TARGETS_CODE
   ).length;
   const succeededCount = projectResults.length - skippedCount - failedCount;
+  const hasTerminalFailure =
+    (projectResults.length > 0 && skippedCount === projectResults.length) ||
+    (failedCount > 0 && succeededCount === 0);
+  const notices: AnalysisNotice[] = [];
 
   if (projectResults.length > 0 && skippedCount === projectResults.length) {
-    return [
+    notices.push(
       {
         level: 'warn',
         message: 'SpotBugs could not build the project. Run a manual build, then try again.',
-      },
-    ];
-  }
-
-  if (failedCount > 0) {
+      }
+    );
+  } else if (failedCount > 0) {
     const skippedSentence =
       skippedCount > 0
         ? ` ${formatProjectCount(skippedCount)} skipped because the build failed.`
         : '';
 
     if (succeededCount === 0) {
-      return [
+      notices.push(
         {
           level: 'error',
           message:
             `SpotBugs: Workspace analysis failed - ${formatProjectCount(failedCount)} failed.` +
             `${skippedSentence} See the SpotBugs view for project errors.`,
-        },
-      ];
-    }
+        }
+      );
+    } else {
+      const successSummary =
+        findingCount === 0
+          ? 'Successful projects produced no findings.'
+          : `${formatIssueCount(findingCount)} found in successful projects.`;
 
-    const successSummary =
-      findingCount === 0
-        ? 'Successful projects produced no findings.'
-        : `${formatIssueCount(findingCount)} found in successful projects.`;
-
-    return [
-      {
+      notices.push({
         level: 'warn',
         message:
           `SpotBugs: Workspace analysis completed with failures - ${formatProjectCount(
             failedCount
           )} failed.` + `${skippedSentence} ${successSummary}`,
-      },
-    ];
-  }
+      });
+    }
+  } else {
+    if (skippedCount > 0) {
+      notices.push({
+        level: 'warn',
+        message:
+          `SpotBugs skipped ${formatProjectCount(skippedCount)} because the build failed. ` +
+          'Run a manual build, then try again.',
+      });
+    }
 
-  const notices: AnalysisNotice[] = [];
-  if (skippedCount > 0) {
     notices.push({
-      level: 'warn',
+      level: 'info',
       message:
-        `SpotBugs skipped ${formatProjectCount(skippedCount)} because the build failed. ` +
-        'Run a manual build, then try again.',
+        findingCount === 0
+          ? 'SpotBugs: Workspace analysis completed - No issues found.'
+          : `SpotBugs: Workspace analysis completed - ${formatIssueCount(findingCount)} found.`,
     });
   }
 
-  notices.push({
-    level: 'info',
-    message:
-      findingCount === 0
-        ? 'SpotBugs: Workspace analysis completed - No issues found.'
-        : `SpotBugs: Workspace analysis completed - ${formatIssueCount(findingCount)} found.`,
-  });
-  return notices;
+  notices.push(
+    ...buildResolutionIssueNotices(resolutionIssues, {
+      terminal: hasTerminalFailure,
+    })
+  );
+  return dedupeNotices(notices);
 }
 
 function formatProjectCount(count: number): string {
@@ -82,4 +90,20 @@ function formatProjectCount(count: number): string {
 
 function formatIssueCount(count: number): string {
   return `${count} issue${count === 1 ? '' : 's'}`;
+}
+
+function dedupeNotices(notices: AnalysisNotice[]): AnalysisNotice[] {
+  const deduped: AnalysisNotice[] = [];
+  const seen = new Set<string>();
+
+  for (const notice of notices) {
+    const key = `${notice.level}|${notice.code ?? ''}|${notice.message}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(notice);
+  }
+
+  return deduped;
 }

--- a/src/services/analysisService.ts
+++ b/src/services/analysisService.ts
@@ -1,6 +1,7 @@
 import { CancellationToken, Uri } from 'vscode';
 import { Logger } from '../core/logger';
 import { Config } from '../core/config';
+import type { AnalysisResolutionIssue } from '../lsp/javaLsOutcome';
 import { AnalysisOutcome } from '../model/analysisOutcome';
 import { formatAnalysisErrors } from '../model/analysisErrors';
 import { ANALYSIS_PROTOCOL_SCHEMA_VERSION } from '../model/analysisProtocol';
@@ -18,7 +19,9 @@ import {
 } from './filterFileValidation';
 import {
   resolveFileAnalysisTarget,
+  resolveFileAnalysisTargetDetailed,
   resolveProjectAnalysisTarget,
+  resolveProjectAnalysisTargetDetailed,
 } from '../workspace/analysisTargetResolver';
 import { getWorkspaceProjectUris } from '../workspace/projectDiscovery';
 
@@ -38,26 +41,71 @@ export interface WorkspaceResult {
   cancelled?: boolean;
 }
 
-export async function analyzeFile(config: Config, uri: Uri): Promise<AnalysisOutcome> {
+export interface AnalysisExecutionContext {
+  resolutionIssues: AnalysisResolutionIssue[];
+}
+
+export interface AnalysisExecutionResult {
+  outcome: AnalysisOutcome;
+  context: AnalysisExecutionContext;
+}
+
+export interface WorkspaceExecutionResult {
+  results: ProjectResult[];
+  cancelled?: boolean;
+  context: AnalysisExecutionContext;
+}
+
+export async function analyzeFileDetailed(
+  config: Config,
+  uri: Uri
+): Promise<AnalysisExecutionResult> {
+  const context = createExecutionContext();
+
   try {
-    const resolution = await resolveFileAnalysisTarget(uri);
-    if (resolution.status !== 'ok') {
+    const result = await resolveFileAnalysisTargetDetailed(uri);
+    context.resolutionIssues.push(...result.issues);
+
+    if (result.resolution.status !== 'ok') {
       return {
-        findings: [],
-        targetPath: uri.fsPath,
-        failure: {
-          kind: 'target',
-          level: 'warn',
-          code: resolution.errorCode,
-          message: resolution.message,
+        outcome: {
+          findings: [],
+          targetPath: uri.fsPath,
+          failure: {
+            kind: 'target',
+            level: 'warn',
+            code: result.resolution.errorCode,
+            message: result.resolution.message,
+          },
         },
+        context,
       };
     }
-    return await runAnalysis(config, resolution.target);
+
+    try {
+      return {
+        outcome: await runAnalysis(config, result.resolution.target),
+        context,
+      };
+    } catch (error) {
+      Logger.error('Analyzer: analyzeFile failed', error);
+      return {
+        outcome: { findings: [] },
+        context,
+      };
+    }
   } catch (error) {
     Logger.error('Analyzer: analyzeFile failed', error);
-    return { findings: [] };
+    return {
+      outcome: { findings: [] },
+      context,
+    };
   }
+}
+
+export async function analyzeFile(config: Config, uri: Uri): Promise<AnalysisOutcome> {
+  const result = await analyzeFileDetailed(config, uri);
+  return result.outcome;
 }
 
 export async function analyzeWorkspace(
@@ -74,7 +122,7 @@ export async function analyzeWorkspace(
   return analyzeWorkspaceFromProjects(config, workspaceFolder, projectUris, notify, token);
 }
 
-export async function analyzeWorkspaceFromProjects(
+export async function analyzeWorkspaceFromProjectsDetailed(
   config: Config,
   workspaceFolder: Uri,
   projectUris: string[],
@@ -84,8 +132,9 @@ export async function analyzeWorkspaceFromProjects(
     onFail?: (uriString: string, message: string) => void;
   },
   token?: CancellationToken
-): Promise<WorkspaceResult> {
+): Promise<WorkspaceExecutionResult> {
   const results: ProjectResult[] = [];
+  const context = createExecutionContext();
   let cancelled = false;
 
   for (let index = 0; index < projectUris.length; index++) {
@@ -98,17 +147,46 @@ export async function analyzeWorkspaceFromProjects(
 
     notify?.onStart?.(uriString, index + 1, projectUris.length);
 
-    const projectResult = await analyzeProject(config, Uri.parse(uriString), workspaceFolder);
-    if (projectResult.error) {
-      notify?.onFail?.(uriString, projectResult.error);
+    const result = await analyzeProjectDetailed(
+      config,
+      Uri.parse(uriString),
+      workspaceFolder
+    );
+    if (result.projectResult.error) {
+      notify?.onFail?.(uriString, result.projectResult.error);
     } else {
-      notify?.onDone?.(uriString, projectResult.findings.length);
+      notify?.onDone?.(uriString, result.projectResult.findings.length);
     }
 
-    results.push(projectResult);
+    results.push(result.projectResult);
+    context.resolutionIssues.push(...result.context.resolutionIssues);
   }
 
-  return { results, cancelled };
+  return { results, cancelled, context };
+}
+
+export async function analyzeWorkspaceFromProjects(
+  config: Config,
+  workspaceFolder: Uri,
+  projectUris: string[],
+  notify?: {
+    onStart?: (uriString: string, index: number, total: number) => void;
+    onDone?: (uriString: string, count: number) => void;
+    onFail?: (uriString: string, message: string) => void;
+  },
+  token?: CancellationToken
+): Promise<WorkspaceResult> {
+  const result = await analyzeWorkspaceFromProjectsDetailed(
+    config,
+    workspaceFolder,
+    projectUris,
+    notify,
+    token
+  );
+  return {
+    results: result.results,
+    cancelled: result.cancelled,
+  };
 }
 
 export async function getWorkspaceProjects(workspaceFolder: Uri): Promise<string[]> {
@@ -120,25 +198,54 @@ async function analyzeProject(
   project: ProjectRef,
   workspaceFolder: Uri
 ): Promise<ProjectResult> {
+  const result = await analyzeProjectDetailed(config, project, workspaceFolder);
+  return result.projectResult;
+}
+
+async function analyzeProjectDetailed(
+  config: Config,
+  project: ProjectRef,
+  workspaceFolder: Uri
+): Promise<{ projectResult: ProjectResult; context: AnalysisExecutionContext }> {
   const projectUri = normalizeProjectRef(project);
   const projectUriString = projectUri.toString();
+  const context = createExecutionContext();
 
   try {
-    const resolution = await resolveProjectAnalysisTarget(projectUri, workspaceFolder);
-    if (resolution.status !== 'ok') {
+    const result = await resolveProjectAnalysisTargetDetailed(projectUri, workspaceFolder);
+    context.resolutionIssues.push(...result.issues);
+
+    if (result.resolution.status !== 'ok') {
       return {
-        projectUri: projectUriString,
-        findings: [],
-        error: resolution.message,
-        errorCode: resolution.errorCode,
+        projectResult: {
+          projectUri: projectUriString,
+          findings: [],
+          error: result.resolution.message,
+          errorCode: result.resolution.errorCode,
+        },
+        context,
       };
     }
 
-    const outcome = await runAnalysis(config, resolution.target);
-    return projectResultFromOutcome(projectUriString, outcome);
+    try {
+      const outcome = await runAnalysis(config, result.resolution.target);
+      return {
+        projectResult: projectResultFromOutcome(projectUriString, outcome),
+        context,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        projectResult: { projectUri: projectUriString, findings: [], error: message },
+        context,
+      };
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    return { projectUri: projectUriString, findings: [], error: message };
+    return {
+      projectResult: { projectUri: projectUriString, findings: [], error: message },
+      context,
+    };
   }
 }
 
@@ -310,4 +417,10 @@ function normalizeProjectRef(project: ProjectRef): Uri {
   }
 
   throw new Error('Unsupported project reference');
+}
+
+function createExecutionContext(): AnalysisExecutionContext {
+  return {
+    resolutionIssues: [],
+  };
 }

--- a/src/services/javaLsClient.ts
+++ b/src/services/javaLsClient.ts
@@ -1,13 +1,29 @@
 import { Uri } from 'vscode';
+import type { JavaProjectsOutcome } from '../lsp/javaLsOutcome';
 import { requestAllJavaProjects } from '../lsp/javaLsGateway';
 import { buildWorkspace, BuildMode } from './workspaceBuildService';
 
 export class JavaLsClient {
-  static async getAllProjects(): Promise<string[]> {
+  static async getAllProjectsOutcome(): Promise<JavaProjectsOutcome> {
     try {
-      const uris = (await requestAllJavaProjects()) || [];
-      // filter out default pseudo project
-      return uris.filter((uriString) => {
+      const uris = await requestAllJavaProjects();
+      if (uris === undefined || uris === null) {
+        return {
+          status: 'unavailable',
+          projectUris: [],
+          issues: [
+            {
+              code: 'JAVA_LS_NO_RESULT',
+              level: 'warn',
+              source: 'java-ls',
+              phase: 'get-all-projects',
+              message: 'Java LS project discovery returned no usable result.',
+            },
+          ],
+        };
+      }
+
+      const projectUris = uris.filter((uriString) => {
         try {
           const p = Uri.parse(uriString).fsPath;
           return !p.endsWith('jdt.ls-java-project');
@@ -15,9 +31,49 @@ export class JavaLsClient {
           return true;
         }
       });
-    } catch {
-      return [];
+
+      if (projectUris.length === 0) {
+        return {
+          status: 'empty',
+          projectUris: [],
+          issues: [
+            {
+              code: 'JAVA_LS_EMPTY_PROJECT_LIST',
+              level: 'info',
+              source: 'project-discovery',
+              phase: 'get-all-projects',
+              message: 'Java LS reported no Java projects.',
+            },
+          ],
+        };
+      }
+
+      return {
+        status: 'resolved',
+        projectUris,
+        issues: [],
+      };
+    } catch (error) {
+      return {
+        status: 'unavailable',
+        projectUris: [],
+        issues: [
+          {
+            code: 'JAVA_LS_REQUEST_FAILED',
+            level: 'warn',
+            source: 'java-ls',
+            phase: 'get-all-projects',
+            message: 'Java LS project discovery request failed.',
+            cause: error instanceof Error ? error.message : String(error),
+          },
+        ],
+      };
     }
+  }
+
+  static async getAllProjects(): Promise<string[]> {
+    const outcome = await JavaLsClient.getAllProjectsOutcome();
+    return outcome.projectUris;
   }
 
   static async buildWorkspace(mode: BuildMode = 'auto'): Promise<number | undefined> {

--- a/src/test/analysisNotices.unit.test.ts
+++ b/src/test/analysisNotices.unit.test.ts
@@ -1,0 +1,475 @@
+import * as assert from 'assert';
+import {
+  buildAnalysisNotices,
+  buildResolutionIssueNotices,
+} from '../orchestration/analysisNotices';
+
+describe('analysisNotices', () => {
+  it('maps JAVA_LS_EMPTY_RUNTIME_CLASSPATH to a warning notice', () => {
+    const notices = buildResolutionIssueNotices([
+      {
+        code: 'JAVA_LS_EMPTY_RUNTIME_CLASSPATH',
+        level: 'warn',
+        source: 'java-ls',
+        phase: 'get-classpaths',
+        message: 'Java LS classpath lookup returned no runtime classpath entries.',
+      },
+    ]);
+
+    assert.deepStrictEqual(notices, [
+      {
+        level: 'warn',
+        code: 'JAVA_LS_EMPTY_RUNTIME_CLASSPATH',
+        message:
+          'SpotBugs: Java runtime classpath information is unavailable; results may be incomplete.',
+      },
+    ]);
+  });
+
+  it('suppresses WORKSPACE_FALLBACK_USED when a more specific workspace-discovery cause exists', () => {
+    const notices = buildResolutionIssueNotices([
+      {
+        code: 'JAVA_LS_EMPTY_PROJECT_LIST',
+        level: 'info',
+        source: 'project-discovery',
+        phase: 'get-all-projects',
+        message: 'Java LS reported no Java projects.',
+      },
+      {
+        code: 'WORKSPACE_FALLBACK_USED',
+        level: 'info',
+        source: 'project-discovery',
+        phase: 'workspace-fallback',
+        message: 'Workspace-folder fallback was used for project discovery.',
+      },
+    ]);
+
+    assert.deepStrictEqual(notices, [
+      {
+        level: 'info',
+        code: 'JAVA_LS_EMPTY_PROJECT_LIST',
+        message:
+          'SpotBugs: No Java projects were reported by the Java Language Server; workspace-folder analysis was used.',
+      },
+    ]);
+  });
+
+  it('dedupes JAVA_LS_REQUEST_FAILED and JAVA_LS_NO_RESULT into one semantic warning notice', () => {
+    const notices = buildResolutionIssueNotices([
+      {
+        code: 'JAVA_LS_REQUEST_FAILED',
+        level: 'warn',
+        source: 'java-ls',
+        phase: 'get-classpaths',
+        message: 'Java LS classpath lookup failed.',
+      },
+      {
+        code: 'JAVA_LS_NO_RESULT',
+        level: 'warn',
+        source: 'java-ls',
+        phase: 'get-classpaths',
+        message: 'Java LS classpath lookup returned no usable result.',
+      },
+      {
+        code: 'OUTPUT_FALLBACK_USED',
+        level: 'info',
+        source: 'target-resolution',
+        phase: 'output-fallback',
+        message: 'Output folder fallback was used because Java build output metadata was unavailable.',
+      },
+    ]);
+
+    assert.deepStrictEqual(notices, [
+      {
+        level: 'warn',
+        code: 'JAVA_LS_REQUEST_FAILED',
+        message:
+          'SpotBugs: Java project metadata lookup failed; analysis continued with fallback behavior.',
+      },
+      {
+        level: 'info',
+        code: 'OUTPUT_FALLBACK_USED',
+        message:
+          'SpotBugs: Java build output metadata was unavailable; output folder fallback was used.',
+      },
+    ]);
+  });
+
+  it('appends translated resolution notices to successful analysis outcomes', () => {
+    const notices = buildAnalysisNotices(
+      {
+        findings: [],
+        targetPath: '/workspace/src/main/java/Foo.java',
+      },
+      {
+        resolutionIssues: [
+          {
+            code: 'OUTPUT_FALLBACK_USED',
+            level: 'info',
+            source: 'target-resolution',
+            phase: 'output-fallback',
+            message: 'Output folder fallback was used because Java build output metadata was unavailable.',
+          },
+        ],
+      }
+    );
+
+    assert.deepStrictEqual(notices, [
+      {
+        level: 'info',
+        code: 'OUTPUT_FALLBACK_USED',
+        message:
+          'SpotBugs: Java build output metadata was unavailable; output folder fallback was used.',
+      },
+    ]);
+  });
+
+  it('keeps resolution notices on failure outcomes instead of returning early', () => {
+    const notices = buildAnalysisNotices(
+      {
+        findings: [],
+        targetPath: '/workspace/src/main/java/Foo.java',
+        failure: {
+          kind: 'target',
+          level: 'warn',
+          code: 'NO_CLASS_TARGETS',
+          message: 'No compiled classes found.',
+        },
+      },
+      {
+        resolutionIssues: [
+          {
+            code: 'OUTPUT_FALLBACK_USED',
+            level: 'info',
+            source: 'target-resolution',
+            phase: 'output-fallback',
+            message:
+              'Output folder fallback was used because Java build output metadata was unavailable.',
+          },
+        ],
+      }
+    );
+
+    assert.deepStrictEqual(notices, [
+      {
+        level: 'warn',
+        code: 'NO_CLASS_TARGETS',
+        message: 'No compiled classes found.',
+      },
+      {
+        level: 'info',
+        code: 'OUTPUT_FALLBACK_USED',
+        message:
+          'SpotBugs: Java build output metadata was unavailable; output folder fallback was used.',
+      },
+    ]);
+  });
+
+  it('keeps only one terminal notice for failure + errors + no findings while preserving resolution notices', () => {
+    const notices = buildAnalysisNotices(
+      {
+        findings: [],
+        targetPath: '/workspace/src/main/java/Foo.java',
+        failure: {
+          kind: 'analysis-error',
+          level: 'error',
+          code: 'CFG_AUX_CLASSPATH_NOT_FOUND',
+          message:
+            'SpotBugs analysis failed: [CFG_AUX_CLASSPATH_NOT_FOUND] aux classpath is invalid',
+        },
+        errors: [
+          {
+            message: 'aux classpath is invalid',
+            code: 'CFG_AUX_CLASSPATH_NOT_FOUND',
+          },
+        ],
+      },
+      {
+        includeHints: true,
+        resolutionIssues: [
+          {
+            code: 'JAVA_LS_REQUEST_FAILED',
+            level: 'warn',
+            source: 'java-ls',
+            phase: 'get-classpaths',
+            message: 'Java LS classpath lookup failed.',
+          },
+        ],
+      }
+    );
+
+    const terminalNotices = notices.filter(
+      (notice) => notice.message === 'SpotBugs analysis failed: [CFG_AUX_CLASSPATH_NOT_FOUND] aux classpath is invalid'
+    );
+
+    assert.strictEqual(terminalNotices.length, 1);
+    assert.deepStrictEqual(notices, [
+      {
+        level: 'error',
+        code: 'CFG_AUX_CLASSPATH_NOT_FOUND',
+        message:
+          'SpotBugs analysis failed: [CFG_AUX_CLASSPATH_NOT_FOUND] aux classpath is invalid',
+      },
+    ]);
+    assert.ok(
+      notices.every(
+        (notice) =>
+          notice.message !==
+          'SpotBugs: Java project metadata lookup failed; analysis continued with fallback behavior.'
+      )
+    );
+    assert.ok(
+      notices.every(
+        (notice) =>
+          notice.message !==
+          'SpotBugs: No compiled classes found (target-resolution roots unavailable). Make sure the target is inside a Java project and build the workspace.'
+      )
+    );
+  });
+
+  it('keeps resolution notices on fatal error outcomes with no findings', () => {
+    const notices = buildAnalysisNotices(
+      {
+        findings: [],
+        errors: [
+          {
+            message: 'aux classpath is invalid',
+            code: 'CFG_AUX_CLASSPATH_NOT_FOUND',
+          },
+        ],
+      },
+      {
+        resolutionIssues: [
+          {
+            code: 'JAVA_LS_REQUEST_FAILED',
+            level: 'warn',
+            source: 'java-ls',
+            phase: 'get-classpaths',
+            message: 'Java LS classpath lookup failed.',
+          },
+        ],
+      }
+    );
+
+    assert.deepStrictEqual(notices, [
+      {
+        level: 'error',
+        message: 'SpotBugs analysis failed: [CFG_AUX_CLASSPATH_NOT_FOUND] aux classpath is invalid',
+      },
+    ]);
+  });
+
+  it('suppresses JAVA_LS_REQUEST_FAILED on terminal target failures', () => {
+    const notices = buildAnalysisNotices(
+      {
+        findings: [],
+        failure: {
+          kind: 'target',
+          level: 'warn',
+          code: 'NO_CLASS_TARGETS',
+          message: 'No compiled classes found.',
+        },
+      },
+      {
+        resolutionIssues: [
+          {
+            code: 'JAVA_LS_REQUEST_FAILED',
+            level: 'warn',
+            source: 'java-ls',
+            phase: 'get-classpaths',
+            message: 'Java LS classpath lookup failed.',
+          },
+        ],
+      }
+    );
+
+    assert.deepStrictEqual(notices, [
+      {
+        level: 'warn',
+        code: 'NO_CLASS_TARGETS',
+        message: 'No compiled classes found.',
+      },
+    ]);
+    assert.ok(
+      notices.every(
+        (notice) =>
+          notice.message !==
+          'SpotBugs: Java project metadata lookup failed; analysis continued with fallback behavior.'
+      )
+    );
+  });
+
+  it('keeps a fatal error notice for errors-only outcomes with no findings', () => {
+    const notices = buildAnalysisNotices({
+      findings: [],
+      errors: [
+        {
+          message: 'aux classpath is invalid',
+          code: 'CFG_AUX_CLASSPATH_NOT_FOUND',
+        },
+      ],
+    });
+
+    assert.deepStrictEqual(notices, [
+      {
+        level: 'error',
+        message: 'SpotBugs analysis failed: [CFG_AUX_CLASSPATH_NOT_FOUND] aux classpath is invalid',
+      },
+    ]);
+  });
+
+  it('still surfaces JAVA_LS_REQUEST_FAILED on non-terminal analysis outcomes', () => {
+    const notices = buildAnalysisNotices(
+      {
+        findings: [{ patternId: 'X', location: {} } as any],
+        errors: [
+          {
+            message: 'minor warning',
+            code: 'ANALYSIS_WARNING',
+          },
+        ],
+      },
+      {
+        resolutionIssues: [
+          {
+            code: 'JAVA_LS_REQUEST_FAILED',
+            level: 'warn',
+            source: 'java-ls',
+            phase: 'get-classpaths',
+            message: 'Java LS classpath lookup failed.',
+          },
+        ],
+      }
+    );
+
+    assert.deepStrictEqual(notices, [
+      {
+        level: 'warn',
+        message: 'SpotBugs analysis completed with warnings: [ANALYSIS_WARNING] minor warning',
+      },
+      {
+        level: 'warn',
+        code: 'JAVA_LS_REQUEST_FAILED',
+        message:
+          'SpotBugs: Java project metadata lookup failed; analysis continued with fallback behavior.',
+      },
+    ]);
+  });
+
+  it('suppresses JAVA_LS_NO_RESULT on terminal outcomes', () => {
+    const notices = buildAnalysisNotices(
+      {
+        findings: [],
+        failure: {
+          kind: 'target',
+          level: 'warn',
+          code: 'NO_CLASS_TARGETS',
+          message: 'No compiled classes found.',
+        },
+      },
+      {
+        resolutionIssues: [
+          {
+            code: 'JAVA_LS_NO_RESULT',
+            level: 'warn',
+            source: 'java-ls',
+            phase: 'get-classpaths',
+            message: 'Java LS classpath lookup returned no usable result.',
+          },
+          {
+            code: 'OUTPUT_FALLBACK_USED',
+            level: 'info',
+            source: 'target-resolution',
+            phase: 'output-fallback',
+            message:
+              'Output folder fallback was used because Java build output metadata was unavailable.',
+          },
+        ],
+      }
+    );
+
+    assert.deepStrictEqual(notices, [
+      {
+        level: 'warn',
+        code: 'NO_CLASS_TARGETS',
+        message: 'No compiled classes found.',
+      },
+      {
+        level: 'info',
+        code: 'OUTPUT_FALLBACK_USED',
+        message:
+          'SpotBugs: Java build output metadata was unavailable; output folder fallback was used.',
+      },
+    ]);
+    assert.ok(
+      notices.every(
+        (notice) =>
+          notice.message !==
+          'SpotBugs: Java project metadata lookup failed; analysis continued with fallback behavior.'
+      )
+    );
+  });
+
+  it('still surfaces JAVA_LS_NO_RESULT on non-terminal analysis outcomes when behavior changed', () => {
+    const notices = buildAnalysisNotices(
+      {
+        findings: [],
+        targetPath: '/workspace/src/main/java/Foo.java',
+      },
+      {
+        resolutionIssues: [
+          {
+            code: 'JAVA_LS_NO_RESULT',
+            level: 'warn',
+            source: 'java-ls',
+            phase: 'get-classpaths',
+            message: 'Java LS classpath lookup returned no usable result.',
+          },
+          {
+            code: 'OUTPUT_FALLBACK_USED',
+            level: 'info',
+            source: 'target-resolution',
+            phase: 'output-fallback',
+            message:
+              'Output folder fallback was used because Java build output metadata was unavailable.',
+          },
+        ],
+      }
+    );
+
+    assert.deepStrictEqual(notices, [
+      {
+        level: 'warn',
+        code: 'JAVA_LS_NO_RESULT',
+        message:
+          'SpotBugs: Java project metadata lookup failed; analysis continued with fallback behavior.',
+      },
+      {
+        level: 'info',
+        code: 'OUTPUT_FALLBACK_USED',
+        message:
+          'SpotBugs: Java build output metadata was unavailable; output folder fallback was used.',
+      },
+    ]);
+  });
+
+  it('keeps a single failure notice for failure-only outcomes', () => {
+    const notices = buildAnalysisNotices({
+      findings: [],
+      failure: {
+        kind: 'target',
+        level: 'warn',
+        code: 'NO_CLASS_TARGETS',
+        message: 'No compiled classes found.',
+      },
+    });
+
+    assert.deepStrictEqual(notices, [
+      {
+        level: 'warn',
+        code: 'NO_CLASS_TARGETS',
+        message: 'No compiled classes found.',
+      },
+    ]);
+  });
+});

--- a/src/test/analysisService.unit.test.ts
+++ b/src/test/analysisService.unit.test.ts
@@ -1,0 +1,199 @@
+import * as assert from 'assert';
+import { installVscodeMock, resetVscodeMock } from './helpers/mockVscode';
+
+function clearModule(moduleId: string): void {
+  delete require.cache[require.resolve(moduleId)];
+}
+
+describe('analysisService', () => {
+  beforeEach(() => {
+    installVscodeMock();
+    resetVscodeMock();
+    clearModule('../services/analysisService');
+    clearModule('../workspace/analysisTargetResolver');
+    clearModule('../workspace/pathResolver');
+    clearModule('../lsp/spotbugsClient');
+  });
+
+  it('returns resolution issues through analyzeFileDetailed while preserving the public analyzeFile contract', async () => {
+    const vscode = installVscodeMock();
+    const resolverModule =
+      require('../workspace/analysisTargetResolver') as typeof import('../workspace/analysisTargetResolver');
+    const service = require('../services/analysisService') as typeof import('../services/analysisService');
+
+    resolverModule.resolveFileAnalysisTargetDetailed = (async () => ({
+      resolution: {
+        status: 'no-class-targets',
+        errorCode: 'NO_CLASS_TARGETS',
+        message: 'No class targets',
+      },
+      issues: [
+        {
+          code: 'OUTPUT_FALLBACK_USED',
+          level: 'info',
+          source: 'target-resolution',
+          phase: 'output-fallback',
+          message: 'Output folder fallback was used because Java build output metadata was unavailable.',
+        },
+      ],
+    })) as typeof resolverModule.resolveFileAnalysisTargetDetailed;
+
+    const detailed = await service.analyzeFileDetailed(
+      { getAnalysisSettings: () => ({ effort: 'default' }) } as any,
+      vscode.Uri.file('/workspace/src/Foo.java') as any
+    );
+    const publicOutcome = await service.analyzeFile(
+      { getAnalysisSettings: () => ({ effort: 'default' }) } as any,
+      vscode.Uri.file('/workspace/src/Foo.java') as any
+    );
+
+    assert.deepStrictEqual(detailed.context.resolutionIssues.map((issue) => issue.code), [
+      'OUTPUT_FALLBACK_USED',
+    ]);
+    assert.strictEqual(detailed.outcome.failure?.code, 'NO_CLASS_TARGETS');
+    assert.strictEqual(publicOutcome.failure?.code, 'NO_CLASS_TARGETS');
+  });
+
+  it('aggregates per-project resolution issues in analyzeWorkspaceFromProjectsDetailed', async () => {
+    const resolverModule =
+      require('../workspace/analysisTargetResolver') as typeof import('../workspace/analysisTargetResolver');
+    const service = require('../services/analysisService') as typeof import('../services/analysisService');
+
+    resolverModule.resolveProjectAnalysisTargetDetailed = (async (projectUri) => ({
+      resolution: {
+        status: 'no-class-targets',
+        errorCode: 'NO_CLASS_TARGETS',
+        message: `No classes for ${projectUri.toString()}`,
+      },
+      issues: [
+        {
+          code: projectUri.toString().includes('project-a')
+            ? 'JAVA_LS_REQUEST_FAILED'
+            : 'JAVA_LS_EMPTY_RUNTIME_CLASSPATH',
+          level: 'warn',
+          source: 'java-ls',
+          phase: 'get-classpaths',
+          message: 'Resolution issue',
+        },
+      ],
+    })) as typeof resolverModule.resolveProjectAnalysisTargetDetailed;
+
+    const detailed = await service.analyzeWorkspaceFromProjectsDetailed(
+      { getAnalysisSettings: () => ({ effort: 'default' }) } as any,
+      installVscodeMock().Uri.file('/workspace') as any,
+      ['file:///workspace/project-a', 'file:///workspace/project-b']
+    );
+    const legacy = await service.analyzeWorkspaceFromProjects(
+      { getAnalysisSettings: () => ({ effort: 'default' }) } as any,
+      installVscodeMock().Uri.file('/workspace') as any,
+      ['file:///workspace/project-a', 'file:///workspace/project-b']
+    );
+
+    assert.deepStrictEqual(
+      detailed.context.resolutionIssues.map((issue) => issue.code),
+      ['JAVA_LS_REQUEST_FAILED', 'JAVA_LS_EMPTY_RUNTIME_CLASSPATH']
+    );
+    assert.strictEqual(detailed.results.length, 2);
+    assert.strictEqual('context' in (legacy as any), false);
+    assert.strictEqual(legacy.results.length, 2);
+  });
+
+  it('preserves file resolution issues when analysis execution throws after target resolution', async () => {
+    const vscode = installVscodeMock();
+    const resolverModule =
+      require('../workspace/analysisTargetResolver') as typeof import('../workspace/analysisTargetResolver');
+    const spotbugsClient =
+      require('../lsp/spotbugsClient') as typeof import('../lsp/spotbugsClient');
+    const service = require('../services/analysisService') as typeof import('../services/analysisService');
+
+    resolverModule.resolveFileAnalysisTargetDetailed = (async () => ({
+      resolution: {
+        status: 'ok',
+        target: {
+          targetPath: '/workspace/build/classes',
+          preferredProject: vscode.Uri.file('/workspace/src/Foo.java') as any,
+          targetResolutionRoots: ['/workspace/build/classes'],
+          runtimeClasspaths: ['/workspace/build/classes'],
+          sourcepaths: ['/workspace/src/main/java'],
+        },
+      },
+      issues: [
+        {
+          code: 'JAVA_LS_REQUEST_FAILED',
+          level: 'warn',
+          source: 'java-ls',
+          phase: 'get-classpaths',
+          message: 'Java LS classpath lookup failed.',
+        },
+      ],
+    })) as typeof resolverModule.resolveFileAnalysisTargetDetailed;
+    spotbugsClient.runSpotBugsAnalysis = (async () => {
+      throw new Error('analysis boom');
+    }) as typeof spotbugsClient.runSpotBugsAnalysis;
+
+    const result = await service.analyzeFileDetailed(
+      { getAnalysisSettings: () => ({ effort: 'default' }) } as any,
+      vscode.Uri.file('/workspace/src/Foo.java') as any
+    );
+
+    assert.deepStrictEqual(result.context.resolutionIssues.map((issue) => issue.code), [
+      'JAVA_LS_REQUEST_FAILED',
+    ]);
+    assert.deepStrictEqual(result.outcome, { findings: [] });
+  });
+
+  it('preserves workspace/project resolution issues when analysis execution throws after target resolution', async () => {
+    const vscode = installVscodeMock();
+    const resolverModule =
+      require('../workspace/analysisTargetResolver') as typeof import('../workspace/analysisTargetResolver');
+    const spotbugsClient =
+      require('../lsp/spotbugsClient') as typeof import('../lsp/spotbugsClient');
+    const service = require('../services/analysisService') as typeof import('../services/analysisService');
+
+    resolverModule.resolveProjectAnalysisTargetDetailed = (async (projectUri) => ({
+      resolution: {
+        status: 'ok',
+        target: {
+          targetPath: `/workspace/out/${projectUri.toString().split('/').pop()}`,
+          preferredProject: projectUri,
+          targetResolutionRoots: ['/workspace/out'],
+          runtimeClasspaths: ['/workspace/out'],
+          sourcepaths: ['/workspace/src'],
+        },
+      },
+      issues: [
+        {
+          code: projectUri.toString().includes('project-a')
+            ? 'JAVA_LS_REQUEST_FAILED'
+            : 'OUTPUT_FALLBACK_USED',
+          level: projectUri.toString().includes('project-a') ? 'warn' : 'info',
+          source: projectUri.toString().includes('project-a')
+            ? 'java-ls'
+            : 'target-resolution',
+          phase: projectUri.toString().includes('project-a')
+            ? 'get-classpaths'
+            : 'output-fallback',
+          message: 'Resolution issue',
+        },
+      ],
+    })) as typeof resolverModule.resolveProjectAnalysisTargetDetailed;
+    spotbugsClient.runSpotBugsAnalysis = (async () => {
+      throw new Error('analysis boom');
+    }) as typeof spotbugsClient.runSpotBugsAnalysis;
+
+    const result = await service.analyzeWorkspaceFromProjectsDetailed(
+      { getAnalysisSettings: () => ({ effort: 'default' }) } as any,
+      vscode.Uri.file('/workspace') as any,
+      ['file:///workspace/project-a', 'file:///workspace/project-b']
+    );
+
+    assert.deepStrictEqual(
+      result.context.resolutionIssues.map((issue) => issue.code),
+      ['JAVA_LS_REQUEST_FAILED', 'OUTPUT_FALLBACK_USED']
+    );
+    assert.deepStrictEqual(
+      result.results.map((project) => project.error),
+      ['analysis boom', 'analysis boom']
+    );
+  });
+});

--- a/src/test/analysisTargetResolver.unit.test.ts
+++ b/src/test/analysisTargetResolver.unit.test.ts
@@ -1,0 +1,147 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import { installVscodeMock, resetVscodeMock } from './helpers/mockVscode';
+
+describe('analysisTargetResolver', () => {
+  beforeEach(() => {
+    installVscodeMock();
+    resetVscodeMock();
+    delete require.cache[require.resolve('../workspace/analysisTargetResolver')];
+  });
+
+  it('propagates classpath issues and emits OUTPUT_FALLBACK_USED when output fallback succeeds', async () => {
+    const vscode = installVscodeMock();
+    const resolverModule =
+      require('../workspace/analysisTargetResolver') as typeof import('../workspace/analysisTargetResolver');
+    const resolver = resolverModule.createTargetResolver({
+      getClasspathsOutcome: async () => ({
+        status: 'resolved',
+        classpath: {
+          output: undefined,
+          runtimeClasspaths: ['/deps/classes'],
+          targetResolutionRoots: ['/workspace/project/target/classes'],
+          sourcepaths: [],
+        },
+        issues: [
+          {
+            code: 'JAVA_LS_NO_RESULT',
+            level: 'warn',
+            source: 'java-ls',
+            phase: 'get-classpaths',
+            message: 'Java LS classpath lookup returned no usable result.',
+          },
+        ],
+      }),
+      deriveOutputFolder: async () => '/workspace/project/target/classes',
+      findOutputFolderFromProject: async () => undefined,
+      hasClassTargets: async () => true,
+      isBytecodeTarget: () => false,
+      primeSourcepathsCache: () => undefined,
+      getWorkspaceFolder: () =>
+        ({
+          name: 'workspace',
+          index: 0,
+          uri: vscode.Uri.file('/workspace') as any,
+        }) as any,
+      dirname: path.dirname,
+      logger: { log: () => undefined } as any,
+    });
+
+    const result = await resolver.resolveProjectAnalysisTargetDetailed(
+      vscode.Uri.file('/workspace/project') as any,
+      vscode.Uri.file('/workspace') as any
+    );
+
+    assert.strictEqual(result.resolution.status, 'ok');
+    assert.strictEqual(
+      result.resolution.status === 'ok' ? result.resolution.target.targetPath : '',
+      '/workspace/project/target/classes'
+    );
+    assert.deepStrictEqual(
+      result.issues.map((issue) => issue.code),
+      ['JAVA_LS_NO_RESULT', 'OUTPUT_FALLBACK_USED']
+    );
+  });
+
+  it('does not emit OUTPUT_FALLBACK_USED when Java LS output metadata is already present', async () => {
+    const vscode = installVscodeMock();
+    const resolverModule =
+      require('../workspace/analysisTargetResolver') as typeof import('../workspace/analysisTargetResolver');
+    const resolver = resolverModule.createTargetResolver({
+      getClasspathsOutcome: async () => ({
+        status: 'resolved',
+        classpath: {
+          output: '/workspace/project/build/classes',
+          runtimeClasspaths: ['/deps/classes'],
+          targetResolutionRoots: ['/workspace/project/build/classes'],
+          sourcepaths: [],
+        },
+        issues: [],
+      }),
+      deriveOutputFolder: async () => {
+        throw new Error('deriveOutputFolder should not be called');
+      },
+      findOutputFolderFromProject: async () => {
+        throw new Error('findOutputFolderFromProject should not be called');
+      },
+      hasClassTargets: async () => true,
+      isBytecodeTarget: () => false,
+      primeSourcepathsCache: () => undefined,
+      getWorkspaceFolder: () =>
+        ({
+          name: 'workspace',
+          index: 0,
+          uri: vscode.Uri.file('/workspace') as any,
+        }) as any,
+      dirname: path.dirname,
+      logger: { log: () => undefined } as any,
+    });
+
+    const result = await resolver.resolveProjectAnalysisTargetDetailed(
+      vscode.Uri.file('/workspace/project') as any,
+      vscode.Uri.file('/workspace') as any
+    );
+
+    assert.strictEqual(result.resolution.status, 'ok');
+    assert.deepStrictEqual(result.issues, []);
+  });
+
+  it('does not emit OUTPUT_FALLBACK_USED when fallback cannot resolve a usable output folder', async () => {
+    const vscode = installVscodeMock();
+    const resolverModule =
+      require('../workspace/analysisTargetResolver') as typeof import('../workspace/analysisTargetResolver');
+    const resolver = resolverModule.createTargetResolver({
+      getClasspathsOutcome: async () => ({
+        status: 'resolved',
+        classpath: {
+          output: undefined,
+          runtimeClasspaths: ['/deps/classes'],
+          targetResolutionRoots: ['/workspace/project/target/classes'],
+          sourcepaths: [],
+        },
+        issues: [],
+      }),
+      deriveOutputFolder: async () => '/workspace/project/target/classes',
+      findOutputFolderFromProject: async () => undefined,
+      hasClassTargets: async () => false,
+      isBytecodeTarget: () => false,
+      primeSourcepathsCache: () => undefined,
+      getWorkspaceFolder: () =>
+        ({
+          name: 'workspace',
+          index: 0,
+          uri: vscode.Uri.file('/workspace') as any,
+        }) as any,
+      dirname: path.dirname,
+      logger: { log: () => undefined } as any,
+    });
+
+    const result = await resolver.resolveProjectAnalysisTargetDetailed(
+      vscode.Uri.file('/workspace/project') as any,
+      vscode.Uri.file('/workspace') as any
+    );
+
+    assert.strictEqual(result.resolution.status, 'no-class-targets');
+    assert.deepStrictEqual(result.issues, []);
+  });
+});

--- a/src/test/classpathCommandRunner.unit.test.ts
+++ b/src/test/classpathCommandRunner.unit.test.ts
@@ -1,0 +1,221 @@
+import * as assert from 'assert';
+import { installVscodeMock, resetVscodeMock } from './helpers/mockVscode';
+
+function clearModule(moduleId: string): void {
+  delete require.cache[require.resolve(moduleId)];
+}
+
+describe('classpathCommandRunner', () => {
+  beforeEach(() => {
+    installVscodeMock();
+    resetVscodeMock();
+    clearModule('../workspace/classpathCommandRunner');
+    clearModule('../lsp/javaLsGateway');
+    clearModule('../core/utils');
+    clearModule('../core/logger');
+  });
+
+  it('returns the first successful command result without degradation issues', async () => {
+    const gateway = require('../lsp/javaLsGateway') as typeof import('../lsp/javaLsGateway');
+    const utils = require('../core/utils') as typeof import('../core/utils');
+    const runner =
+      require('../workspace/classpathCommandRunner') as typeof import('../workspace/classpathCommandRunner');
+
+    let callCount = 0;
+    gateway.requestJavaClasspaths = (async () => {
+      callCount += 1;
+      return {
+        classpaths: ['/workspace/bin'],
+        sourcepaths: ['/workspace/src/main/java'],
+        output: '/workspace/bin',
+      };
+    }) as typeof gateway.requestJavaClasspaths;
+    utils.getJavaExtension = (async () => undefined) as typeof utils.getJavaExtension;
+
+    const outcome = await runner.runClasspathAttemptsOutcome([
+      { label: 'preferred:file:///workspace/project', arg: 'file:///workspace/project' },
+    ]);
+
+    assert.strictEqual(callCount, 1);
+    assert.strictEqual(outcome.status, 'resolved');
+    assert.deepStrictEqual(outcome.issues, []);
+    assert.deepStrictEqual(
+      outcome.status === 'resolved' ? outcome.classpath.runtimeClasspaths : [],
+      ['/workspace/bin']
+    );
+  });
+
+  it('does not leak earlier command failures when a later command variant succeeds', async () => {
+    const gateway = require('../lsp/javaLsGateway') as typeof import('../lsp/javaLsGateway');
+    const utils = require('../core/utils') as typeof import('../core/utils');
+    const runner =
+      require('../workspace/classpathCommandRunner') as typeof import('../workspace/classpathCommandRunner');
+
+    let callCount = 0;
+    gateway.requestJavaClasspaths = (async () => {
+      callCount += 1;
+      if (callCount === 1) {
+        throw new Error('uri-scope failed');
+      }
+      return {
+        classpaths: ['/workspace/bin'],
+        sourcepaths: [],
+        output: '/workspace/bin',
+      };
+    }) as typeof gateway.requestJavaClasspaths;
+    utils.getJavaExtension = (async () => undefined) as typeof utils.getJavaExtension;
+
+    const outcome = await runner.runClasspathAttemptsOutcome([
+      { label: 'preferred:file:///workspace/project', arg: 'file:///workspace/project' },
+    ]);
+
+    assert.strictEqual(callCount, 2);
+    assert.strictEqual(outcome.status, 'resolved');
+    assert.deepStrictEqual(outcome.issues, []);
+  });
+
+  it('summarizes no-result fallback when the extension API fallback succeeds', async () => {
+    const gateway = require('../lsp/javaLsGateway') as typeof import('../lsp/javaLsGateway');
+    const utils = require('../core/utils') as typeof import('../core/utils');
+    const runner =
+      require('../workspace/classpathCommandRunner') as typeof import('../workspace/classpathCommandRunner');
+
+    gateway.requestJavaClasspaths = (async () => undefined) as typeof gateway.requestJavaClasspaths;
+    utils.getJavaExtension = (async () => ({
+      exports: {
+        getClasspaths: async () => ({
+          classpaths: ['/workspace/bin'],
+          sourcepaths: ['/workspace/src/main/java'],
+          output: '/workspace/bin',
+        }),
+      },
+    })) as typeof utils.getJavaExtension;
+
+    const outcome = await runner.runClasspathAttemptsOutcome([
+      { label: 'preferred:file:///workspace/project', arg: 'file:///workspace/project' },
+    ]);
+
+    assert.strictEqual(outcome.status, 'resolved');
+    assert.deepStrictEqual(
+      outcome.issues.map((issue) => issue.code),
+      ['JAVA_LS_NO_RESULT', 'JAVA_LS_EXTENSION_FALLBACK_USED']
+    );
+  });
+
+  it('collapses mixed command variant failure history into a single no-result summary issue', async () => {
+    const gateway = require('../lsp/javaLsGateway') as typeof import('../lsp/javaLsGateway');
+    const utils = require('../core/utils') as typeof import('../core/utils');
+    const runner =
+      require('../workspace/classpathCommandRunner') as typeof import('../workspace/classpathCommandRunner');
+
+    let callCount = 0;
+    gateway.requestJavaClasspaths = (async () => {
+      callCount += 1;
+      if (callCount === 1) {
+        throw new Error('uri-scope failed');
+      }
+      return undefined;
+    }) as typeof gateway.requestJavaClasspaths;
+    utils.getJavaExtension = (async () => ({
+      exports: {
+        getClasspaths: async () => ({
+          classpaths: ['/workspace/bin'],
+          sourcepaths: ['/workspace/src/main/java'],
+          output: '/workspace/bin',
+        }),
+      },
+    })) as typeof utils.getJavaExtension;
+
+    const outcome = await runner.runClasspathAttemptsOutcome([
+      { label: 'preferred:file:///workspace/project', arg: 'file:///workspace/project' },
+    ]);
+
+    assert.strictEqual(outcome.status, 'resolved');
+    assert.deepStrictEqual(
+      outcome.issues.map((issue) => issue.code),
+      ['JAVA_LS_NO_RESULT', 'JAVA_LS_EXTENSION_FALLBACK_USED']
+    );
+  });
+
+  it('emits an empty runtime classpath issue when metadata resolves without runtime entries', async () => {
+    const gateway = require('../lsp/javaLsGateway') as typeof import('../lsp/javaLsGateway');
+    const utils = require('../core/utils') as typeof import('../core/utils');
+    const runner =
+      require('../workspace/classpathCommandRunner') as typeof import('../workspace/classpathCommandRunner');
+
+    gateway.requestJavaClasspaths = (async () => ({
+      classpaths: [],
+      sourcepaths: [],
+      output: '/workspace/bin',
+    })) as typeof gateway.requestJavaClasspaths;
+    utils.getJavaExtension = (async () => undefined) as typeof utils.getJavaExtension;
+
+    const outcome = await runner.runClasspathAttemptsOutcome([
+      { label: 'preferred:file:///workspace/project', arg: 'file:///workspace/project' },
+    ]);
+
+    assert.strictEqual(outcome.status, 'resolved');
+    assert.deepStrictEqual(
+      outcome.issues.map((issue) => issue.code),
+      ['JAVA_LS_EMPTY_RUNTIME_CLASSPATH']
+    );
+  });
+
+  it('returns an unavailable outcome and preserves the legacy failure log side effect', async () => {
+    const gateway = require('../lsp/javaLsGateway') as typeof import('../lsp/javaLsGateway');
+    const utils = require('../core/utils') as typeof import('../core/utils');
+    const logger = require('../core/logger') as typeof import('../core/logger');
+    const runner =
+      require('../workspace/classpathCommandRunner') as typeof import('../workspace/classpathCommandRunner');
+
+    const logs: string[] = [];
+    gateway.requestJavaClasspaths = (async () => {
+      throw new Error('boom');
+    }) as typeof gateway.requestJavaClasspaths;
+    utils.getJavaExtension = (async () => undefined) as typeof utils.getJavaExtension;
+    logger.Logger.log = ((message: string) => {
+      logs.push(message);
+    }) as typeof logger.Logger.log;
+
+    const outcome = await runner.runClasspathAttemptsOutcome(
+      [{ label: 'no-arg' }],
+      { logFailures: true }
+    );
+
+    assert.strictEqual(outcome.status, 'unavailable');
+    assert.deepStrictEqual(
+      outcome.issues.map((issue) => issue.code),
+      ['JAVA_LS_REQUEST_FAILED']
+    );
+    assert.ok(
+      logs.some((message) => message.includes('getClasspaths failed (no-arg within no-arg): boom'))
+    );
+  });
+
+  it('returns only JAVA_LS_NO_RESULT for mixed unavailable command history', async () => {
+    const gateway = require('../lsp/javaLsGateway') as typeof import('../lsp/javaLsGateway');
+    const utils = require('../core/utils') as typeof import('../core/utils');
+    const runner =
+      require('../workspace/classpathCommandRunner') as typeof import('../workspace/classpathCommandRunner');
+
+    let callCount = 0;
+    gateway.requestJavaClasspaths = (async () => {
+      callCount += 1;
+      if (callCount === 1) {
+        throw new Error('uri-scope failed');
+      }
+      return undefined;
+    }) as typeof gateway.requestJavaClasspaths;
+    utils.getJavaExtension = (async () => undefined) as typeof utils.getJavaExtension;
+
+    const outcome = await runner.runClasspathAttemptsOutcome([
+      { label: 'preferred:file:///workspace/project', arg: 'file:///workspace/project' },
+    ]);
+
+    assert.strictEqual(outcome.status, 'unavailable');
+    assert.deepStrictEqual(
+      outcome.issues.map((issue) => issue.code),
+      ['JAVA_LS_NO_RESULT']
+    );
+  });
+});

--- a/src/test/helpers/mockVscode.ts
+++ b/src/test/helpers/mockVscode.ts
@@ -1,0 +1,151 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+const Module = require('module') as {
+  _load: (...args: unknown[]) => unknown;
+};
+
+type WorkspaceFolder = {
+  name: string;
+  uri: MockUri;
+};
+
+class MockUri {
+  public readonly scheme: string;
+  public readonly fsPath: string;
+  private readonly value: string;
+
+  private constructor(value: string, scheme: string, fsPath: string) {
+    this.value = value;
+    this.scheme = scheme;
+    this.fsPath = fsPath;
+  }
+
+  static parse(value: string): MockUri {
+    const schemeMatch = /^([a-z0-9+.-]+):/i.exec(value);
+    const scheme = schemeMatch?.[1]?.toLowerCase() ?? 'file';
+
+    if (scheme === 'file') {
+      const rawPath = decodeURIComponent(value.replace(/^file:\/\/\/?/, '/'));
+      return new MockUri(value, scheme, rawPath);
+    }
+
+    return new MockUri(value, scheme, value);
+  }
+
+  static file(fsPath: string): MockUri {
+    const portablePath = fsPath.replace(/\\/g, '/');
+    const encodedPath = encodeURI(portablePath.startsWith('/') ? portablePath : `/${portablePath}`);
+    return new MockUri(`file://${encodedPath}`, 'file', fsPath);
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}
+
+type VscodeMock = {
+  Uri: typeof MockUri;
+  workspace: {
+    workspaceFolders: WorkspaceFolder[];
+    getWorkspaceFolder: (uri: MockUri) => WorkspaceFolder | undefined;
+    fs: {
+      stat: (uri: MockUri) => Promise<unknown>;
+    };
+  };
+  window: {
+    createOutputChannel: (name: string) => { appendLine: (value: string) => void; show: () => void };
+    activeTextEditor?: { document: { uri: MockUri } };
+    withProgress: <T>(
+      options: unknown,
+      task: (
+        progress: { report: (value: unknown) => void },
+        token: { isCancellationRequested: boolean }
+      ) => Promise<T>
+    ) => Promise<T>;
+  };
+  commands: {
+    executeCommand: (...args: unknown[]) => Promise<unknown>;
+    getCommands: (filterInternal?: boolean) => Promise<string[]>;
+  };
+  extensions: {
+    getExtension: (id: string) => unknown;
+  };
+  ProgressLocation: {
+    Notification: number;
+  };
+};
+
+const originalLoad = Module._load;
+let installed = false;
+let currentMock = createVscodeMock();
+
+export function installVscodeMock(overrides: Partial<VscodeMock> = {}): VscodeMock {
+  currentMock = createVscodeMock(overrides);
+
+  if (!installed) {
+    Module._load = function patchedLoad(request: unknown, parent: unknown, isMain: unknown) {
+      if (request === 'vscode') {
+        return currentMock;
+      }
+      return originalLoad.call(this, request, parent, isMain);
+    };
+    installed = true;
+  }
+
+  return currentMock;
+}
+
+export function resetVscodeMock(overrides: Partial<VscodeMock> = {}): VscodeMock {
+  currentMock = createVscodeMock(overrides);
+  return currentMock;
+}
+
+function createVscodeMock(overrides: Partial<VscodeMock> = {}): VscodeMock {
+  const workspaceFolders = overrides.workspace?.workspaceFolders ?? [];
+  const workspace = {
+    workspaceFolders,
+    getWorkspaceFolder:
+      overrides.workspace?.getWorkspaceFolder ??
+      ((uri: MockUri) =>
+        workspaceFolders.find((folder) => uri.fsPath.startsWith(folder.uri.fsPath))),
+    fs: {
+      stat: overrides.workspace?.fs?.stat ?? (async () => ({})),
+    },
+  };
+
+  const window = {
+    createOutputChannel:
+      overrides.window?.createOutputChannel ??
+      (() => ({
+        appendLine: () => undefined,
+        show: () => undefined,
+      })),
+    activeTextEditor: overrides.window?.activeTextEditor,
+    withProgress:
+      overrides.window?.withProgress ??
+      (async (_options, task) =>
+        task(
+          {
+            report: () => undefined,
+          },
+          {
+            isCancellationRequested: false,
+          }
+        )),
+  };
+
+  return {
+    Uri: MockUri,
+    workspace,
+    window,
+    commands: {
+      executeCommand: overrides.commands?.executeCommand ?? (async () => undefined),
+      getCommands: overrides.commands?.getCommands ?? (async () => []),
+    },
+    extensions: {
+      getExtension: overrides.extensions?.getExtension ?? (() => undefined),
+    },
+    ProgressLocation: overrides.ProgressLocation ?? {
+      Notification: 15,
+    },
+  };
+}

--- a/src/test/javaLsClient.unit.test.ts
+++ b/src/test/javaLsClient.unit.test.ts
@@ -1,0 +1,114 @@
+import * as assert from 'assert';
+import { installVscodeMock, resetVscodeMock } from './helpers/mockVscode';
+
+function clearModule(moduleId: string): void {
+  delete require.cache[require.resolve(moduleId)];
+}
+
+describe('javaLsClient', () => {
+  beforeEach(() => {
+    installVscodeMock();
+    resetVscodeMock();
+    clearModule('../services/javaLsClient');
+    clearModule('../lsp/javaLsGateway');
+    clearModule('../services/workspaceBuildService');
+  });
+
+  it('returns unavailable with JAVA_LS_REQUEST_FAILED when project discovery throws', async () => {
+    const gateway = require('../lsp/javaLsGateway') as typeof import('../lsp/javaLsGateway');
+    const client = require('../services/javaLsClient') as typeof import('../services/javaLsClient');
+
+    gateway.requestAllJavaProjects = (async () => {
+      throw new Error('request failed');
+    }) as typeof gateway.requestAllJavaProjects;
+
+    const outcome = await client.JavaLsClient.getAllProjectsOutcome();
+
+    assert.deepStrictEqual(outcome, {
+      status: 'unavailable',
+      projectUris: [],
+      issues: [
+        {
+          code: 'JAVA_LS_REQUEST_FAILED',
+          level: 'warn',
+          source: 'java-ls',
+          phase: 'get-all-projects',
+          message: 'Java LS project discovery request failed.',
+          cause: 'request failed',
+        },
+      ],
+    });
+    assert.deepStrictEqual(await client.JavaLsClient.getAllProjects(), []);
+  });
+
+  it('treats undefined responses as unavailable with JAVA_LS_NO_RESULT', async () => {
+    const gateway = require('../lsp/javaLsGateway') as typeof import('../lsp/javaLsGateway');
+    const client = require('../services/javaLsClient') as typeof import('../services/javaLsClient');
+
+    gateway.requestAllJavaProjects = (async () => undefined) as typeof gateway.requestAllJavaProjects;
+
+    const outcome = await client.JavaLsClient.getAllProjectsOutcome();
+
+    assert.deepStrictEqual(outcome, {
+      status: 'unavailable',
+      projectUris: [],
+      issues: [
+        {
+          code: 'JAVA_LS_NO_RESULT',
+          level: 'warn',
+          source: 'java-ls',
+          phase: 'get-all-projects',
+          message: 'Java LS project discovery returned no usable result.',
+        },
+      ],
+    });
+  });
+
+  it('returns empty only when normalized projects are empty after pseudo-project filtering', async () => {
+    const gateway = require('../lsp/javaLsGateway') as typeof import('../lsp/javaLsGateway');
+    const client = require('../services/javaLsClient') as typeof import('../services/javaLsClient');
+
+    gateway.requestAllJavaProjects = (async () => [
+      'file:///tmp/jdt.ls-java-project',
+    ]) as typeof gateway.requestAllJavaProjects;
+
+    const outcome = await client.JavaLsClient.getAllProjectsOutcome();
+
+    assert.deepStrictEqual(outcome, {
+      status: 'empty',
+      projectUris: [],
+      issues: [
+        {
+          code: 'JAVA_LS_EMPTY_PROJECT_LIST',
+          level: 'info',
+          source: 'project-discovery',
+          phase: 'get-all-projects',
+          message: 'Java LS reported no Java projects.',
+        },
+      ],
+    });
+  });
+
+  it('returns resolved project URIs after filtering pseudo-project entries', async () => {
+    const gateway = require('../lsp/javaLsGateway') as typeof import('../lsp/javaLsGateway');
+    const client = require('../services/javaLsClient') as typeof import('../services/javaLsClient');
+
+    gateway.requestAllJavaProjects = (async () => [
+      'file:///workspace/project-a',
+      'file:///workspace/jdt.ls-java-project',
+      'file:///workspace/project-b',
+    ]) as typeof gateway.requestAllJavaProjects;
+
+    const outcome = await client.JavaLsClient.getAllProjectsOutcome();
+
+    assert.deepStrictEqual(outcome, {
+      status: 'resolved',
+      projectUris: ['file:///workspace/project-a', 'file:///workspace/project-b'],
+      issues: [],
+    });
+    assert.deepStrictEqual(await client.JavaLsClient.getAllProjects(), [
+      'file:///workspace/project-a',
+      'file:///workspace/project-b',
+    ]);
+  });
+});

--- a/src/test/projectDiscovery.unit.test.ts
+++ b/src/test/projectDiscovery.unit.test.ts
@@ -1,0 +1,120 @@
+import * as assert from 'assert';
+import { installVscodeMock, resetVscodeMock } from './helpers/mockVscode';
+
+function clearModule(moduleId: string): void {
+  delete require.cache[require.resolve(moduleId)];
+}
+
+describe('projectDiscovery', () => {
+  beforeEach(() => {
+    installVscodeMock();
+    resetVscodeMock();
+    clearModule('../workspace/projectDiscovery');
+    clearModule('../services/javaLsClient');
+    clearModule('../core/logger');
+  });
+
+  it('returns resolved project discovery without fallback issues', async () => {
+    const vscode = installVscodeMock();
+    const discovery =
+      require('../workspace/projectDiscovery') as typeof import('../workspace/projectDiscovery');
+    const client = require('../services/javaLsClient') as typeof import('../services/javaLsClient');
+
+    client.JavaLsClient.getAllProjectsOutcome = (async () => ({
+      status: 'resolved',
+      projectUris: ['file:///workspace/project-a'],
+      issues: [],
+    })) as typeof client.JavaLsClient.getAllProjectsOutcome;
+
+    const result = await discovery.getWorkspaceProjectDiscovery(
+      vscode.Uri.file('/workspace') as any
+    );
+
+    assert.deepStrictEqual(result, {
+      projectUris: ['file:///workspace/project-a'],
+      issues: [],
+    });
+  });
+
+  it('falls back to the workspace folder and appends WORKSPACE_FALLBACK_USED when discovery is unavailable', async () => {
+    const vscode = installVscodeMock();
+    const discovery =
+      require('../workspace/projectDiscovery') as typeof import('../workspace/projectDiscovery');
+    const client = require('../services/javaLsClient') as typeof import('../services/javaLsClient');
+
+    client.JavaLsClient.getAllProjectsOutcome = (async () => ({
+      status: 'unavailable',
+      projectUris: [],
+      issues: [
+        {
+          code: 'JAVA_LS_REQUEST_FAILED',
+          level: 'warn',
+          source: 'java-ls',
+          phase: 'get-all-projects',
+          message: 'Java LS project discovery request failed.',
+        },
+      ],
+    })) as typeof client.JavaLsClient.getAllProjectsOutcome;
+
+    const result = await discovery.getWorkspaceProjectDiscovery(
+      vscode.Uri.file('/workspace') as any
+    );
+
+    assert.deepStrictEqual(result, {
+      projectUris: ['file:///workspace'],
+      issues: [
+        {
+          code: 'JAVA_LS_REQUEST_FAILED',
+          level: 'warn',
+          source: 'java-ls',
+          phase: 'get-all-projects',
+          message: 'Java LS project discovery request failed.',
+        },
+        {
+          code: 'WORKSPACE_FALLBACK_USED',
+          level: 'info',
+          source: 'project-discovery',
+          phase: 'workspace-fallback',
+          message: 'Workspace-folder fallback was used for project discovery.',
+        },
+      ],
+    });
+  });
+
+  it('preserves the legacy fallback log when the wrapper falls back after an empty result', async () => {
+    const vscode = installVscodeMock();
+    const discovery =
+      require('../workspace/projectDiscovery') as typeof import('../workspace/projectDiscovery');
+    const client = require('../services/javaLsClient') as typeof import('../services/javaLsClient');
+    const logger = require('../core/logger') as typeof import('../core/logger');
+
+    const logs: string[] = [];
+    client.JavaLsClient.getAllProjectsOutcome = (async () => ({
+      status: 'empty',
+      projectUris: [],
+      issues: [
+        {
+          code: 'JAVA_LS_EMPTY_PROJECT_LIST',
+          level: 'info',
+          source: 'project-discovery',
+          phase: 'get-all-projects',
+          message: 'Java LS reported no Java projects.',
+        },
+      ],
+    })) as typeof client.JavaLsClient.getAllProjectsOutcome;
+    logger.Logger.log = ((message: string) => {
+      logs.push(message);
+    }) as typeof logger.Logger.log;
+
+    const projectUris = await discovery.getWorkspaceProjectUris(
+      vscode.Uri.file('/workspace') as any
+    );
+
+    assert.deepStrictEqual(projectUris, ['file:///workspace']);
+    assert.ok(
+      logs.some((message) =>
+        message.includes('No Java projects from LS; falling back to workspace folder analysis.')
+      )
+    );
+  });
+});

--- a/src/test/workspaceSummary.unit.test.ts
+++ b/src/test/workspaceSummary.unit.test.ts
@@ -86,6 +86,40 @@ describe('workspaceSummary', () => {
     ]);
   });
 
+  it('suppresses degraded-success Java LS notices for terminal workspace failures', () => {
+    const notices = buildWorkspaceCompletionNotices(
+      [
+        makeProjectResult({ error: 'bad aux classpath', errorCode: 'CFG_AUX_CLASSPATH_NOT_FOUND' }),
+        makeProjectResult({ error: 'build failed', errorCode: NO_CLASS_TARGETS_CODE }),
+      ],
+      0,
+      [
+        {
+          code: 'JAVA_LS_REQUEST_FAILED',
+          level: 'warn',
+          source: 'java-ls',
+          phase: 'get-classpaths',
+          message: 'Java LS classpath lookup failed.',
+        },
+        {
+          code: 'JAVA_LS_NO_RESULT',
+          level: 'warn',
+          source: 'java-ls',
+          phase: 'get-classpaths',
+          message: 'Java LS classpath lookup returned no usable result.',
+        },
+      ]
+    );
+
+    assert.deepStrictEqual(notices, [
+      {
+        level: 'error',
+        message:
+          'SpotBugs: Workspace analysis failed - 1 project failed. 1 project skipped because the build failed. See the SpotBugs view for project errors.',
+      },
+    ]);
+  });
+
   it('returns the clean success summary when nothing failed and no findings were produced', () => {
     const notices = buildWorkspaceCompletionNotices([makeProjectResult()], 0);
 
@@ -93,6 +127,103 @@ describe('workspaceSummary', () => {
       {
         level: 'info',
         message: 'SpotBugs: Workspace analysis completed - No issues found.',
+      },
+    ]);
+  });
+
+  it('appends translated resolution notices while suppressing generic workspace fallback notices', () => {
+    const notices = buildWorkspaceCompletionNotices([makeProjectResult()], 0, [
+      {
+        code: 'JAVA_LS_EMPTY_PROJECT_LIST',
+        level: 'info',
+        source: 'project-discovery',
+        phase: 'get-all-projects',
+        message: 'Java LS reported no Java projects.',
+      },
+      {
+        code: 'WORKSPACE_FALLBACK_USED',
+        level: 'info',
+        source: 'project-discovery',
+        phase: 'workspace-fallback',
+        message: 'Workspace-folder fallback was used for project discovery.',
+      },
+    ]);
+
+    assert.deepStrictEqual(notices, [
+      {
+        level: 'info',
+        message: 'SpotBugs: Workspace analysis completed - No issues found.',
+      },
+      {
+        level: 'info',
+        code: 'JAVA_LS_EMPTY_PROJECT_LIST',
+        message:
+          'SpotBugs: No Java projects were reported by the Java Language Server; workspace-folder analysis was used.',
+      },
+    ]);
+  });
+
+  it('keeps degraded-success Java LS notices for non-terminal workspace outcomes', () => {
+    const notices = buildWorkspaceCompletionNotices(
+      [
+        makeProjectResult({ findings: [{ patternId: 'X', location: {} }] }),
+        makeProjectResult({ error: 'bad aux classpath', errorCode: 'CFG_AUX_CLASSPATH_NOT_FOUND' }),
+      ],
+      1,
+      [
+        {
+          code: 'JAVA_LS_REQUEST_FAILED',
+          level: 'warn',
+          source: 'java-ls',
+          phase: 'get-classpaths',
+          message: 'Java LS classpath lookup failed.',
+        },
+      ]
+    );
+
+    assert.deepStrictEqual(notices, [
+      {
+        level: 'warn',
+        message:
+          'SpotBugs: Workspace analysis completed with failures - 1 project failed. 1 issue found in successful projects.',
+      },
+      {
+        level: 'warn',
+        code: 'JAVA_LS_REQUEST_FAILED',
+        message:
+          'SpotBugs: Java project metadata lookup failed; analysis continued with fallback behavior.',
+      },
+    ]);
+  });
+
+  it('dedupes repeated translated resolution notices in the final workspace summary', () => {
+    const notices = buildWorkspaceCompletionNotices([makeProjectResult()], 0, [
+      {
+        code: 'OUTPUT_FALLBACK_USED',
+        level: 'info',
+        source: 'target-resolution',
+        phase: 'output-fallback',
+        message: 'Output folder fallback was used because Java build output metadata was unavailable.',
+      },
+      {
+        code: 'OUTPUT_FALLBACK_USED',
+        level: 'info',
+        source: 'target-resolution',
+        phase: 'output-fallback',
+        message: 'Output folder fallback was used because Java build output metadata was unavailable.',
+      },
+    ]);
+
+    assert.deepStrictEqual(notices, [
+      {
+        level: 'info',
+        message: 'SpotBugs: Workspace analysis completed - No issues found.',
+      },
+      {
+        level: 'info',
+        code: 'OUTPUT_FALLBACK_USED',
+        message:
+          'SpotBugs: Java build output metadata was unavailable; output folder fallback was used.',
       },
     ]);
   });

--- a/src/workspace/analysisTargetResolver.ts
+++ b/src/workspace/analysisTargetResolver.ts
@@ -1,7 +1,11 @@
 import { Uri, workspace } from 'vscode';
 import * as path from 'path';
 import { Logger } from '../core/logger';
-import { deriveOutputFolder, getClasspaths } from './classpathService';
+import type { AnalysisResolutionIssue } from '../lsp/javaLsOutcome';
+import {
+  deriveOutputFolder,
+  getClasspathsOutcome,
+} from './classpathService';
 import { primeSourcepathsCache } from './pathResolver';
 import { NO_CLASS_TARGETS_CODE, NO_CLASS_TARGETS_MESSAGE } from './analysisTargetCodes';
 import {
@@ -31,8 +35,13 @@ export interface TargetResolutionFailure {
 
 export type TargetResolution = TargetResolutionOk | TargetResolutionFailure;
 
+export interface TargetResolutionResult {
+  resolution: TargetResolution;
+  issues: AnalysisResolutionIssue[];
+}
+
 export interface TargetResolverDeps {
-  getClasspaths: typeof getClasspaths;
+  getClasspathsOutcome: typeof getClasspathsOutcome;
   deriveOutputFolder: typeof deriveOutputFolder;
   findOutputFolderFromProject: typeof findOutputFolderFromProject;
   hasClassTargets: typeof hasClassTargets;
@@ -44,7 +53,7 @@ export interface TargetResolverDeps {
 }
 
 const defaultDeps: TargetResolverDeps = {
-  getClasspaths,
+  getClasspathsOutcome,
   deriveOutputFolder,
   findOutputFolderFromProject,
   hasClassTargets,
@@ -63,6 +72,12 @@ export function createTargetResolver(overrides: Partial<TargetResolverDeps> = {}
     runtimeClasspaths?: string[];
     sourcepaths?: string[];
     outputPath?: string;
+    issues: AnalysisResolutionIssue[];
+  };
+
+  type OutputResolution = {
+    outputPath?: string;
+    usedFallback: boolean;
   };
 
   function noClassTargets(logMessage?: string): TargetResolutionFailure {
@@ -84,9 +99,15 @@ export function createTargetResolver(overrides: Partial<TargetResolverDeps> = {}
     let runtimeClasspaths: string[] | undefined;
     let sourcepaths: string[] | undefined;
     let outputPath: string | undefined;
+    let issues: AnalysisResolutionIssue[] = [];
 
     try {
-      const cp = await deps.getClasspaths(project, { logFailures: options.logFailure });
+      const outcome = await deps.getClasspathsOutcome(project, {
+        logFailures: options.logFailure,
+      });
+      issues = outcome.issues;
+      const cp = outcome.status === 'resolved' ? outcome.classpath : undefined;
+
       if (cp && Array.isArray(cp.runtimeClasspaths) && cp.runtimeClasspaths.length > 0) {
         runtimeClasspaths = cp.runtimeClasspaths;
         if (options.logSuccess) {
@@ -116,7 +137,7 @@ export function createTargetResolver(overrides: Partial<TargetResolverDeps> = {}
       }
     }
 
-    return { targetResolutionRoots, runtimeClasspaths, sourcepaths, outputPath };
+    return { targetResolutionRoots, runtimeClasspaths, sourcepaths, outputPath, issues };
   }
 
   async function resolveOutputPath(
@@ -124,107 +145,180 @@ export function createTargetResolver(overrides: Partial<TargetResolverDeps> = {}
     outputPath: string | undefined,
     classpathsRoot: string,
     projectRoot: string
-  ): Promise<string | undefined> {
+  ): Promise<OutputResolution> {
     let resolved = outputPath;
+    let usedFallback = false;
+
     if (!resolved && Array.isArray(targetResolutionRoots)) {
       resolved = await deps.deriveOutputFolder(targetResolutionRoots, classpathsRoot);
+      usedFallback = !!resolved;
     }
+
     if (!resolved) {
       resolved = await deps.findOutputFolderFromProject(projectRoot);
+      usedFallback = !!resolved;
     }
-    return resolved;
+
+    return {
+      outputPath: resolved,
+      usedFallback,
+    };
   }
 
-  async function resolveFileAnalysisTarget(uri: Uri): Promise<TargetResolution> {
-    const { targetResolutionRoots, runtimeClasspaths, sourcepaths, outputPath } =
+  async function resolveFileAnalysisTargetDetailed(
+    uri: Uri
+  ): Promise<TargetResolutionResult> {
+    const { targetResolutionRoots, runtimeClasspaths, sourcepaths, outputPath, issues } =
       await readClasspaths(uri, {
       logSuccess: true,
       logEmpty: true,
       logFailure: true,
-      });
+    });
+    const resolutionIssues = [...issues];
 
     const targetPath = uri.fsPath;
     if (!deps.isBytecodeTarget(targetPath)) {
       const workspaceFolder = deps.getWorkspaceFolder(uri);
       const workspacePath = workspaceFolder?.uri.fsPath ?? deps.dirname(targetPath);
-      const resolvedOutput = await resolveOutputPath(
+      const outputResolution = await resolveOutputPath(
         targetResolutionRoots,
         outputPath,
         workspacePath,
         workspacePath
       );
-      if (!resolvedOutput || !(await deps.hasClassTargets(resolvedOutput))) {
-        return noClassTargets(
+      if (
+        !outputResolution.outputPath ||
+        !(await deps.hasClassTargets(outputResolution.outputPath))
+      ) {
+        return {
+          resolution: noClassTargets(
           `Skipping SpotBugs analysis for ${targetPath}: no compiled classes found.`
-        );
+          ),
+          issues: resolutionIssues,
+        };
+      }
+
+      if (outputResolution.usedFallback) {
+        resolutionIssues.push(createOutputFallbackIssue());
       }
     } else if (!(await deps.hasClassTargets(targetPath))) {
-      return noClassTargets(
-        `Skipping SpotBugs analysis for ${targetPath}: target does not exist.`
-      );
+      return {
+        resolution: noClassTargets(
+          `Skipping SpotBugs analysis for ${targetPath}: target does not exist.`
+        ),
+        issues: resolutionIssues,
+      };
     }
 
     return {
-      status: 'ok',
-      target: {
-        targetPath,
-        preferredProject: uri,
-        targetResolutionRoots,
-        runtimeClasspaths,
-        sourcepaths,
+      resolution: {
+        status: 'ok',
+        target: {
+          targetPath,
+          preferredProject: uri,
+          targetResolutionRoots,
+          runtimeClasspaths,
+          sourcepaths,
+        },
       },
+      issues: resolutionIssues,
     };
+  }
+
+  async function resolveProjectAnalysisTargetDetailed(
+    projectUri: Uri,
+    workspaceFolder: Uri
+  ): Promise<TargetResolutionResult> {
+    const projectUriString = projectUri.toString();
+    const { targetResolutionRoots, runtimeClasspaths, sourcepaths, outputPath, issues } =
+      await readClasspaths(projectUri, {
+        logEmpty: true,
+        logFailure: true,
+      });
+    const resolutionIssues = [...issues];
+    const projectRoot =
+      projectUri.scheme === 'file' ? projectUri.fsPath : workspaceFolder.fsPath;
+    const outputResolution = await resolveOutputPath(
+      targetResolutionRoots,
+      outputPath,
+      workspaceFolder.fsPath,
+      projectRoot
+    );
+    if (!outputResolution.outputPath) {
+      return {
+        resolution: noClassTargets(
+          `Skipping SpotBugs analysis for ${projectUriString}: no output folder.`
+        ),
+        issues: resolutionIssues,
+      };
+    }
+
+    if (!(await deps.hasClassTargets(outputResolution.outputPath))) {
+      return {
+        resolution: noClassTargets(
+          `Skipping SpotBugs analysis for ${projectUriString}: no compiled classes in ${outputResolution.outputPath}`
+        ),
+        issues: resolutionIssues,
+      };
+    }
+
+    if (outputResolution.usedFallback) {
+      resolutionIssues.push(createOutputFallbackIssue());
+    }
+
+    return {
+      resolution: {
+        status: 'ok',
+        target: {
+          targetPath: outputResolution.outputPath,
+          preferredProject: projectUri,
+          targetResolutionRoots,
+          runtimeClasspaths,
+          sourcepaths,
+        },
+      },
+      issues: resolutionIssues,
+    };
+  }
+
+  async function resolveFileAnalysisTarget(uri: Uri): Promise<TargetResolution> {
+    const result = await resolveFileAnalysisTargetDetailed(uri);
+    return result.resolution;
   }
 
   async function resolveProjectAnalysisTarget(
     projectUri: Uri,
     workspaceFolder: Uri
   ): Promise<TargetResolution> {
-    const projectUriString = projectUri.toString();
-    const { targetResolutionRoots, runtimeClasspaths, sourcepaths, outputPath } =
-      await readClasspaths(projectUri, {
-        logEmpty: true,
-        logFailure: true,
-      });
-    const projectRoot =
-      projectUri.scheme === 'file' ? projectUri.fsPath : workspaceFolder.fsPath;
-    const resolvedOutput = await resolveOutputPath(
-      targetResolutionRoots,
-      outputPath,
-      workspaceFolder.fsPath,
-      projectRoot
-    );
-    if (!resolvedOutput) {
-      return noClassTargets(
-        `Skipping SpotBugs analysis for ${projectUriString}: no output folder.`
-      );
-    }
-
-    if (!(await deps.hasClassTargets(resolvedOutput))) {
-      return noClassTargets(
-        `Skipping SpotBugs analysis for ${projectUriString}: no compiled classes in ${resolvedOutput}`
-      );
-    }
-
-    return {
-      status: 'ok',
-      target: {
-        targetPath: resolvedOutput,
-        preferredProject: projectUri,
-        targetResolutionRoots,
-        runtimeClasspaths,
-        sourcepaths,
-      },
-    };
+    const result = await resolveProjectAnalysisTargetDetailed(projectUri, workspaceFolder);
+    return result.resolution;
   }
 
-  return { resolveFileAnalysisTarget, resolveProjectAnalysisTarget };
+  return {
+    resolveFileAnalysisTarget,
+    resolveFileAnalysisTargetDetailed,
+    resolveProjectAnalysisTarget,
+    resolveProjectAnalysisTargetDetailed,
+  };
 }
 
 const defaultResolver = createTargetResolver();
 
+export async function resolveFileAnalysisTargetDetailed(
+  uri: Uri
+): Promise<TargetResolutionResult> {
+  return defaultResolver.resolveFileAnalysisTargetDetailed(uri);
+}
+
 export async function resolveFileAnalysisTarget(uri: Uri): Promise<TargetResolution> {
   return defaultResolver.resolveFileAnalysisTarget(uri);
+}
+
+export async function resolveProjectAnalysisTargetDetailed(
+  projectUri: Uri,
+  workspaceFolder: Uri
+): Promise<TargetResolutionResult> {
+  return defaultResolver.resolveProjectAnalysisTargetDetailed(projectUri, workspaceFolder);
 }
 
 export async function resolveProjectAnalysisTarget(
@@ -232,4 +326,14 @@ export async function resolveProjectAnalysisTarget(
   workspaceFolder: Uri
 ): Promise<TargetResolution> {
   return defaultResolver.resolveProjectAnalysisTarget(projectUri, workspaceFolder);
+}
+
+function createOutputFallbackIssue(): AnalysisResolutionIssue {
+  return {
+    code: 'OUTPUT_FALLBACK_USED',
+    level: 'info',
+    source: 'target-resolution',
+    phase: 'output-fallback',
+    message: 'Output folder fallback was used because Java build output metadata was unavailable.',
+  };
 }

--- a/src/workspace/classpathCommandRunner.ts
+++ b/src/workspace/classpathCommandRunner.ts
@@ -5,17 +5,37 @@ import {
   JavaLsClasspathResponse,
   requestJavaClasspaths,
 } from '../lsp/javaLsGateway';
+import type {
+  AnalysisResolutionIssue,
+  ClasspathLookupOutcome,
+} from '../lsp/javaLsOutcome';
 import { ClasspathAttempt } from './classpathAttemptSelector';
 import { deriveTargetResolutionRoots } from './classpathLayout';
-import {
-  ClasspathLookupOptions,
-  ClasspathResult,
-} from './classpathService';
+import { ClasspathLookupOptions } from './classpathService';
+import type { ClasspathResult } from './classpathTypes';
+
+type AttemptSummary = {
+  invocationCount: number;
+  requestFailureCount: number;
+  noResultCount: number;
+};
+
+type CommandResult = AttemptSummary & {
+  response?: JavaLsClasspathResponse;
+};
 
 export async function runClasspathAttempts(
   attempts: ClasspathAttempt[],
   opts?: ClasspathLookupOptions
 ): Promise<ClasspathResult | undefined> {
+  const outcome = await runClasspathAttemptsOutcome(attempts, opts);
+  return outcome.status === 'resolved' ? outcome.classpath : undefined;
+}
+
+export async function runClasspathAttemptsOutcome(
+  attempts: ClasspathAttempt[],
+  opts?: ClasspathLookupOptions
+): Promise<ClasspathLookupOutcome> {
   const verbose = opts?.verbose ?? envVerbose();
   const logFailures = opts?.logFailures === true;
 
@@ -25,20 +45,45 @@ export async function runClasspathAttempts(
   const recordFailure = (context: string, message: string): void => {
     lastFailure = { context, message };
   };
+  const summary: AttemptSummary = {
+    invocationCount: 0,
+    requestFailureCount: 0,
+    noResultCount: 0,
+  };
 
   for (const attempt of attempts) {
     const param = normalizeAttemptParam(attempt.arg);
-
-    let res = await tryCommandVariants(param, attempt.label, verbose, recordFailure);
+    const commandResult = await tryCommandVariants(
+      param,
+      attempt.label,
+      verbose,
+      recordFailure
+    );
+    mergeAttemptSummary(summary, commandResult);
+    let res = commandResult.response;
+    let usedExtensionFallback = false;
 
     if (!res && api && typeof api.getClasspaths === 'function' && param) {
-      res = await tryExtensionFallback(api, param, attempt.label, verbose, recordFailure);
+      const fallbackResult = await tryExtensionFallback(
+        api,
+        param,
+        attempt.label,
+        verbose,
+        recordFailure
+      );
+      mergeAttemptSummary(summary, fallbackResult);
+      res = fallbackResult.response;
+      usedExtensionFallback = !!res;
     }
 
     if (res) {
       const result = normalizeClasspathResult(res);
       logSuccess(attempt.label, result);
-      return result;
+      return {
+        status: 'resolved',
+        classpath: result,
+        issues: buildResolvedIssues(result, summary, usedExtensionFallback, lastFailure),
+      };
     }
   }
 
@@ -54,7 +99,10 @@ export async function runClasspathAttempts(
     }
   }
 
-  return undefined;
+  return {
+    status: 'unavailable',
+    issues: buildUnavailableIssues(summary, lastFailure),
+  };
 }
 
 function normalizeAttemptParam(arg: unknown): unknown {
@@ -73,7 +121,13 @@ async function tryCommandVariants(
   label: string,
   verbose: boolean,
   recordFailure: (context: string, message: string) => void
-): Promise<JavaLsClasspathResponse | undefined> {
+): Promise<CommandResult> {
+  const summary: AttemptSummary = {
+    invocationCount: 0,
+    requestFailureCount: 0,
+    noResultCount: 0,
+  };
+
   if (param !== undefined) {
     const variants: Array<{ args: unknown[]; failureContext: string }> = [
       {
@@ -86,23 +140,37 @@ async function tryCommandVariants(
     ];
 
     for (const variant of variants) {
-      const res = await executeClasspathCommand(
+      const result = await executeClasspathCommand(
         variant.args,
         variant.failureContext,
         verbose,
         recordFailure
       );
-      if (res) {
-        return res;
+      mergeAttemptSummary(summary, result);
+      if (result.response) {
+        return {
+          ...summary,
+          response: result.response,
+        };
       }
     }
   }
 
   if (param === undefined) {
-    return executeClasspathCommand([], `no-arg within ${label}`, verbose, recordFailure);
+    const result = await executeClasspathCommand(
+      [],
+      `no-arg within ${label}`,
+      verbose,
+      recordFailure
+    );
+    mergeAttemptSummary(summary, result);
+    return {
+      ...summary,
+      response: result.response,
+    };
   }
 
-  return undefined;
+  return summary;
 }
 
 async function executeClasspathCommand(
@@ -110,14 +178,31 @@ async function executeClasspathCommand(
   failureContext: string,
   verbose: boolean,
   recordFailure: (context: string, message: string) => void
-): Promise<JavaLsClasspathResponse | undefined> {
+): Promise<CommandResult> {
   try {
-    return await requestJavaClasspaths(...args);
+    const response = await requestJavaClasspaths(...args);
+    if (response !== undefined && response !== null) {
+      return {
+        invocationCount: 1,
+        requestFailureCount: 0,
+        noResultCount: 0,
+        response,
+      };
+    }
+    return {
+      invocationCount: 1,
+      requestFailureCount: 0,
+      noResultCount: 1,
+    };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     recordFailure(failureContext, message);
     if (verbose) Logger.log(`getClasspaths(${failureContext}) failed: ${message}`);
-    return undefined;
+    return {
+      invocationCount: 1,
+      requestFailureCount: 1,
+      noResultCount: 0,
+    };
   }
 }
 
@@ -127,25 +212,39 @@ async function tryExtensionFallback(
   label: string,
   verbose: boolean,
   recordFailure: (context: string, message: string) => void
-): Promise<JavaLsClasspathResponse | undefined> {
+): Promise<CommandResult> {
   try {
     const cpRes = await api.getClasspaths(param, { scope: 'runtime' });
     if (cpRes) {
       if (verbose) Logger.log(`Using extension API getClasspaths for ${label}`);
       return {
-        classpaths: cpRes.classpaths,
-        sourcepaths: cpRes.sourcepaths ?? [],
-        output: cpRes.output,
+        invocationCount: 1,
+        requestFailureCount: 0,
+        noResultCount: 0,
+        response: {
+          classpaths: cpRes.classpaths,
+          sourcepaths: cpRes.sourcepaths ?? [],
+          output: cpRes.output,
+        },
       };
     }
+    return {
+      invocationCount: 1,
+      requestFailureCount: 0,
+      noResultCount: 1,
+    };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     recordFailure(`extensionApi ${label}`, message);
     if (verbose) {
       Logger.log(`extensionApi.getClasspaths(${label}) failed: ${message}`);
     }
+    return {
+      invocationCount: 1,
+      requestFailureCount: 1,
+      noResultCount: 0,
+    };
   }
-  return undefined;
 }
 
 function normalizeClasspathResult(res: JavaLsClasspathResponse): ClasspathResult {
@@ -174,4 +273,97 @@ function envVerbose(): boolean {
   } catch {
     return false;
   }
+}
+
+function mergeAttemptSummary(target: AttemptSummary, update: AttemptSummary): void {
+  target.invocationCount += update.invocationCount;
+  target.requestFailureCount += update.requestFailureCount;
+  target.noResultCount += update.noResultCount;
+}
+
+function buildResolvedIssues(
+  result: ClasspathResult,
+  summary: AttemptSummary,
+  usedExtensionFallback: boolean,
+  lastFailure?: { context: string; message: string }
+): AnalysisResolutionIssue[] {
+  const issues: AnalysisResolutionIssue[] = [];
+
+  if (usedExtensionFallback) {
+    issues.push(...buildUnavailableIssues(summary, lastFailure));
+    issues.push({
+      code: 'JAVA_LS_EXTENSION_FALLBACK_USED',
+      level: 'info',
+      source: 'java-ls',
+      phase: 'get-classpaths',
+      message: 'Java LS extension API fallback provided classpath metadata.',
+      variant: 'extension-api',
+    });
+  }
+
+  if (result.runtimeClasspaths.length === 0) {
+    issues.push({
+      code: 'JAVA_LS_EMPTY_RUNTIME_CLASSPATH',
+      level: 'warn',
+      source: 'java-ls',
+      phase: 'get-classpaths',
+      message: 'Java LS classpath lookup returned no runtime classpath entries.',
+    });
+  }
+
+  return issues;
+}
+
+function buildUnavailableIssues(
+  summary: AttemptSummary,
+  lastFailure?: { context: string; message: string }
+): AnalysisResolutionIssue[] {
+  const classification = classifyLookupFailure(summary);
+  if (!classification) {
+    return [];
+  }
+
+  const issues: AnalysisResolutionIssue[] = [];
+
+  if (classification === 'request-failed') {
+    issues.push({
+      code: 'JAVA_LS_REQUEST_FAILED',
+      level: 'warn',
+      source: 'java-ls',
+      phase: 'get-classpaths',
+      message: 'Java LS classpath lookup failed.',
+      attemptLabel: lastFailure?.context,
+      cause: lastFailure?.message,
+    });
+  }
+
+  if (classification === 'no-result') {
+    issues.push({
+      code: 'JAVA_LS_NO_RESULT',
+      level: 'warn',
+      source: 'java-ls',
+      phase: 'get-classpaths',
+      message: 'Java LS classpath lookup returned no usable result.',
+    });
+  }
+
+  return issues;
+}
+
+function classifyLookupFailure(
+  summary: AttemptSummary
+): 'request-failed' | 'no-result' | undefined {
+  if (summary.invocationCount === 0) {
+    return undefined;
+  }
+
+  if (summary.noResultCount > 0) {
+    return 'no-result';
+  }
+
+  if (summary.requestFailureCount === summary.invocationCount) {
+    return 'request-failed';
+  }
+
+  return undefined;
 }

--- a/src/workspace/classpathService.ts
+++ b/src/workspace/classpathService.ts
@@ -1,16 +1,13 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { Uri } from 'vscode';
+import type { ClasspathLookupOutcome } from '../lsp/javaLsOutcome';
 import { collectClasspathAttempts } from './classpathAttemptSelector';
-import { runClasspathAttempts } from './classpathCommandRunner';
-import { deriveTargetResolutionRoots } from './classpathLayout';
-
-export interface ClasspathResult {
-  output?: string;
-  runtimeClasspaths: string[];
-  targetResolutionRoots: string[];
-  sourcepaths: string[];
-}
+import {
+  runClasspathAttempts,
+  runClasspathAttemptsOutcome,
+} from './classpathCommandRunner';
+import type { ClasspathResult } from './classpathTypes';
 
 export interface ClasspathLookupOptions {
   verbose?: boolean;
@@ -29,12 +26,20 @@ const PREFERRED_OUTPUT_SUFFIXES = [
 
 export type ProjectRef = string | Uri | undefined;
 
+export async function getClasspathsOutcome(
+  project?: ProjectRef,
+  options?: ClasspathLookupOptions
+): Promise<ClasspathLookupOutcome> {
+  const attempts = await collectClasspathAttempts(project);
+  return runClasspathAttemptsOutcome(attempts, options);
+}
+
 export async function getClasspaths(
   project?: ProjectRef,
   options?: ClasspathLookupOptions
 ): Promise<ClasspathResult | undefined> {
-  const attempts = await collectClasspathAttempts(project);
-  return runClasspathAttempts(attempts, options);
+  const outcome = await getClasspathsOutcome(project, options);
+  return outcome.status === 'resolved' ? outcome.classpath : undefined;
 }
 
 export async function deriveOutputFolder(

--- a/src/workspace/classpathTypes.ts
+++ b/src/workspace/classpathTypes.ts
@@ -1,0 +1,6 @@
+export interface ClasspathResult {
+  output?: string;
+  runtimeClasspaths: string[];
+  targetResolutionRoots: string[];
+  sourcepaths: string[];
+}

--- a/src/workspace/projectDiscovery.ts
+++ b/src/workspace/projectDiscovery.ts
@@ -1,11 +1,19 @@
 import { Uri, workspace } from 'vscode';
 import * as path from 'path';
 import { Logger } from '../core/logger';
+import type { AnalysisResolutionIssue } from '../lsp/javaLsOutcome';
 import { JavaLsClient } from '../services/javaLsClient';
 
-export async function getWorkspaceProjectUris(workspaceFolder: Uri): Promise<string[]> {
-  let projectUris = await JavaLsClient.getAllProjects();
-  projectUris = projectUris.filter((uriString) => {
+export interface WorkspaceProjectDiscoveryResult {
+  projectUris: string[];
+  issues: AnalysisResolutionIssue[];
+}
+
+export async function getWorkspaceProjectDiscovery(
+  workspaceFolder: Uri
+): Promise<WorkspaceProjectDiscoveryResult> {
+  const outcome = await JavaLsClient.getAllProjectsOutcome();
+  const projectUris = outcome.projectUris.filter((uriString) => {
     try {
       const fsPath = Uri.parse(uriString).fsPath;
       return path.basename(fsPath) !== 'jdt.ls-java-project';
@@ -14,14 +22,33 @@ export async function getWorkspaceProjectUris(workspaceFolder: Uri): Promise<str
     }
   });
 
-  if (projectUris.length === 0) {
-    projectUris = [workspaceFolder.toString()];
-    Logger.log('No Java projects from LS; falling back to workspace folder analysis.');
-  } else {
+  if (outcome.status === 'resolved' && projectUris.length > 0) {
     Logger.log(`Workspace contains ${projectUris.length} Java projects.`);
+    return {
+      projectUris,
+      issues: outcome.issues,
+    };
   }
 
-  return projectUris;
+  Logger.log('No Java projects from LS; falling back to workspace folder analysis.');
+  return {
+    projectUris: [workspaceFolder.toString()],
+    issues: [
+      ...outcome.issues,
+      {
+        code: 'WORKSPACE_FALLBACK_USED',
+        level: 'info',
+        source: 'project-discovery',
+        phase: 'workspace-fallback',
+        message: 'Workspace-folder fallback was used for project discovery.',
+      },
+    ],
+  };
+}
+
+export async function getWorkspaceProjectUris(workspaceFolder: Uri): Promise<string[]> {
+  const discovery = await getWorkspaceProjectDiscovery(workspaceFolder);
+  return discovery.projectUris;
 }
 
 export async function getProjectRootPaths(): Promise<string[]> {


### PR DESCRIPTION
## Summary

- Treat all-skipped or all-failed workspace runs as terminal failures.
- Avoid degraded success notices while preserving resolution details.