### PR TITLE
fix(runner): Apply engine analysis settings

### DIFF
--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/config/PreferencesApplier.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/config/PreferencesApplier.java
@@ -16,6 +16,11 @@ public class PreferencesApplier {
         // Map effort
         String effortString = toEffortString(cfg.getEffort());
         prefs.setEffort(effortString);
+        if (engine != null) {
+            // FindBugs2 executes whatever is currently stored in AnalysisOptions.
+            // Updating UserPreferences alone leaves the engine pinned to DEFAULT_EFFORT.
+            engine.setAnalysisFeatureSettings(prefs.getAnalysisFeatureSettings());
+        }
 
         // Filter files are applied by FindBugs2#setUserPreferences via configureFilters.
         prefs.setIncludeFilterFiles(toEnabledPathMap(cfg.getIncludeFilterPaths()));


### PR DESCRIPTION
## Summary

- Apply configured effort settings to the active SpotBugs engine.
- Ensure analysis feature settings affect actual execution.