### PR TITLE
fix: surface SpotBugs analysis failures

### DIFF
--- a/javaext/com.spotbugs.runner/pom.xml
+++ b/javaext/com.spotbugs.runner/pom.xml
@@ -26,6 +26,12 @@
             <artifactId>gson</artifactId>
             <version>2.10.1</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -59,6 +65,20 @@
                                 </filter>
                             </filters>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <executions>
+                    <execution>
+                        <id>unit-tests</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/api/CommandResponse.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/api/CommandResponse.java
@@ -24,8 +24,12 @@ public class CommandResponse {
     }
 
     public static CommandResponse error(String code, String message) {
+        return error(code, message, null);
+    }
+
+    public static CommandResponse error(String code, String message, Map<String, Object> stats) {
         CommandError error = new CommandError(code, message);
-        return new CommandResponse(Collections.emptyList(), Collections.singletonList(error), null);
+        return new CommandResponse(Collections.emptyList(), Collections.singletonList(error), stats);
     }
 
     public int getSchemaVersion() {

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/AnalyzerService.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/AnalyzerService.java
@@ -57,31 +57,28 @@ public class AnalyzerService {
         return lastAuxClasspathCount;
     }
 
-    public List<BugInfo> analyzeToBugs(String... filePaths) {
+    public List<BugInfo> analyzeToBugs(String... filePaths) throws java.io.IOException, InterruptedException {
         return analyzeToBugs(null, filePaths);
     }
 
-    public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths) {
-        try {
-            PreparedAnalysis prepared = prepareAnalysis(monitor, filePaths);
-            if (prepared == null) {
-                return java.util.Collections.emptyList();
-            }
-            SpotBugsRunner runner = new SpotBugsRunner();
-            checkCanceled(monitor);
-            List<BugInfo> bugs = runner.run(
-                    this.findBugs,
-                    prepared.project,
-                    prepared.reporterPriorityThreshold,
-                    prepared.plugins
-            );
-            checkCanceled(monitor);
-            applyFullPaths(bugs, monitor, filePaths);
-            applyRankThreshold(bugs, monitor);
-            return bugs;
-        } catch (Exception e) {
+    public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths)
+            throws java.io.IOException, InterruptedException {
+        PreparedAnalysis prepared = prepareAnalysis(monitor, filePaths);
+        if (prepared == null) {
             return java.util.Collections.emptyList();
         }
+        SpotBugsRunner runner = new SpotBugsRunner();
+        checkCanceled(monitor);
+        List<BugInfo> bugs = runner.run(
+                this.findBugs,
+                prepared.project,
+                prepared.reporterPriorityThreshold,
+                prepared.plugins
+        );
+        checkCanceled(monitor);
+        applyFullPaths(bugs, monitor, filePaths);
+        applyRankThreshold(bugs, monitor);
+        return bugs;
     }
 
     public String analyzeToNativeSarif(String... filePaths) {

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/AbstractCommandAction.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/AbstractCommandAction.java
@@ -20,9 +20,11 @@ public abstract class AbstractCommandAction implements CommandAction {
     public final String execute(ActionInvocation invocation) {
         ActionContext context = new ActionContext(invocation);
         try {
-            context.checkCanceled();
+            context.checkCanceled(cancellationErrorCode());
             CommandResult result = run(context);
-            context.checkCanceled();
+            if (shouldCheckCanceledAfterRun()) {
+                context.checkCanceled(cancellationErrorCode());
+            }
             if (result == null) {
                 return gson.toJson(Collections.emptyMap());
             }
@@ -60,6 +62,21 @@ public abstract class AbstractCommandAction implements CommandAction {
      */
     protected final CommandResult successRaw(String rawJson) {
         return CommandResult.raw(rawJson);
+    }
+
+    /**
+     * Error code to use when wrapper-level cancellation is detected.
+     */
+    protected String cancellationErrorCode() {
+        return DEFAULT_ERROR_CODE;
+    }
+
+    /**
+     * Whether the wrapper should check cancellation again after run(...).
+     * Actions that return their own cancellation envelope with stats can override this.
+     */
+    protected boolean shouldCheckCanceledAfterRun() {
+        return true;
     }
 
     /**
@@ -133,8 +150,12 @@ public abstract class AbstractCommandAction implements CommandAction {
         }
 
         public void checkCanceled() throws CommandActionException {
+            checkCanceled(DEFAULT_ERROR_CODE);
+        }
+
+        public void checkCanceled(String code) throws CommandActionException {
             if (isCanceled()) {
-                throw new CommandActionException(DEFAULT_ERROR_CODE, "Command cancelled");
+                throw new CommandActionException(code, "Command cancelled");
             }
         }
 

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisAction.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisAction.java
@@ -23,22 +23,44 @@ import edu.umd.cs.findbugs.Version;
 public final class RunAnalysisAction extends AbstractCommandAction {
 
     private static final String COMMAND_ID = "java.spotbugs.run";
+    private static final String ERROR_ANALYSIS_FAILED = "ANALYSIS_FAILED";
+    private static final String ERROR_ANALYSIS_CANCELLED = "ANALYSIS_CANCELLED";
 
     private final ConfigParser configParser;
     private final ConfigValidator configValidator;
+    private final AnalyzerServiceFactory analyzerFactory;
 
     public RunAnalysisAction() {
-        this(new ConfigParser(), new ConfigValidator());
+        this(new ConfigParser(), new ConfigValidator(), AnalyzerService::new);
     }
 
     RunAnalysisAction(ConfigParser parser, ConfigValidator validator) {
+        this(parser, validator, AnalyzerService::new);
+    }
+
+    RunAnalysisAction(AnalyzerServiceFactory analyzerFactory) {
+        this(new ConfigParser(), new ConfigValidator(), analyzerFactory);
+    }
+
+    RunAnalysisAction(ConfigParser parser, ConfigValidator validator, AnalyzerServiceFactory analyzerFactory) {
         this.configParser = parser;
         this.configValidator = validator;
+        this.analyzerFactory = analyzerFactory != null ? analyzerFactory : AnalyzerService::new;
     }
 
     @Override
     public String id() {
         return COMMAND_ID;
+    }
+
+    @Override
+    protected String cancellationErrorCode() {
+        return ERROR_ANALYSIS_CANCELLED;
+    }
+
+    @Override
+    protected boolean shouldCheckCanceledAfterRun() {
+        return false;
     }
 
     @Override
@@ -51,17 +73,59 @@ public final class RunAnalysisAction extends AbstractCommandAction {
 
         AnalysisConfig config = parseAndValidateConfig(configJson);
 
-        AnalyzerService analyzer = new AnalyzerService();
+        AnalyzerService analyzer = analyzerFactory.create();
         analyzer.setConfiguration(config);
         long start = System.currentTimeMillis();
-        List<BugInfo> bugs = analyzer.analyzeToBugs(context.monitor(), targetPath);
-        long elapsed = System.currentTimeMillis() - start;
+        try {
+            List<BugInfo> bugs = analyzer.analyzeToBugs(context.monitor(), targetPath);
+            List<BugInfo> results = bugs != null ? bugs : java.util.Collections.emptyList();
+            if (context.isCanceled()) {
+                Map<String, Object> stats = buildStats(targetPath, start, config, analyzer, 0);
+                return success(CommandResponse.error(
+                        ERROR_ANALYSIS_CANCELLED,
+                        "Command cancelled",
+                        stats
+                ));
+            }
+            Map<String, Object> stats = buildStats(targetPath, start, config, analyzer, results.size());
+            return success(CommandResponse.success(results, stats));
+        } catch (java.util.concurrent.CancellationException cancellation) {
+            Map<String, Object> stats = buildStats(targetPath, start, config, analyzer, 0);
+            return success(CommandResponse.error(
+                    ERROR_ANALYSIS_CANCELLED,
+                    "Command cancelled",
+                    stats
+            ));
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            Map<String, Object> stats = buildStats(targetPath, start, config, analyzer, 0);
+            return success(CommandResponse.error(
+                    ERROR_ANALYSIS_CANCELLED,
+                    "Command cancelled",
+                    stats
+            ));
+        } catch (Exception analysisFailure) {
+            Map<String, Object> stats = buildStats(targetPath, start, config, analyzer, 0);
+            return success(CommandResponse.error(
+                    ERROR_ANALYSIS_FAILED,
+                    rootCauseMessage(analysisFailure),
+                    stats
+            ));
+        }
+    }
 
-        List<BugInfo> results = bugs != null ? bugs : java.util.Collections.emptyList();
+    private Map<String, Object> buildStats(
+            String targetPath,
+            long startMillis,
+            AnalysisConfig config,
+            AnalyzerService analyzer,
+            int findingCount
+    ) {
+        long elapsed = System.currentTimeMillis() - startMillis;
         Map<String, Object> stats = new HashMap<>();
         stats.put("target", targetPath);
         stats.put("durationMs", Long.valueOf(elapsed));
-        stats.put("findingCount", Integer.valueOf(results.size()));
+        stats.put("findingCount", Integer.valueOf(findingCount));
         stats.put("spotbugsVersion", Version.VERSION_STRING);
         stats.put("targetResolutionRootCount", Integer.valueOf(analyzer.getLastTargetResolutionRootCount()));
         stats.put("runtimeClasspathCount", Integer.valueOf(config.getRuntimeClasspaths().size()));
@@ -69,8 +133,27 @@ public final class RunAnalysisAction extends AbstractCommandAction {
         stats.put("auxClasspathCount", Integer.valueOf(analyzer.getLastAuxClasspathCount()));
         stats.put("targetCount", Integer.valueOf(analyzer.getLastTargetCount()));
         stats.put("pluginCount", Integer.valueOf(config.getPlugins().size()));
+        return stats;
+    }
 
-        return success(CommandResponse.success(results, stats));
+    private String rootCauseMessage(Throwable throwable) {
+        Throwable root = throwable;
+        java.util.Set<Throwable> seen = new java.util.HashSet<>();
+        while (root != null && root.getCause() != null && !seen.contains(root.getCause())) {
+            seen.add(root);
+            root = root.getCause();
+        }
+        if (root == null) {
+            return "Unknown error";
+        }
+        String message = root.getMessage();
+        if (message != null && !message.trim().isEmpty()) {
+            return message.trim();
+        }
+        String simpleName = root.getClass().getSimpleName();
+        return simpleName != null && !simpleName.trim().isEmpty()
+                ? simpleName
+                : root.getClass().getName();
     }
 
     private AnalysisConfig parseAndValidateConfig(String configJson) throws CommandActionException {
@@ -91,5 +174,9 @@ public final class RunAnalysisAction extends AbstractCommandAction {
         String code = error != null ? error.getCode() : "CFG_ERROR";
         String message = error != null ? error.getMessage() : "Configuration error";
         return new CommandActionException(code, message);
+    }
+
+    interface AnalyzerServiceFactory {
+        AnalyzerService create();
     }
 }

--- a/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisActionTest.java
+++ b/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisActionTest.java
@@ -1,0 +1,90 @@
+package com.spotbugs.vscode.runner.internal.command;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.junit.Test;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.spotbugs.vscode.runner.api.BugInfo;
+import com.spotbugs.vscode.runner.internal.AnalyzerService;
+
+public class RunAnalysisActionTest {
+
+    @Test
+    public void executeWrapsAnalyzerFailuresAsAnalysisFailedEnvelope() {
+        RunAnalysisAction action = new RunAnalysisAction(() -> new AnalyzerService() {
+            @Override
+            public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths)
+                    throws IOException, InterruptedException {
+                throw new IOException("analysis boom");
+            }
+        });
+
+        JsonObject response = execute(action);
+
+        assertEquals(2, response.get("schemaVersion").getAsInt());
+        assertEquals(0, response.getAsJsonArray("results").size());
+        assertEquals("ANALYSIS_FAILED", firstError(response).get("code").getAsString());
+        assertEquals("analysis boom", firstError(response).get("message").getAsString());
+        assertEquals(0, response.getAsJsonObject("stats").get("findingCount").getAsInt());
+    }
+
+    @Test
+    public void executeWrapsAnalyzerCancellationsAsAnalysisCancelledEnvelope() {
+        RunAnalysisAction action = new RunAnalysisAction(() -> new AnalyzerService() {
+            @Override
+            public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths)
+                    throws IOException, InterruptedException {
+                throw new CancellationException("Command cancelled");
+            }
+        });
+
+        JsonObject response = execute(action);
+
+        assertEquals(2, response.get("schemaVersion").getAsInt());
+        assertEquals(0, response.getAsJsonArray("results").size());
+        assertEquals("ANALYSIS_CANCELLED", firstError(response).get("code").getAsString());
+        assertEquals("Command cancelled", firstError(response).get("message").getAsString());
+        assertEquals(0, response.getAsJsonObject("stats").get("findingCount").getAsInt());
+    }
+
+    @Test
+    public void executeReportsSuccessFindingCountFromResults() {
+        RunAnalysisAction action = new RunAnalysisAction(() -> new AnalyzerService() {
+            @Override
+            public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths) {
+                return Collections.emptyList();
+            }
+        });
+
+        JsonObject response = execute(action);
+
+        assertEquals(2, response.get("schemaVersion").getAsInt());
+        assertEquals(0, response.getAsJsonArray("errors").size());
+        assertEquals(0, response.getAsJsonArray("results").size());
+        assertEquals(0, response.getAsJsonObject("stats").get("findingCount").getAsInt());
+    }
+
+    private static JsonObject execute(RunAnalysisAction action) {
+        String json = action.execute(new ActionInvocation(
+                "java.spotbugs.run",
+                new Object[] { "/workspace/build/classes", "{}" },
+                new NullProgressMonitor(),
+                Thread.currentThread(),
+                System.nanoTime()
+        ));
+        return JsonParser.parseString(json).getAsJsonObject();
+    }
+
+    private static JsonObject firstError(JsonObject response) {
+        return response.getAsJsonArray("errors").get(0).getAsJsonObject();
+    }
+}

--- a/src/lsp/spotbugsParser.ts
+++ b/src/lsp/spotbugsParser.ts
@@ -20,6 +20,8 @@ export type ParseResult =
   | { ok: true; value: ParsedAnalysis }
   | { ok: false; error: ParseError };
 
+const INVALID_RESPONSE_MESSAGE = 'Invalid response payload.';
+
 export function parseAnalysisResponse(raw: string): ParseResult {
   let parsed: unknown;
   try {
@@ -29,7 +31,7 @@ export function parseAnalysisResponse(raw: string): ParseResult {
       ok: false,
       error: {
         kind: 'invalid-json',
-        message: 'Invalid response payload.',
+        message: INVALID_RESPONSE_MESSAGE,
         cause,
       },
     };
@@ -51,8 +53,24 @@ export function parseAnalysisResponse(raw: string): ParseResult {
 
   if (parsed && typeof parsed === 'object') {
     const envelope = parsed as AnalysisResponse<Bug>;
-    const errors = Array.isArray(envelope.errors) ? envelope.errors : undefined;
-    const bugs = Array.isArray(envelope.results) ? envelope.results : [];
+    const hasResults = Object.prototype.hasOwnProperty.call(envelope, 'results');
+    const hasErrors = Object.prototype.hasOwnProperty.call(envelope, 'errors');
+    if (!hasResults && !hasErrors) {
+      return invalidResponse();
+    }
+    if (hasResults && !Array.isArray(envelope.results)) {
+      return invalidResponse();
+    }
+    if (hasErrors && !Array.isArray(envelope.errors)) {
+      return invalidResponse();
+    }
+
+    const errors = hasErrors ? envelope.errors : undefined;
+    if (!hasResults && Array.isArray(errors) && errors.length === 0) {
+      return invalidResponse();
+    }
+
+    const bugs = hasResults ? envelope.results ?? [] : [];
     const stats = envelope.stats;
     return {
       ok: true,
@@ -65,5 +83,15 @@ export function parseAnalysisResponse(raw: string): ParseResult {
     };
   }
 
-  return { ok: true, value: { bugs: [] } };
+  return invalidResponse();
+}
+
+function invalidResponse(): ParseResult {
+  return {
+    ok: false,
+    error: {
+      kind: 'invalid-json',
+      message: INVALID_RESPONSE_MESSAGE,
+    },
+  };
 }

--- a/src/orchestration/analysisRunner.ts
+++ b/src/orchestration/analysisRunner.ts
@@ -52,8 +52,12 @@ export async function runFileAnalysis(
     const result = await analyzeFileDetailed(args.config, fileUri);
     const outcome = result.outcome;
     const findings = outcome.findings;
-    args.tree.showResults(findings);
-    args.diagnostics.updateForFile(fileUri, findings);
+    if (outcome.failure) {
+      args.tree.showAnalysisFailure(outcome.failure.message, outcome.failure.code);
+    } else {
+      args.tree.showResults(findings);
+      args.diagnostics.updateForFile(fileUri, findings);
+    }
     const notices = buildAnalysisNotices(outcome, {
       includeHints: true,
       resolutionIssues: result.context.resolutionIssues,
@@ -72,10 +76,11 @@ export async function runFileAnalysis(
       `File analysis finished: elapsedMs=${t1 - t0}, file=${fileUri.fsPath}, findings=${findings.length}`
     );
   } catch (err) {
+    const errorMessage = messageFromUnknown(err);
+    const failureMessage = `SpotBugs analysis failed: ${errorMessage}`;
     Logger.error('An error occurred during SpotBugs analysis', err);
-    notifier.error('An error occurred during SpotBugs analysis. See SpotBugs output channel for details.');
-    args.tree.showResults([]);
-    args.diagnostics.updateForFile(fileUri, []);
+    notifier.error(failureMessage);
+    args.tree.showAnalysisFailure(failureMessage, 'ANALYSIS_FAILED');
   }
 }
 
@@ -145,8 +150,10 @@ export async function runWorkspaceAnalysis(
       return;
     }
 
-    args.tree.showResults(aggregated);
-    args.diagnostics.replaceAll(aggregated);
+    args.tree.showWorkspaceResults(projectResults);
+    if (projectResults.every((result) => !result.error)) {
+      args.diagnostics.replaceAll(aggregated);
+    }
     const notices = buildWorkspaceCompletionNotices(
       projectResults,
       aggregated.length,
@@ -174,4 +181,12 @@ async function focusSpotbugsTree(): Promise<void> {
 
 function getActiveFileUri(): Uri | undefined {
   return window.activeTextEditor?.document.uri;
+}
+
+function messageFromUnknown(error: unknown): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message.trim();
+  }
+  const message = String(error);
+  return message.trim().length > 0 ? message.trim() : 'Unknown error';
 }

--- a/src/services/analysisService.ts
+++ b/src/services/analysisService.ts
@@ -25,6 +25,9 @@ import {
 } from '../workspace/analysisTargetResolver';
 import { getWorkspaceProjectUris } from '../workspace/projectDiscovery';
 
+const ERROR_ANALYSIS_FAILED = 'ANALYSIS_FAILED';
+const ERROR_ANALYSIS_NO_RESPONSE = 'ANALYSIS_NO_RESPONSE';
+
 type AnalysisContext = {
   targetPath: string;
   preferredProject?: Uri;
@@ -90,14 +93,22 @@ export async function analyzeFileDetailed(
     } catch (error) {
       Logger.error('Analyzer: analyzeFile failed', error);
       return {
-        outcome: { findings: [] },
+        outcome: createAnalysisFailureOutcome(
+          result.resolution.target.targetPath,
+          ERROR_ANALYSIS_FAILED,
+          messageFromUnknown(error)
+        ),
         context,
       };
     }
   } catch (error) {
     Logger.error('Analyzer: analyzeFile failed', error);
     return {
-      outcome: { findings: [] },
+      outcome: createAnalysisFailureOutcome(
+        uri.fsPath,
+        ERROR_ANALYSIS_FAILED,
+        messageFromUnknown(error)
+      ),
       context,
     };
   }
@@ -300,7 +311,11 @@ async function runAnalysis(
   });
 
   if (!result) {
-    return { findings: [] };
+    return createAnalysisFailureOutcome(
+      targetPath,
+      ERROR_ANALYSIS_NO_RESPONSE,
+      'No response from SpotBugs backend.'
+    );
   }
 
   const parsed = parseAnalysisResponse(result);
@@ -401,6 +416,31 @@ async function runAnalysis(
     outcome.errors = errors;
   }
   return outcome;
+}
+
+function createAnalysisFailureOutcome(
+  targetPath: string,
+  code: string,
+  message: string
+): AnalysisOutcome {
+  return {
+    findings: [],
+    targetPath,
+    failure: {
+      kind: 'analysis-error',
+      level: 'error',
+      code,
+      message: `SpotBugs analysis failed: ${message}`,
+    },
+  };
+}
+
+function messageFromUnknown(error: unknown): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message.trim();
+  }
+  const message = String(error);
+  return message.trim().length > 0 ? message.trim() : 'Unknown error';
 }
 
 function normalizeProjectRef(project: ProjectRef): Uri {

--- a/src/test/L0.spotbugsParser.test.ts
+++ b/src/test/L0.spotbugsParser.test.ts
@@ -28,6 +28,25 @@ describe('spotbugsParser', () => {
     }
   });
 
+  it('rejects unsupported JSON protocol shapes', () => {
+    const samples = [
+      JSON.stringify({}),
+      JSON.stringify({ stats: { durationMs: 1 } }),
+      JSON.stringify({ errors: [] }),
+      JSON.stringify(null),
+      JSON.stringify('boom'),
+    ];
+
+    for (const sample of samples) {
+      const result = parseAnalysisResponse(sample);
+      assert.strictEqual(result.ok, false, sample);
+      if (!result.ok) {
+        assert.strictEqual(result.error.kind, 'invalid-json');
+        assert.strictEqual(result.error.message, 'Invalid response payload.');
+      }
+    }
+  });
+
   it('parses envelope responses with errors and stats', () => {
     const result = parseAnalysisResponse(
       JSON.stringify({
@@ -45,6 +64,67 @@ describe('spotbugsParser', () => {
       assert.strictEqual(result.value.errors?.[0]?.code, 'X');
       assert.strictEqual(result.value.errors?.[0]?.message, 'warn');
       assert.strictEqual(result.value.stats?.target, '/tmp/Foo');
+    }
+  });
+
+  it('parses terminal analysis failure envelopes with stats', () => {
+    const result = parseAnalysisResponse(
+      JSON.stringify({
+        schemaVersion: 2,
+        results: [],
+        errors: [
+          {
+            code: 'ANALYSIS_FAILED',
+            message: 'boom',
+          },
+        ],
+        stats: {
+          target: '/workspace/build/classes',
+          durationMs: 9,
+          spotbugsVersion: '4.8.3',
+        },
+      })
+    );
+
+    assert.strictEqual(result.ok, true);
+    if (result.ok) {
+      assert.strictEqual(result.value.schemaVersion, 2);
+      assert.deepStrictEqual(result.value.bugs, []);
+      assert.strictEqual(result.value.errors?.[0]?.code, 'ANALYSIS_FAILED');
+      assert.strictEqual(result.value.errors?.[0]?.message, 'boom');
+      assert.strictEqual(result.value.stats?.target, '/workspace/build/classes');
+      assert.strictEqual(result.value.stats?.durationMs, 9);
+      assert.strictEqual(result.value.stats?.spotbugsVersion, '4.8.3');
+    }
+  });
+
+  it('parses terminal analysis cancellation envelopes with stats', () => {
+    const result = parseAnalysisResponse(
+      JSON.stringify({
+        schemaVersion: 2,
+        results: [],
+        errors: [
+          {
+            code: 'ANALYSIS_CANCELLED',
+            message: 'Command cancelled',
+          },
+        ],
+        stats: {
+          target: '/workspace/build/classes',
+          durationMs: 4,
+          spotbugsVersion: '4.8.3',
+        },
+      })
+    );
+
+    assert.strictEqual(result.ok, true);
+    if (result.ok) {
+      assert.strictEqual(result.value.schemaVersion, 2);
+      assert.deepStrictEqual(result.value.bugs, []);
+      assert.strictEqual(result.value.errors?.[0]?.code, 'ANALYSIS_CANCELLED');
+      assert.strictEqual(result.value.errors?.[0]?.message, 'Command cancelled');
+      assert.strictEqual(result.value.stats?.target, '/workspace/build/classes');
+      assert.strictEqual(result.value.stats?.durationMs, 4);
     }
   });
 });

--- a/src/test/L1.analysisRunner.test.ts
+++ b/src/test/L1.analysisRunner.test.ts
@@ -1,0 +1,282 @@
+import * as assert from 'assert';
+import { installVscodeMock, resetVscodeMock } from './helpers/mockVscode';
+
+installVscodeMock();
+
+describe('analysisRunner', () => {
+  beforeEach(() => {
+    resetVscodeMock();
+  });
+
+  it('renders file analysis failures without showing empty successful results', async () => {
+    const vscode = installVscodeMock();
+    const analysisService =
+      require('../services/analysisService') as typeof import('../services/analysisService');
+    const originalAnalyzeFileDetailed = analysisService.analyzeFileDetailed;
+    analysisService.analyzeFileDetailed = (async () => ({
+      outcome: {
+        findings: [],
+        failure: {
+          kind: 'analysis-error',
+          level: 'error',
+          code: 'ANALYSIS_FAILED',
+          message: 'SpotBugs analysis failed: [ANALYSIS_FAILED] boom',
+        },
+      },
+      context: {
+        resolutionIssues: [],
+      },
+    })) as typeof analysisService.analyzeFileDetailed;
+
+    try {
+      const runner =
+        require('../orchestration/analysisRunner') as typeof import('../orchestration/analysisRunner');
+      const calls: string[] = [];
+      const errors: string[] = [];
+
+      await runner.runFileAnalysis({
+        config: { getAnalysisSettings: () => ({}) } as any,
+        tree: {
+          showLoading: () => calls.push('loading'),
+          showResults: (findings: unknown[]) => calls.push(`results:${findings.length}`),
+          showAnalysisFailure: (message: string, code?: string) =>
+            calls.push(`failure:${code ?? ''}:${message}`),
+        } as any,
+        diagnostics: {
+          updateForFile: () => calls.push('diagnostics:update'),
+        } as any,
+        uri: vscode.Uri.file('/workspace/src/Foo.java') as any,
+        notifier: {
+          info: () => undefined,
+          warn: () => undefined,
+          error: (message: string) => errors.push(message),
+        },
+      });
+
+      assert.deepStrictEqual(calls, [
+        'loading',
+        'failure:ANALYSIS_FAILED:SpotBugs analysis failed: [ANALYSIS_FAILED] boom',
+      ]);
+      assert.deepStrictEqual(errors, [
+        'SpotBugs analysis failed: [ANALYSIS_FAILED] boom',
+      ]);
+    } finally {
+      analysisService.analyzeFileDetailed = originalAnalyzeFileDetailed;
+    }
+  });
+
+  it('renders unexpected file analysis exceptions as failure state without clearing diagnostics', async () => {
+    const vscode = installVscodeMock();
+    const analysisService =
+      require('../services/analysisService') as typeof import('../services/analysisService');
+    const originalAnalyzeFileDetailed = analysisService.analyzeFileDetailed;
+    analysisService.analyzeFileDetailed = (async () => {
+      throw new Error('transport boom');
+    }) as typeof analysisService.analyzeFileDetailed;
+
+    try {
+      const runner =
+        require('../orchestration/analysisRunner') as typeof import('../orchestration/analysisRunner');
+      const calls: string[] = [];
+      const errors: string[] = [];
+
+      await runner.runFileAnalysis({
+        config: { getAnalysisSettings: () => ({}) } as any,
+        tree: {
+          showLoading: () => calls.push('loading'),
+          showResults: (findings: unknown[]) => calls.push(`results:${findings.length}`),
+          showAnalysisFailure: (message: string, code?: string) =>
+            calls.push(`failure:${code ?? ''}:${message}`),
+        } as any,
+        diagnostics: {
+          updateForFile: () => calls.push('diagnostics:update'),
+        } as any,
+        uri: vscode.Uri.file('/workspace/src/Foo.java') as any,
+        notifier: {
+          info: () => undefined,
+          warn: () => undefined,
+          error: (message: string) => errors.push(message),
+        },
+      });
+
+      assert.deepStrictEqual(calls, [
+        'loading',
+        'failure:ANALYSIS_FAILED:SpotBugs analysis failed: transport boom',
+      ]);
+      assert.deepStrictEqual(errors, [
+        'SpotBugs analysis failed: transport boom',
+      ]);
+    } finally {
+      analysisService.analyzeFileDetailed = originalAnalyzeFileDetailed;
+    }
+  });
+
+  it('renders all-failed workspace analysis without clearing diagnostics as empty success', async () => {
+    const vscode = installVscodeMock();
+    resetVscodeMock({
+      workspace: {
+        workspaceFolders: [
+          {
+            name: 'workspace',
+            uri: vscode.Uri.file('/workspace') as any,
+          },
+        ],
+      } as any,
+    });
+    const workspaceBuildService =
+      require('../services/workspaceBuildService') as typeof import('../services/workspaceBuildService');
+    const projectDiscovery =
+      require('../workspace/projectDiscovery') as typeof import('../workspace/projectDiscovery');
+    const analysisService =
+      require('../services/analysisService') as typeof import('../services/analysisService');
+    const originalBuildWorkspaceAuto = workspaceBuildService.buildWorkspaceAuto;
+    const originalGetWorkspaceProjectDiscovery = projectDiscovery.getWorkspaceProjectDiscovery;
+    const originalAnalyzeWorkspaceFromProjectsDetailed =
+      analysisService.analyzeWorkspaceFromProjectsDetailed;
+
+    workspaceBuildService.buildWorkspaceAuto = (async () => 0) as typeof workspaceBuildService.buildWorkspaceAuto;
+    projectDiscovery.getWorkspaceProjectDiscovery = (async () => ({
+      projectUris: ['file:///workspace/project-a', 'file:///workspace/project-b'],
+      issues: [],
+    })) as typeof projectDiscovery.getWorkspaceProjectDiscovery;
+    analysisService.analyzeWorkspaceFromProjectsDetailed = (async () => ({
+      results: [
+        {
+          projectUri: 'file:///workspace/project-a',
+          findings: [],
+          error: 'SpotBugs analysis failed: [ANALYSIS_FAILED] boom',
+          errorCode: 'ANALYSIS_FAILED',
+        },
+        {
+          projectUri: 'file:///workspace/project-b',
+          findings: [],
+          error: 'SpotBugs analysis failed: [ANALYSIS_FAILED] boom',
+          errorCode: 'ANALYSIS_FAILED',
+        },
+      ],
+      context: {
+        resolutionIssues: [],
+      },
+    })) as typeof analysisService.analyzeWorkspaceFromProjectsDetailed;
+
+    try {
+      const runner =
+        require('../orchestration/analysisRunner') as typeof import('../orchestration/analysisRunner');
+      const calls: string[] = [];
+      const errors: string[] = [];
+
+      await runner.runWorkspaceAnalysis({
+        config: { getAnalysisSettings: () => ({}) } as any,
+        tree: {
+          showWorkspaceProgress: (projectUris: string[]) =>
+            calls.push(`progress:${projectUris.length}`),
+          updateProjectStatus: () => undefined,
+          showResults: (findings: unknown[]) => calls.push(`results:${findings.length}`),
+          showWorkspaceResults: (projectResults: unknown[]) =>
+            calls.push(`workspaceResults:${projectResults.length}`),
+        } as any,
+        diagnostics: {
+          replaceAll: (findings: unknown[]) => calls.push(`diagnostics:${findings.length}`),
+        } as any,
+        notifier: {
+          info: () => undefined,
+          warn: () => undefined,
+          error: (message: string) => errors.push(message),
+        },
+      });
+
+      assert.deepStrictEqual(calls, ['progress:2', 'workspaceResults:2']);
+      assert.deepStrictEqual(errors, [
+        'SpotBugs: Workspace analysis failed - 2 projects failed. See the SpotBugs view for project errors.',
+      ]);
+    } finally {
+      workspaceBuildService.buildWorkspaceAuto = originalBuildWorkspaceAuto;
+      projectDiscovery.getWorkspaceProjectDiscovery = originalGetWorkspaceProjectDiscovery;
+      analysisService.analyzeWorkspaceFromProjectsDetailed =
+        originalAnalyzeWorkspaceFromProjectsDetailed;
+    }
+  });
+
+  it('leaves diagnostics untouched when workspace analysis partially fails', async () => {
+    const vscode = installVscodeMock();
+    resetVscodeMock({
+      workspace: {
+        workspaceFolders: [
+          {
+            name: 'workspace',
+            uri: vscode.Uri.file('/workspace') as any,
+          },
+        ],
+      } as any,
+    });
+    const workspaceBuildService =
+      require('../services/workspaceBuildService') as typeof import('../services/workspaceBuildService');
+    const projectDiscovery =
+      require('../workspace/projectDiscovery') as typeof import('../workspace/projectDiscovery');
+    const analysisService =
+      require('../services/analysisService') as typeof import('../services/analysisService');
+    const originalBuildWorkspaceAuto = workspaceBuildService.buildWorkspaceAuto;
+    const originalGetWorkspaceProjectDiscovery = projectDiscovery.getWorkspaceProjectDiscovery;
+    const originalAnalyzeWorkspaceFromProjectsDetailed =
+      analysisService.analyzeWorkspaceFromProjectsDetailed;
+
+    workspaceBuildService.buildWorkspaceAuto = (async () => 0) as typeof workspaceBuildService.buildWorkspaceAuto;
+    projectDiscovery.getWorkspaceProjectDiscovery = (async () => ({
+      projectUris: ['file:///workspace/project-a', 'file:///workspace/project-b'],
+      issues: [],
+    })) as typeof projectDiscovery.getWorkspaceProjectDiscovery;
+    analysisService.analyzeWorkspaceFromProjectsDetailed = (async () => ({
+      results: [
+        {
+          projectUri: 'file:///workspace/project-a',
+          findings: [],
+          error: 'SpotBugs analysis failed: [ANALYSIS_FAILED] boom',
+          errorCode: 'ANALYSIS_FAILED',
+        },
+        {
+          projectUri: 'file:///workspace/project-b',
+          findings: [],
+        },
+      ],
+      context: {
+        resolutionIssues: [],
+      },
+    })) as typeof analysisService.analyzeWorkspaceFromProjectsDetailed;
+
+    try {
+      const runner =
+        require('../orchestration/analysisRunner') as typeof import('../orchestration/analysisRunner');
+      const calls: string[] = [];
+
+      await runner.runWorkspaceAnalysis({
+        config: { getAnalysisSettings: () => ({}) } as any,
+        tree: {
+          showWorkspaceProgress: (projectUris: string[]) =>
+            calls.push(`progress:${projectUris.length}`),
+          updateProjectStatus: () => undefined,
+          showWorkspaceResults: (projectResults: unknown[]) =>
+            calls.push(`workspaceResults:${projectResults.length}`),
+        } as any,
+        diagnostics: {
+          replaceAll: (findings: unknown[]) => calls.push(`replaceAll:${findings.length}`),
+        } as any,
+        notifier: {
+          info: () => undefined,
+          warn: () => undefined,
+          error: () => undefined,
+        },
+      });
+
+      assert.deepStrictEqual(calls, [
+        'progress:2',
+        'workspaceResults:2',
+      ]);
+    } finally {
+      workspaceBuildService.buildWorkspaceAuto = originalBuildWorkspaceAuto;
+      projectDiscovery.getWorkspaceProjectDiscovery = originalGetWorkspaceProjectDiscovery;
+      analysisService.analyzeWorkspaceFromProjectsDetailed =
+        originalAnalyzeWorkspaceFromProjectsDetailed;
+    }
+  });
+
+});

--- a/src/test/L1.analysisService.test.ts
+++ b/src/test/L1.analysisService.test.ts
@@ -139,7 +139,165 @@ describe('analysisService', () => {
     assert.deepStrictEqual(result.context.resolutionIssues.map((issue) => issue.code), [
       'JAVA_LS_REQUEST_FAILED',
     ]);
-    assert.deepStrictEqual(result.outcome, { findings: [] });
+    assert.deepStrictEqual(result.outcome.findings, []);
+    assert.strictEqual(result.outcome.failure?.kind, 'analysis-error');
+    assert.strictEqual(result.outcome.failure?.level, 'error');
+    assert.strictEqual(result.outcome.failure?.code, 'ANALYSIS_FAILED');
+    assert.strictEqual(
+      result.outcome.failure?.message,
+      'SpotBugs analysis failed: analysis boom'
+    );
+    assert.strictEqual(result.outcome.targetPath, '/workspace/build/classes');
+  });
+
+  it('turns missing backend responses into file analysis failure outcomes', async () => {
+    const vscode = installVscodeMock();
+    const resolverModule =
+      require('../workspace/analysisTargetResolver') as typeof import('../workspace/analysisTargetResolver');
+    const spotbugsClient =
+      require('../lsp/spotbugsClient') as typeof import('../lsp/spotbugsClient');
+    const service = require('../services/analysisService') as typeof import('../services/analysisService');
+
+    resolverModule.resolveFileAnalysisTargetDetailed = (async () => ({
+      resolution: {
+        status: 'ok',
+        target: {
+          targetPath: '/workspace/build/classes',
+          preferredProject: vscode.Uri.file('/workspace/src/Foo.java') as any,
+          targetResolutionRoots: ['/workspace/build/classes'],
+          runtimeClasspaths: ['/workspace/build/classes'],
+          sourcepaths: ['/workspace/src/main/java'],
+        },
+      },
+      issues: [],
+    })) as typeof resolverModule.resolveFileAnalysisTargetDetailed;
+    spotbugsClient.runSpotBugsAnalysis = (async () =>
+      undefined) as typeof spotbugsClient.runSpotBugsAnalysis;
+
+    const result = await service.analyzeFileDetailed(
+      { getAnalysisSettings: () => ({ effort: 'default' }) } as any,
+      vscode.Uri.file('/workspace/src/Foo.java') as any
+    );
+
+    assert.deepStrictEqual(result.outcome.findings, []);
+    assert.strictEqual(result.outcome.failure?.kind, 'analysis-error');
+    assert.strictEqual(result.outcome.failure?.level, 'error');
+    assert.strictEqual(result.outcome.failure?.code, 'ANALYSIS_NO_RESPONSE');
+    assert.strictEqual(
+      result.outcome.failure?.message,
+      'SpotBugs analysis failed: No response from SpotBugs backend.'
+    );
+    assert.strictEqual(result.outcome.targetPath, '/workspace/build/classes');
+  });
+
+  it('turns backend ANALYSIS_FAILED envelopes into file analysis failure outcomes', async () => {
+    const vscode = installVscodeMock();
+    const resolverModule =
+      require('../workspace/analysisTargetResolver') as typeof import('../workspace/analysisTargetResolver');
+    const spotbugsClient =
+      require('../lsp/spotbugsClient') as typeof import('../lsp/spotbugsClient');
+    const service = require('../services/analysisService') as typeof import('../services/analysisService');
+
+    resolverModule.resolveFileAnalysisTargetDetailed = (async () => ({
+      resolution: {
+        status: 'ok',
+        target: {
+          targetPath: '/workspace/build/classes',
+          preferredProject: vscode.Uri.file('/workspace/src/Foo.java') as any,
+          targetResolutionRoots: ['/workspace/build/classes'],
+          runtimeClasspaths: ['/workspace/build/classes'],
+          sourcepaths: ['/workspace/src/main/java'],
+        },
+      },
+      issues: [],
+    })) as typeof resolverModule.resolveFileAnalysisTargetDetailed;
+    spotbugsClient.runSpotBugsAnalysis = (async () =>
+      JSON.stringify({
+        schemaVersion: 2,
+        results: [],
+        errors: [
+          {
+            code: 'ANALYSIS_FAILED',
+            message: 'boom',
+          },
+        ],
+        stats: {
+          target: '/workspace/build/classes',
+          durationMs: 9,
+          spotbugsVersion: '4.8.3',
+        },
+      })) as typeof spotbugsClient.runSpotBugsAnalysis;
+
+    const result = await service.analyzeFileDetailed(
+      { getAnalysisSettings: () => ({ effort: 'default' }) } as any,
+      vscode.Uri.file('/workspace/src/Foo.java') as any
+    );
+
+    assert.deepStrictEqual(result.outcome.findings, []);
+    assert.strictEqual(result.outcome.failure?.kind, 'analysis-error');
+    assert.strictEqual(result.outcome.failure?.level, 'error');
+    assert.strictEqual(result.outcome.failure?.code, 'ANALYSIS_FAILED');
+    assert.strictEqual(
+      result.outcome.failure?.message,
+      'SpotBugs analysis failed: [ANALYSIS_FAILED] boom'
+    );
+    assert.strictEqual(result.outcome.errors?.[0]?.code, 'ANALYSIS_FAILED');
+    assert.strictEqual(result.outcome.stats?.target, '/workspace/build/classes');
+    assert.strictEqual(result.outcome.schemaVersion, 2);
+  });
+
+  it('preserves backend ANALYSIS_CANCELLED envelopes in file analysis outcomes', async () => {
+    const vscode = installVscodeMock();
+    const resolverModule =
+      require('../workspace/analysisTargetResolver') as typeof import('../workspace/analysisTargetResolver');
+    const spotbugsClient =
+      require('../lsp/spotbugsClient') as typeof import('../lsp/spotbugsClient');
+    const service = require('../services/analysisService') as typeof import('../services/analysisService');
+
+    resolverModule.resolveFileAnalysisTargetDetailed = (async () => ({
+      resolution: {
+        status: 'ok',
+        target: {
+          targetPath: '/workspace/build/classes',
+          preferredProject: vscode.Uri.file('/workspace/src/Foo.java') as any,
+          targetResolutionRoots: ['/workspace/build/classes'],
+          runtimeClasspaths: ['/workspace/build/classes'],
+          sourcepaths: ['/workspace/src/main/java'],
+        },
+      },
+      issues: [],
+    })) as typeof resolverModule.resolveFileAnalysisTargetDetailed;
+    spotbugsClient.runSpotBugsAnalysis = (async () =>
+      JSON.stringify({
+        schemaVersion: 2,
+        results: [],
+        errors: [
+          {
+            code: 'ANALYSIS_CANCELLED',
+            message: 'Command cancelled',
+          },
+        ],
+        stats: {
+          target: '/workspace/build/classes',
+          durationMs: 4,
+          spotbugsVersion: '4.8.3',
+        },
+      })) as typeof spotbugsClient.runSpotBugsAnalysis;
+
+    const result = await service.analyzeFileDetailed(
+      { getAnalysisSettings: () => ({ effort: 'default' }) } as any,
+      vscode.Uri.file('/workspace/src/Foo.java') as any
+    );
+
+    assert.deepStrictEqual(result.outcome.findings, []);
+    assert.strictEqual(result.outcome.failure?.kind, 'analysis-error');
+    assert.strictEqual(result.outcome.failure?.code, 'ANALYSIS_CANCELLED');
+    assert.strictEqual(
+      result.outcome.failure?.message,
+      'SpotBugs analysis failed: [ANALYSIS_CANCELLED] Command cancelled'
+    );
+    assert.strictEqual(result.outcome.stats?.target, '/workspace/build/classes');
+    assert.strictEqual(result.outcome.schemaVersion, 2);
   });
 
   it('preserves workspace/project resolution issues when analysis execution throws after target resolution', async () => {
@@ -195,5 +353,58 @@ describe('analysisService', () => {
       result.results.map((project) => project.error),
       ['analysis boom', 'analysis boom']
     );
+  });
+
+  it('marks workspace projects failed when backend returns ANALYSIS_FAILED envelopes', async () => {
+    const vscode = installVscodeMock();
+    const resolverModule =
+      require('../workspace/analysisTargetResolver') as typeof import('../workspace/analysisTargetResolver');
+    const spotbugsClient =
+      require('../lsp/spotbugsClient') as typeof import('../lsp/spotbugsClient');
+    const service = require('../services/analysisService') as typeof import('../services/analysisService');
+
+    resolverModule.resolveProjectAnalysisTargetDetailed = (async (projectUri) => ({
+      resolution: {
+        status: 'ok',
+        target: {
+          targetPath: '/workspace/project/target/classes',
+          preferredProject: projectUri,
+          targetResolutionRoots: ['/workspace/project/target/classes'],
+          runtimeClasspaths: ['/workspace/project/target/classes'],
+          sourcepaths: ['/workspace/project/src/main/java'],
+        },
+      },
+      issues: [],
+    })) as typeof resolverModule.resolveProjectAnalysisTargetDetailed;
+    spotbugsClient.runSpotBugsAnalysis = (async () =>
+      JSON.stringify({
+        schemaVersion: 2,
+        results: [],
+        errors: [
+          {
+            code: 'ANALYSIS_FAILED',
+            message: 'workspace boom',
+          },
+        ],
+        stats: {
+          target: '/workspace/project/target/classes',
+          durationMs: 12,
+          spotbugsVersion: '4.8.3',
+        },
+      })) as typeof spotbugsClient.runSpotBugsAnalysis;
+
+    const result = await service.analyzeWorkspaceFromProjectsDetailed(
+      { getAnalysisSettings: () => ({ effort: 'default' }) } as any,
+      vscode.Uri.file('/workspace') as any,
+      ['file:///workspace/project']
+    );
+
+    assert.strictEqual(result.results.length, 1);
+    assert.strictEqual(result.results[0].errorCode, 'ANALYSIS_FAILED');
+    assert.strictEqual(
+      result.results[0].error,
+      'SpotBugs analysis failed: [ANALYSIS_FAILED] workspace boom'
+    );
+    assert.deepStrictEqual(result.results[0].findings, []);
   });
 });

--- a/src/test/L1.spotbugsTreeDataProvider.test.ts
+++ b/src/test/L1.spotbugsTreeDataProvider.test.ts
@@ -1,0 +1,136 @@
+import * as assert from 'assert';
+import { installVscodeMock, resetVscodeMock } from './helpers/mockVscode';
+import type { Finding } from '../model/finding';
+
+installVscodeMock();
+
+describe('spotbugsTreeDataProvider', () => {
+  beforeEach(() => {
+    resetVscodeMock();
+  });
+
+  it('renders analysis failure as a distinct tree state', async () => {
+    const treeProviderModule = await import('../ui/spotbugsTreeDataProvider');
+    const provider = new treeProviderModule.SpotBugsTreeDataProvider();
+
+    provider.showAnalysisFailure(
+      'SpotBugs analysis failed: [ANALYSIS_FAILED] boom',
+      'ANALYSIS_FAILED'
+    );
+
+    const children = await provider.getChildren();
+
+    assert.strictEqual(children.length, 1);
+    assert.strictEqual(
+      children[0].label,
+      'SpotBugs analysis failed: [ANALYSIS_FAILED] boom'
+    );
+    assert.strictEqual(children[0].description, 'ANALYSIS_FAILED');
+    assert.strictEqual(children[0].contextValue, 'spotbugs.message.error');
+    assert.deepStrictEqual(provider.getCachedFindings(), []);
+    assert.deepStrictEqual(provider.getAllFindings(), []);
+  });
+
+  it('keeps workspace project failures visible when all projects fail', async () => {
+    const treeProviderModule = await import('../ui/spotbugsTreeDataProvider');
+    const provider = new treeProviderModule.SpotBugsTreeDataProvider();
+
+    provider.showWorkspaceResults([
+      {
+        projectUri: 'file:///workspace/project-a',
+        findings: [],
+        error: 'SpotBugs analysis failed: [ANALYSIS_FAILED] boom',
+        errorCode: 'ANALYSIS_FAILED',
+      },
+      {
+        projectUri: 'file:///workspace/project-b',
+        findings: [],
+        error: 'SpotBugs could not build the project.',
+        errorCode: 'no-class-targets',
+      },
+    ]);
+
+    const children = await provider.getChildren();
+
+    assert.strictEqual(children.length, 2);
+    assert.strictEqual(children[0].label, 'project-a');
+    assert.strictEqual(
+      children[0].description,
+      'Failed: SpotBugs analysis failed: [ANALYSIS_FAILED] boom'
+    );
+    assert.strictEqual(children[1].label, 'project-b');
+    assert.strictEqual(
+      children[1].description,
+      'Skipped: SpotBugs could not build the project.'
+    );
+    assert.ok(!children.some((item) => item.label === 'No issues found.'));
+    assert.deepStrictEqual(provider.getCachedFindings(), []);
+    assert.deepStrictEqual(provider.getAllFindings(), []);
+  });
+
+  it('renders workspace project failures before successful finding groups', async () => {
+    const treeProviderModule = await import('../ui/spotbugsTreeDataProvider');
+    const provider = new treeProviderModule.SpotBugsTreeDataProvider();
+
+    provider.showWorkspaceResults([
+      {
+        projectUri: 'file:///workspace/project-a',
+        findings: [],
+        error: 'SpotBugs analysis failed: [ANALYSIS_FAILED] boom',
+        errorCode: 'ANALYSIS_FAILED',
+      },
+      {
+        projectUri: 'file:///workspace/project-b',
+        findings: [makeFinding()],
+      },
+    ]);
+
+    const children = await provider.getChildren();
+
+    assert.strictEqual(children.length, 2);
+    assert.strictEqual(children[0].label, 'project-a');
+    assert.strictEqual(
+      children[0].description,
+      'Failed: SpotBugs analysis failed: [ANALYSIS_FAILED] boom'
+    );
+    assert.strictEqual(children[1].label, 'Correctness (1)');
+    assert.deepStrictEqual(provider.getCachedFindings(), [makeFinding()]);
+    assert.deepStrictEqual(provider.getAllFindings(), [makeFinding()]);
+
+    provider.setFilter('category', 'Correctness');
+    const filteredChildren = await provider.getChildren();
+
+    assert.strictEqual(filteredChildren.length, 2);
+    assert.strictEqual(filteredChildren[0].label, 'project-a');
+    assert.strictEqual(
+      filteredChildren[0].description,
+      'Failed: SpotBugs analysis failed: [ANALYSIS_FAILED] boom'
+    );
+    assert.strictEqual(filteredChildren[1].label, 'Correctness (1)');
+
+    provider.clearFilters();
+    const clearedChildren = await provider.getChildren();
+
+    assert.strictEqual(clearedChildren.length, 2);
+    assert.strictEqual(clearedChildren[0].label, 'project-a');
+    assert.strictEqual(
+      clearedChildren[0].description,
+      'Failed: SpotBugs analysis failed: [ANALYSIS_FAILED] boom'
+    );
+    assert.strictEqual(clearedChildren[1].label, 'Correctness (1)');
+  });
+});
+
+function makeFinding(): Finding {
+  return {
+    patternId: 'NP_ALWAYS_NULL',
+    type: 'NP_ALWAYS_NULL',
+    abbrev: 'NP',
+    category: 'Correctness',
+    message: 'NP: Null pointer in Foo',
+    location: {
+      fullPath: '/workspace/project-b/src/Foo.java',
+      startLine: 10,
+    },
+  };
+}

--- a/src/ui/findingTreeItem.ts
+++ b/src/ui/findingTreeItem.ts
@@ -40,10 +40,11 @@ export class FindingItem extends TreeItem {
 }
 
 // view computations moved to findingViewModel.ts
+export type ProjectStatus = 'pending' | 'running' | 'done' | 'failed' | 'skipped';
 
 export class ProjectStatusItem extends TreeItem {
   public idKey: string;
-  public status: 'pending' | 'running' | 'done' | 'failed' = 'pending';
+  public status: ProjectStatus = 'pending';
   public count?: number;
 
   constructor(idKey: string, label: string) {
@@ -54,7 +55,7 @@ export class ProjectStatusItem extends TreeItem {
   }
 
   public setStatus(
-    status: 'pending' | 'running' | 'done' | 'failed',
+    status: ProjectStatus,
     extra?: { count?: number; error?: string }
   ) {
     this.status = status;
@@ -71,6 +72,9 @@ export class ProjectStatusItem extends TreeItem {
     } else if (status === 'failed') {
       this.iconPath = new ThemeIcon('error');
       this.description = extra?.error ? `Failed: ${extra.error}` : 'Failed';
+    } else if (status === 'skipped') {
+      this.iconPath = new ThemeIcon('warning');
+      this.description = extra?.error ? `Skipped: ${extra.error}` : 'Skipped';
     }
   }
 }

--- a/src/ui/spotbugsTreeDataProvider.ts
+++ b/src/ui/spotbugsTreeDataProvider.ts
@@ -1,14 +1,17 @@
 'use strict';
 
-import { Event, EventEmitter, TreeDataProvider, TreeItem, Uri } from 'vscode';
+import { Event, EventEmitter, ThemeIcon, TreeDataProvider, TreeItem, Uri } from 'vscode';
 import { Finding } from '../model/finding';
 import {
   CategoryGroupItem,
   PatternGroupItem,
   FindingItem,
+  type ProjectStatus,
   ProjectStatusItem,
 } from './findingTreeItem';
 import * as path from 'path';
+import type { ProjectResult } from '../services/projectResult';
+import { NO_CLASS_TARGETS_CODE } from '../workspace/analysisTargetCodes';
 import { groupFindingsByCategoryAndPattern } from './treeModel';
 import {
   applyFindingFilters,
@@ -27,6 +30,7 @@ export class SpotBugsTreeDataProvider implements TreeDataProvider<TreeItem> {
 
   private viewItems: TreeItem[] = [];
   private projectItems: Map<string, ProjectStatusItem> = new Map();
+  private workspaceStatusItems: ProjectStatusItem[] = [];
   private cachedResults: Finding[] = [];
   private visibleResults: Finding[] = [];
   private activeFilters: FindingFilterState = {};
@@ -53,6 +57,7 @@ export class SpotBugsTreeDataProvider implements TreeDataProvider<TreeItem> {
 
   public showInitialMessage(): void {
     this.projectItems.clear();
+    this.workspaceStatusItems = [];
     this.cachedResults = [];
     this.visibleResults = [];
     this.activeFilters = {};
@@ -62,6 +67,7 @@ export class SpotBugsTreeDataProvider implements TreeDataProvider<TreeItem> {
 
   public showLoading(): void {
     this.projectItems.clear();
+    this.workspaceStatusItems = [];
     this.cachedResults = [];
     this.visibleResults = [];
     this.activeFilters = {};
@@ -69,8 +75,21 @@ export class SpotBugsTreeDataProvider implements TreeDataProvider<TreeItem> {
     this._onDidChangeTreeData.fire(undefined);
   }
 
+  public showAnalysisFailure(message: string, code?: string): void {
+    this.projectItems.clear();
+    this.workspaceStatusItems = [];
+    this.cachedResults = [];
+    this.visibleResults = [];
+    this.activeFilters = {};
+    this.viewItems = [
+      this.createMessageItem(message, code, 'spotbugs.message.error', new ThemeIcon('error')),
+    ];
+    this._onDidChangeTreeData.fire(undefined);
+  }
+
   public showWorkspaceProgress(projectUris: string[]): void {
     this.projectItems.clear();
+    this.workspaceStatusItems = [];
     const items: ProjectStatusItem[] = [];
     for (const uriString of projectUris) {
       const label = this.toDisplayName(uriString);
@@ -87,7 +106,7 @@ export class SpotBugsTreeDataProvider implements TreeDataProvider<TreeItem> {
 
   public updateProjectStatus(
     uriString: string,
-    status: 'pending' | 'running' | 'done' | 'failed',
+    status: ProjectStatus,
     extra?: { count?: number; error?: string }
   ): void {
     const item = this.projectItems.get(uriString);
@@ -95,6 +114,14 @@ export class SpotBugsTreeDataProvider implements TreeDataProvider<TreeItem> {
       item.setStatus(status, extra);
       this._onDidChangeTreeData.fire(item);
     }
+  }
+
+  public showWorkspaceResults(projectResults: ProjectResult[]): void {
+    this.projectItems.clear();
+    this.workspaceStatusItems = this.createFinalProjectStatusItems(projectResults);
+    this.cachedResults = projectResults.flatMap((result) => result.findings);
+    this.refreshResultsView();
+    this._onDidChangeTreeData.fire(undefined);
   }
 
   private toDisplayName(uriString: string): string {
@@ -108,6 +135,7 @@ export class SpotBugsTreeDataProvider implements TreeDataProvider<TreeItem> {
 
   public showResults(findings: Finding[]): void {
     this.projectItems.clear();
+    this.workspaceStatusItems = [];
     this.cachedResults = findings ? findings.slice() : [];
     this.refreshResultsView();
     this._onDidChangeTreeData.fire(undefined);
@@ -173,10 +201,26 @@ export class SpotBugsTreeDataProvider implements TreeDataProvider<TreeItem> {
     return [];
   }
 
+  private createFinalProjectStatusItems(projectResults: ProjectResult[]): ProjectStatusItem[] {
+    return projectResults
+      .filter((result) => !!result.error)
+      .map((result) => {
+        const item = new ProjectStatusItem(
+          result.projectUri,
+          this.toDisplayName(result.projectUri)
+        );
+        const status: ProjectStatus =
+          result.errorCode === NO_CLASS_TARGETS_CODE ? 'skipped' : 'failed';
+        item.setStatus(status, { error: result.error });
+        return item;
+      });
+  }
+
   private refreshResultsView(): void {
     if (this.cachedResults.length === 0) {
       this.viewItems = [this.createMessageItem('No issues found.')];
       this.visibleResults = [];
+      this.applyWorkspaceStatusItems();
       return;
     }
 
@@ -186,6 +230,7 @@ export class SpotBugsTreeDataProvider implements TreeDataProvider<TreeItem> {
     if (filteredFindings.length === 0) {
       const emptyState = createFilteredEmptyState(this.cachedResults, this.activeFilters);
       this.viewItems = [this.createMessageItem(emptyState.label, emptyState.description)];
+      this.applyWorkspaceStatusItems();
       return;
     }
 
@@ -196,12 +241,28 @@ export class SpotBugsTreeDataProvider implements TreeDataProvider<TreeItem> {
       );
       return new CategoryGroupItem(category.name, patterns, category.total);
     });
+    this.applyWorkspaceStatusItems();
   }
 
-  private createMessageItem(label: string, description?: string): TreeItem {
+  private applyWorkspaceStatusItems(): void {
+    if (this.workspaceStatusItems.length === 0) {
+      return;
+    }
+
+    const resultItems = this.cachedResults.length > 0 ? this.viewItems : [];
+    this.viewItems = [...this.workspaceStatusItems, ...resultItems];
+  }
+
+  private createMessageItem(
+    label: string,
+    description?: string,
+    contextValue = 'spotbugs.message',
+    iconPath?: ThemeIcon
+  ): TreeItem {
     const item = new TreeItem(label);
     item.description = description;
-    item.contextValue = 'spotbugs.message';
+    item.contextValue = contextValue;
+    item.iconPath = iconPath;
     return item;
   }
 }


### PR DESCRIPTION
## Summary

- Return structured SpotBugs analysis failures from the Java command.
- Show failure states and notices instead of empty results in VS Code.