### PR TITLE
refactor: extract RunAnalysisAction analysis pipeline

### DIFF
--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/AnalysisPipeline.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/AnalysisPipeline.java
@@ -1,0 +1,43 @@
+package com.spotbugs.vscode.runner.internal.command;
+
+import java.util.List;
+import java.util.concurrent.CancellationException;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+
+import com.spotbugs.vscode.runner.api.BugInfo;
+import com.spotbugs.vscode.runner.internal.AnalyzerService;
+
+final class AnalysisPipeline {
+
+    private final AnalyzerServiceFactory analyzerFactory;
+
+    AnalysisPipeline() {
+        this(AnalyzerService::new);
+    }
+
+    AnalysisPipeline(AnalyzerServiceFactory analyzerFactory) {
+        this.analyzerFactory = analyzerFactory != null ? analyzerFactory : AnalyzerService::new;
+    }
+
+    AnalysisPipelineResult run(IProgressMonitor monitor, RunAnalysisRequest request) {
+        AnalyzerService analyzer = analyzerFactory.create();
+        analyzer.setConfiguration(request.getConfig());
+        long startMillis = System.currentTimeMillis();
+        try {
+            List<BugInfo> bugs = analyzer.analyzeToBugs(monitor, request.getTargetPath());
+            List<BugInfo> results = bugs != null ? bugs : java.util.Collections.emptyList();
+            if (monitor != null && monitor.isCanceled()) {
+                return AnalysisPipelineResult.cancelled(analyzer, startMillis);
+            }
+            return AnalysisPipelineResult.success(analyzer, startMillis, results);
+        } catch (CancellationException cancellation) {
+            return AnalysisPipelineResult.cancelled(analyzer, startMillis);
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            return AnalysisPipelineResult.cancelled(analyzer, startMillis);
+        } catch (Exception analysisFailure) {
+            return AnalysisPipelineResult.failed(analyzer, startMillis, analysisFailure);
+        }
+    }
+}

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/AnalysisPipelineResult.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/AnalysisPipelineResult.java
@@ -1,0 +1,83 @@
+package com.spotbugs.vscode.runner.internal.command;
+
+import java.util.List;
+
+import com.spotbugs.vscode.runner.api.BugInfo;
+import com.spotbugs.vscode.runner.internal.AnalyzerService;
+
+final class AnalysisPipelineResult {
+
+    enum Status {
+        SUCCESS,
+        CANCELLED,
+        FAILED
+    }
+
+    private final Status status;
+    private final AnalyzerService analyzer;
+    private final long startMillis;
+    private final List<BugInfo> results;
+    private final Throwable failure;
+
+    private AnalysisPipelineResult(
+            Status status,
+            AnalyzerService analyzer,
+            long startMillis,
+            List<BugInfo> results,
+            Throwable failure
+    ) {
+        this.status = status;
+        this.analyzer = analyzer;
+        this.startMillis = startMillis;
+        this.results = results != null ? results : java.util.Collections.emptyList();
+        this.failure = failure;
+    }
+
+    static AnalysisPipelineResult success(AnalyzerService analyzer, long startMillis, List<BugInfo> results) {
+        return new AnalysisPipelineResult(Status.SUCCESS, analyzer, startMillis, results, null);
+    }
+
+    static AnalysisPipelineResult cancelled(AnalyzerService analyzer, long startMillis) {
+        return new AnalysisPipelineResult(
+                Status.CANCELLED,
+                analyzer,
+                startMillis,
+                java.util.Collections.emptyList(),
+                null
+        );
+    }
+
+    static AnalysisPipelineResult failed(AnalyzerService analyzer, long startMillis, Throwable failure) {
+        return new AnalysisPipelineResult(
+                Status.FAILED,
+                analyzer,
+                startMillis,
+                java.util.Collections.emptyList(),
+                failure
+        );
+    }
+
+    Status getStatus() {
+        return status;
+    }
+
+    AnalyzerService getAnalyzer() {
+        return analyzer;
+    }
+
+    long getStartMillis() {
+        return startMillis;
+    }
+
+    List<BugInfo> getResults() {
+        return results;
+    }
+
+    int getFindingCount() {
+        return results.size();
+    }
+
+    Throwable getFailure() {
+        return failure;
+    }
+}

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/AnalyzerServiceFactory.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/AnalyzerServiceFactory.java
@@ -1,0 +1,7 @@
+package com.spotbugs.vscode.runner.internal.command;
+
+import com.spotbugs.vscode.runner.internal.AnalyzerService;
+
+interface AnalyzerServiceFactory {
+    AnalyzerService create();
+}

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisAction.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisAction.java
@@ -1,9 +1,7 @@
 package com.spotbugs.vscode.runner.internal.command;
 
-import java.util.List;
 import java.util.Map;
 
-import com.spotbugs.vscode.runner.api.BugInfo;
 import com.spotbugs.vscode.runner.api.CommandResponse;
 import com.spotbugs.vscode.runner.internal.AnalyzerService;
 import com.spotbugs.vscode.runner.internal.config.AnalysisConfig;
@@ -20,8 +18,8 @@ public final class RunAnalysisAction extends AbstractCommandAction {
     private static final String ERROR_ANALYSIS_FAILED = "ANALYSIS_FAILED";
     private static final String ERROR_ANALYSIS_CANCELLED = "ANALYSIS_CANCELLED";
 
-    private final AnalyzerServiceFactory analyzerFactory;
     private final RunAnalysisRequestParser requestParser;
+    private final AnalysisPipeline pipeline;
     private final RunAnalysisStatsBuilder statsBuilder = new RunAnalysisStatsBuilder();
 
     public RunAnalysisAction() {
@@ -37,8 +35,8 @@ public final class RunAnalysisAction extends AbstractCommandAction {
     }
 
     RunAnalysisAction(ConfigParser parser, ConfigValidator validator, AnalyzerServiceFactory analyzerFactory) {
-        this.analyzerFactory = analyzerFactory != null ? analyzerFactory : AnalyzerService::new;
         this.requestParser = new RunAnalysisRequestParser(parser, validator);
+        this.pipeline = new AnalysisPipeline(analyzerFactory);
     }
 
     @Override
@@ -62,45 +60,32 @@ public final class RunAnalysisAction extends AbstractCommandAction {
         String targetPath = request.getTargetPath();
         AnalysisConfig config = request.getConfig();
 
-        AnalyzerService analyzer = analyzerFactory.create();
-        analyzer.setConfiguration(config);
-        long start = System.currentTimeMillis();
-        try {
-            List<BugInfo> bugs = analyzer.analyzeToBugs(context.monitor(), targetPath);
-            List<BugInfo> results = bugs != null ? bugs : java.util.Collections.emptyList();
-            if (context.isCanceled()) {
-                Map<String, Object> stats = statsBuilder.build(targetPath, start, config, analyzer, 0);
-                return success(CommandResponse.error(
-                        ERROR_ANALYSIS_CANCELLED,
-                        "Command cancelled",
-                        stats
-                ));
-            }
-            Map<String, Object> stats = statsBuilder.build(targetPath, start, config, analyzer, results.size());
-            return success(CommandResponse.success(results, stats));
-        } catch (java.util.concurrent.CancellationException cancellation) {
-            Map<String, Object> stats = statsBuilder.build(targetPath, start, config, analyzer, 0);
+        AnalysisPipelineResult pipelineResult = pipeline.run(context.monitor(), request);
+        Map<String, Object> stats = statsBuilder.build(
+                targetPath,
+                pipelineResult.getStartMillis(),
+                config,
+                pipelineResult.getAnalyzer(),
+                pipelineResult.getFindingCount()
+        );
+
+        if (pipelineResult.getStatus() == AnalysisPipelineResult.Status.CANCELLED) {
             return success(CommandResponse.error(
                     ERROR_ANALYSIS_CANCELLED,
                     "Command cancelled",
-                    stats
-            ));
-        } catch (InterruptedException interrupted) {
-            Thread.currentThread().interrupt();
-            Map<String, Object> stats = statsBuilder.build(targetPath, start, config, analyzer, 0);
-            return success(CommandResponse.error(
-                    ERROR_ANALYSIS_CANCELLED,
-                    "Command cancelled",
-                    stats
-            ));
-        } catch (Exception analysisFailure) {
-            Map<String, Object> stats = statsBuilder.build(targetPath, start, config, analyzer, 0);
-            return success(CommandResponse.error(
-                    ERROR_ANALYSIS_FAILED,
-                    rootCauseMessage(analysisFailure),
                     stats
             ));
         }
+
+        if (pipelineResult.getStatus() == AnalysisPipelineResult.Status.FAILED) {
+            return success(CommandResponse.error(
+                    ERROR_ANALYSIS_FAILED,
+                    rootCauseMessage(pipelineResult.getFailure()),
+                    stats
+            ));
+        }
+
+        return success(CommandResponse.success(pipelineResult.getResults(), stats));
     }
 
     private String rootCauseMessage(Throwable throwable) {
@@ -121,9 +106,5 @@ public final class RunAnalysisAction extends AbstractCommandAction {
         return simpleName != null && !simpleName.trim().isEmpty()
                 ? simpleName
                 : root.getClass().getName();
-    }
-
-    interface AnalyzerServiceFactory {
-        AnalyzerService create();
     }
 }

--- a/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/command/AnalysisPipelineTest.java
+++ b/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/command/AnalysisPipelineTest.java
@@ -1,0 +1,170 @@
+package com.spotbugs.vscode.runner.internal.command;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.junit.Test;
+
+import com.spotbugs.vscode.runner.api.BugInfo;
+import com.spotbugs.vscode.runner.internal.AnalyzerService;
+import com.spotbugs.vscode.runner.internal.config.AnalysisConfig;
+import com.spotbugs.vscode.runner.internal.config.ConfigParser;
+import com.spotbugs.vscode.runner.internal.config.ConfigValidator;
+
+public class AnalysisPipelineTest {
+
+    @Test
+    public void runConfiguresAnalyzerAndReturnsSuccessResults() throws Exception {
+        CapturingAnalyzerService analyzer = new CapturingAnalyzerService(Collections.nCopies(2, (BugInfo) null));
+        AnalysisPipeline pipeline = new AnalysisPipeline(() -> analyzer);
+        RunAnalysisRequest request = request("/workspace/build/classes");
+
+        AnalysisPipelineResult result = pipeline.run(new NullProgressMonitor(), request);
+
+        assertEquals(AnalysisPipelineResult.Status.SUCCESS, result.getStatus());
+        assertSame(analyzer, result.getAnalyzer());
+        assertSame(request.getConfig(), analyzer.config);
+        assertEquals("/workspace/build/classes", analyzer.targetPath);
+        assertEquals(2, result.getResults().size());
+        assertEquals(2, result.getFindingCount());
+        assertTrue(result.getStartMillis() > 0L);
+    }
+
+    @Test
+    public void runNormalizesNullAnalyzerResultsToEmptySuccessResults() throws Exception {
+        AnalysisPipeline pipeline = new AnalysisPipeline(() -> new CapturingAnalyzerService(null));
+
+        AnalysisPipelineResult result = pipeline.run(new NullProgressMonitor(), request("/workspace/build/classes"));
+
+        assertEquals(AnalysisPipelineResult.Status.SUCCESS, result.getStatus());
+        assertEquals(0, result.getResults().size());
+        assertEquals(0, result.getFindingCount());
+    }
+
+    @Test
+    public void runReturnsCancelledWhenMonitorIsCancelledAfterAnalyzerReturns() throws Exception {
+        NullProgressMonitor monitor = new NullProgressMonitor();
+        AnalysisPipeline pipeline = new AnalysisPipeline(() -> new AnalyzerService() {
+            @Override
+            public List<BugInfo> analyzeToBugs(IProgressMonitor progressMonitor, String... filePaths) {
+                progressMonitor.setCanceled(true);
+                return Collections.nCopies(2, (BugInfo) null);
+            }
+        });
+
+        AnalysisPipelineResult result = pipeline.run(monitor, request("/workspace/build/classes"));
+
+        assertEquals(AnalysisPipelineResult.Status.CANCELLED, result.getStatus());
+        assertEquals(0, result.getResults().size());
+        assertEquals(0, result.getFindingCount());
+    }
+
+    @Test
+    public void runReturnsCancelledForCancellationExceptions() throws Exception {
+        AnalysisPipeline pipeline = new AnalysisPipeline(() -> new AnalyzerService() {
+            @Override
+            public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths) {
+                throw new CancellationException("stop");
+            }
+        });
+
+        AnalysisPipelineResult result = pipeline.run(new NullProgressMonitor(), request("/workspace/build/classes"));
+
+        assertEquals(AnalysisPipelineResult.Status.CANCELLED, result.getStatus());
+        assertEquals(0, result.getFindingCount());
+    }
+
+    @Test
+    public void runReturnsCancelledForInterruptedExceptionsAndRestoresInterruptStatus() throws Exception {
+        AnalysisPipeline pipeline = new AnalysisPipeline(() -> new AnalyzerService() {
+            @Override
+            public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths)
+                    throws IOException, InterruptedException {
+                throw new InterruptedException("stop");
+            }
+        });
+
+        AnalysisPipelineResult result = null;
+        boolean wasInterrupted = false;
+        try {
+            result = pipeline.run(new NullProgressMonitor(), request("/workspace/build/classes"));
+            wasInterrupted = Thread.currentThread().isInterrupted();
+        } finally {
+            Thread.interrupted();
+        }
+
+        assertTrue(wasInterrupted);
+        assertNotNull(result);
+        assertEquals(AnalysisPipelineResult.Status.CANCELLED, result.getStatus());
+        assertEquals(0, result.getFindingCount());
+    }
+
+    @Test
+    public void runReturnsFailedResultWithOriginalException() throws Exception {
+        IOException failure = new IOException("analysis boom");
+        AnalysisPipeline pipeline = new AnalysisPipeline(() -> new AnalyzerService() {
+            @Override
+            public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths)
+                    throws IOException, InterruptedException {
+                throw failure;
+            }
+        });
+
+        AnalysisPipelineResult result = pipeline.run(new NullProgressMonitor(), request("/workspace/build/classes"));
+
+        assertEquals(AnalysisPipelineResult.Status.FAILED, result.getStatus());
+        assertSame(failure, result.getFailure());
+        assertEquals(0, result.getResults().size());
+        assertEquals(0, result.getFindingCount());
+    }
+
+    private static RunAnalysisRequest request(String targetPath) throws Exception {
+        return new RunAnalysisRequest(targetPath, defaultConfig());
+    }
+
+    private static AnalysisConfig defaultConfig() throws Exception {
+        return new RunAnalysisRequestParser(new ConfigParser(), new ConfigValidator())
+                .parse(context("/workspace/build/classes", "{}"))
+                .getConfig();
+    }
+
+    private static AbstractCommandAction.ActionContext context(Object... args) {
+        return new AbstractCommandAction.ActionContext(new ActionInvocation(
+                "java.spotbugs.run",
+                args,
+                new NullProgressMonitor(),
+                Thread.currentThread(),
+                System.nanoTime()
+        ));
+    }
+
+    private static final class CapturingAnalyzerService extends AnalyzerService {
+        private final List<BugInfo> result;
+        private AnalysisConfig config;
+        private String targetPath;
+
+        private CapturingAnalyzerService(List<BugInfo> result) {
+            this.result = result;
+        }
+
+        @Override
+        public void setConfiguration(AnalysisConfig cfg) {
+            this.config = cfg;
+        }
+
+        @Override
+        public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths) {
+            this.targetPath = filePaths != null && filePaths.length > 0 ? filePaths[0] : null;
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Extract the Java analysis pipeline from RunAnalysisAction.
- Isolate execution results and analyzer construction for focused testing.