### PR TITLE
feat: reveal source on finding selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,6 +169,19 @@
             "scope": "window"
           }
         }
+      },
+      {
+        "type": "object",
+        "title": "SpotBugs: Results",
+        "order": 2,
+        "properties": {
+          "spotbugs.results.revealSourceOnSelection": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Reveal the source location in a preview editor when selecting a SpotBugs finding in the results tree.",
+            "scope": "window"
+          }
+        }
       }
     ],
     "commands": [

--- a/src/commands/navigation.ts
+++ b/src/commands/navigation.ts
@@ -7,6 +7,7 @@ import { resolveFindingFilePath } from '../workspace/findingLocator';
 export interface RevealFindingSourceOptions {
   preserveFocus?: boolean;
   preview?: boolean;
+  isCurrentRequest?: () => boolean;
 }
 
 /**
@@ -22,6 +23,11 @@ export async function revealFindingSource(
     const notifier = defaultNotifier;
 
     const filePath = await resolveFindingFilePath(finding);
+
+    if (revealOptions.isCurrentRequest?.() === false) {
+      Logger.log('Skipping stale finding source reveal request.');
+      return;
+    }
 
     if (!filePath) {
       const errorMsg = `Cannot open file: Could not resolve path for ${finding.location.realSourcePath || 'unknown file'}`;

--- a/src/commands/navigation.ts
+++ b/src/commands/navigation.ts
@@ -4,11 +4,19 @@ import { Logger } from '../core/logger';
 import { defaultNotifier } from '../core/notifier';
 import { resolveFindingFilePath } from '../workspace/findingLocator';
 
+export interface RevealFindingSourceOptions {
+  preserveFocus?: boolean;
+  preview?: boolean;
+}
+
 /**
  * Reveals a source file and navigates to the specified finding location
  * @param finding The finding information containing file path and line details
  */
-export async function revealFindingSource(finding: Finding): Promise<void> {
+export async function revealFindingSource(
+  finding: Finding,
+  revealOptions: RevealFindingSourceOptions = {}
+): Promise<void> {
   try {
     Logger.log(`Revealing finding source: ${finding.message ?? 'SpotBugs finding'}`);
     const notifier = defaultNotifier;
@@ -40,8 +48,8 @@ export async function revealFindingSource(finding: Finding): Promise<void> {
     }
 
     const options: TextDocumentShowOptions = {
-      preserveFocus: false, // Focus the opened document
-      preview: false, // Open in a permanent tab
+      preserveFocus: revealOptions.preserveFocus ?? false,
+      preview: revealOptions.preview ?? false,
     };
     if (range) {
       options.selection = range;

--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -8,4 +8,5 @@ export const settingKeys = {
   filtersExcludePaths: 'filters.excludePaths',
   filtersExcludeBaselineBugsPaths: 'filters.excludeBaselineBugsPaths',
   pluginsPaths: 'plugins.paths',
+  resultsRevealSourceOnSelection: 'results.revealSourceOnSelection',
 } as const;

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -28,6 +28,7 @@ export class Config {
   // Legacy payload field kept for compatibility with older Java runner schema.
   public excludeFilterPath?: string;
   public plugins?: string[];
+  public revealSourceOnSelection!: boolean;
 
   public constructor(ctx: ExtensionContext) {
     this._ctx = ctx;
@@ -61,6 +62,12 @@ export class Config {
     );
 
     this.plugins = this.readStringArray(config.get<unknown>(settingKeys.pluginsPaths));
+
+    const revealSourceOnSelection = config.get<boolean | undefined>(
+      settingKeys.resultsRevealSourceOnSelection
+    );
+    this.revealSourceOnSelection =
+      typeof revealSourceOnSelection === 'boolean' ? revealSourceOnSelection : true;
   }
 
   // Resolve a workspace-relative path to absolute (best-effort)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,7 +79,10 @@ async function doActivate(
         FINDING_INSPECTOR_VIEW_ID,
         findingInspectorViewProvider
       ),
-      bindFindingInspectorToTree(spotbugsTreeView, findingInspectorState),
+      bindFindingInspectorToTree(spotbugsTreeView, findingInspectorState, {
+        revealSourceOnSelection: () => config.revealSourceOnSelection,
+        revealFindingSource,
+      }),
       languages.registerCodeActionsProvider(
         { language: 'java' },
         diagnosticCodeActionProvider,

--- a/src/test/L1.config.test.ts
+++ b/src/test/L1.config.test.ts
@@ -1,0 +1,32 @@
+import * as assert from 'assert';
+import { installVscodeMock, resetVscodeMock } from './helpers/mockVscode';
+
+installVscodeMock();
+
+describe('Config', () => {
+  beforeEach(() => {
+    resetVscodeMock();
+  });
+
+  it('enables source reveal on result selection by default', async () => {
+    const configModule = await import('../core/config');
+    const config = new configModule.Config({} as never);
+
+    assert.strictEqual(config.revealSourceOnSelection, true);
+  });
+
+  it('reads disabled source reveal on result selection from configuration', async () => {
+    resetVscodeMock({
+      workspace: {
+        getConfiguration: () => ({
+          get: (key: string) =>
+            key === 'results.revealSourceOnSelection' ? false : undefined,
+        }),
+      },
+    } as never);
+    const configModule = await import('../core/config');
+    const config = new configModule.Config({} as never);
+
+    assert.strictEqual(config.revealSourceOnSelection, false);
+  });
+});

--- a/src/test/L1.findingInspectorController.test.ts
+++ b/src/test/L1.findingInspectorController.test.ts
@@ -23,12 +23,64 @@ describe('findingInspectorController', () => {
     const tree = createTreeHarness();
 
     bindFindingInspectorToTree(tree.view, state);
-    tree.fireSelection(leaf);
+    await tree.fireSelection(leaf);
     assert.strictEqual(state.current.status, 'selected');
     assert.strictEqual(state.current.finding, finding);
 
-    tree.fireSelection(category);
+    await tree.fireSelection(category);
     assertInspectorFinding(state.current, 'retained', finding);
+  });
+
+  it('selects finding leaves then previews the finding source when enabled', async () => {
+    const { bindFindingInspectorToTree } = await import('../ui/findingInspectorController');
+    const findingInspectorState = await import('../ui/findingInspectorState');
+    const findingTreeItem = await import('../ui/findingTreeItem');
+    const finding = makeFinding();
+    const leaf = new findingTreeItem.FindingItem(finding);
+    const state = new findingInspectorState.FindingInspectorState();
+    const tree = createTreeHarness();
+    const previews: Array<{ finding: Finding; preserveFocus?: boolean; preview?: boolean }> = [];
+
+    bindFindingInspectorToTree(tree.view, state, {
+      revealSourceOnSelection: () => true,
+      revealFindingSource: async (nextFinding, options) => {
+        previews.push({ finding: nextFinding, ...options });
+      },
+    });
+    await tree.fireSelection(leaf);
+
+    assert.strictEqual(state.current.status, 'selected');
+    assert.strictEqual(state.current.finding, finding);
+    assert.deepStrictEqual(previews, [
+      {
+        finding,
+        preserveFocus: true,
+        preview: true,
+      },
+    ]);
+  });
+
+  it('does not preview the finding source when selection reveal is disabled', async () => {
+    const { bindFindingInspectorToTree } = await import('../ui/findingInspectorController');
+    const findingInspectorState = await import('../ui/findingInspectorState');
+    const findingTreeItem = await import('../ui/findingTreeItem');
+    const finding = makeFinding();
+    const leaf = new findingTreeItem.FindingItem(finding);
+    const state = new findingInspectorState.FindingInspectorState();
+    const tree = createTreeHarness();
+    let previewCount = 0;
+
+    bindFindingInspectorToTree(tree.view, state, {
+      revealSourceOnSelection: () => false,
+      revealFindingSource: async () => {
+        previewCount += 1;
+      },
+    });
+    await tree.fireSelection(leaf);
+
+    assert.strictEqual(state.current.status, 'selected');
+    assert.strictEqual(state.current.finding, finding);
+    assert.strictEqual(previewCount, 0);
   });
 
   it('retains current finding on pattern selection', async () => {
@@ -42,8 +94,8 @@ describe('findingInspectorController', () => {
     const tree = createTreeHarness();
 
     bindFindingInspectorToTree(tree.view, state);
-    tree.fireSelection(leaf);
-    tree.fireSelection(pattern);
+    await tree.fireSelection(leaf);
+    await tree.fireSelection(pattern);
 
     assert.strictEqual(state.current.status, 'retained');
     assert.strictEqual(state.current.finding, finding);
@@ -58,13 +110,17 @@ describe('findingInspectorController', () => {
     const tree = createTreeHarness();
 
     bindFindingInspectorToTree(tree.view, state);
-    tree.fireSelection(new findingTreeItem.ProjectStatusItem('project', 'Analyzing project'));
-    tree.fireSelection({ label: 'message' });
+    await tree.fireSelection(
+      new findingTreeItem.ProjectStatusItem('project', 'Analyzing project')
+    );
+    await tree.fireSelection({ label: 'message' });
     assert.strictEqual(state.current.status, 'empty');
 
-    tree.fireSelection(new findingTreeItem.FindingItem(finding));
-    tree.fireSelection(new findingTreeItem.ProjectStatusItem('project', 'Analyzing project'));
-    tree.fireSelection({ label: 'message' });
+    await tree.fireSelection(new findingTreeItem.FindingItem(finding));
+    await tree.fireSelection(
+      new findingTreeItem.ProjectStatusItem('project', 'Analyzing project')
+    );
+    await tree.fireSelection({ label: 'message' });
 
     assertInspectorFinding(state.current, 'selected', finding);
   });
@@ -81,7 +137,7 @@ function assertInspectorFinding(
 
 function createTreeHarness(): {
   view: never;
-  fireSelection: (selection: unknown) => void;
+  fireSelection: (selection: unknown) => Promise<unknown>;
 } {
   let listener: ((event: { selection: unknown[] }) => unknown) | undefined;
   return {
@@ -92,7 +148,7 @@ function createTreeHarness(): {
       },
     } as never,
     fireSelection: (selection: unknown) => {
-      listener?.({ selection: [selection] });
+      return Promise.resolve(listener?.({ selection: [selection] }));
     },
   };
 }

--- a/src/test/L1.findingInspectorController.test.ts
+++ b/src/test/L1.findingInspectorController.test.ts
@@ -39,7 +39,12 @@ describe('findingInspectorController', () => {
     const leaf = new findingTreeItem.FindingItem(finding);
     const state = new findingInspectorState.FindingInspectorState();
     const tree = createTreeHarness();
-    const previews: Array<{ finding: Finding; preserveFocus?: boolean; preview?: boolean }> = [];
+    const previews: Array<{
+      finding: Finding;
+      preserveFocus?: boolean;
+      preview?: boolean;
+      isCurrentRequest: () => boolean;
+    }> = [];
 
     bindFindingInspectorToTree(tree.view, state, {
       revealSourceOnSelection: () => true,
@@ -51,13 +56,67 @@ describe('findingInspectorController', () => {
 
     assert.strictEqual(state.current.status, 'selected');
     assert.strictEqual(state.current.finding, finding);
-    assert.deepStrictEqual(previews, [
-      {
-        finding,
-        preserveFocus: true,
-        preview: true,
+    assert.strictEqual(previews.length, 1);
+    assert.strictEqual(previews[0].finding, finding);
+    assert.strictEqual(previews[0].preserveFocus, true);
+    assert.strictEqual(previews[0].preview, true);
+    assert.strictEqual(previews[0].isCurrentRequest(), true);
+  });
+
+  it('marks older finding source previews stale after a newer finding selection', async () => {
+    const { bindFindingInspectorToTree } = await import('../ui/findingInspectorController');
+    const findingInspectorState = await import('../ui/findingInspectorState');
+    const findingTreeItem = await import('../ui/findingTreeItem');
+    const firstFinding = makeFinding({ patternId: 'FIRST' });
+    const secondFinding = makeFinding({ patternId: 'SECOND' });
+    const state = new findingInspectorState.FindingInspectorState();
+    const tree = createTreeHarness();
+    const previews: Array<{ finding: Finding; isCurrentRequest: () => boolean }> = [];
+
+    bindFindingInspectorToTree(tree.view, state, {
+      revealSourceOnSelection: () => true,
+      revealFindingSource: async (nextFinding, options) => {
+        previews.push({
+          finding: nextFinding,
+          isCurrentRequest: options.isCurrentRequest,
+        });
       },
-    ]);
+    });
+
+    const firstSelection = tree.fireSelection(new findingTreeItem.FindingItem(firstFinding));
+    const secondSelection = tree.fireSelection(new findingTreeItem.FindingItem(secondFinding));
+    await Promise.all([firstSelection, secondSelection]);
+
+    assert.strictEqual(previews.length, 2);
+    assert.strictEqual(previews[0].finding, firstFinding);
+    assert.strictEqual(previews[0].isCurrentRequest(), false);
+    assert.strictEqual(previews[1].finding, secondFinding);
+    assert.strictEqual(previews[1].isCurrentRequest(), true);
+  });
+
+  it('marks pending finding source previews stale after group selection', async () => {
+    const { bindFindingInspectorToTree } = await import('../ui/findingInspectorController');
+    const findingInspectorState = await import('../ui/findingInspectorState');
+    const findingTreeItem = await import('../ui/findingTreeItem');
+    const finding = makeFinding();
+    const pattern = new findingTreeItem.PatternGroupItem('NP_ALWAYS_NULL', [finding]);
+    const state = new findingInspectorState.FindingInspectorState();
+    const tree = createTreeHarness();
+    let isCurrentRequest: (() => boolean) | undefined;
+
+    bindFindingInspectorToTree(tree.view, state, {
+      revealSourceOnSelection: () => true,
+      revealFindingSource: async (_nextFinding, options) => {
+        isCurrentRequest = options.isCurrentRequest;
+      },
+    });
+
+    await tree.fireSelection(new findingTreeItem.FindingItem(finding));
+    assert.strictEqual(isCurrentRequest?.(), true);
+
+    await tree.fireSelection(pattern);
+
+    assert.strictEqual(isCurrentRequest?.(), false);
   });
 
   it('does not preview the finding source when selection reveal is disabled', async () => {
@@ -153,7 +212,7 @@ function createTreeHarness(): {
   };
 }
 
-function makeFinding(): Finding {
+function makeFinding(overrides: Partial<Finding> = {}): Finding {
   return {
     patternId: 'NP_ALWAYS_NULL',
     type: 'NP_ALWAYS_NULL',
@@ -163,5 +222,6 @@ function makeFinding(): Finding {
       fullPath: '/tmp/Example.java',
       startLine: 1,
     },
+    ...overrides,
   };
 }

--- a/src/test/L1.navigation.test.ts
+++ b/src/test/L1.navigation.test.ts
@@ -1,0 +1,72 @@
+import * as assert from 'assert';
+import { installVscodeMock, resetVscodeMock } from './helpers/mockVscode';
+import { Finding } from '../model/finding';
+
+installVscodeMock();
+
+describe('navigation', () => {
+  beforeEach(() => {
+    resetVscodeMock();
+  });
+
+  it('opens explicit go-to-code navigation in a focused permanent editor', async () => {
+    const shown: Array<{ uri: { fsPath: string }; options: Record<string, unknown> }> = [];
+    resetVscodeMock({
+      window: {
+        showTextDocument: async (
+          uri: { fsPath: string },
+          options: Record<string, unknown>
+        ) => {
+          shown.push({ uri, options });
+          return undefined;
+        },
+      },
+    } as never);
+    const { revealFindingSource } = await import('../commands/navigation');
+    const finding = makeFinding();
+
+    await revealFindingSource(finding);
+
+    assert.strictEqual(shown.length, 1);
+    assert.strictEqual(shown[0].uri.fsPath, '/tmp/Example.java');
+    assert.strictEqual(shown[0].options.preserveFocus, false);
+    assert.strictEqual(shown[0].options.preview, false);
+  });
+
+  it('can preview a selected finding source without stealing focus', async () => {
+    const shown: Array<{ uri: { fsPath: string }; options: Record<string, unknown> }> = [];
+    resetVscodeMock({
+      window: {
+        showTextDocument: async (
+          uri: { fsPath: string },
+          options: Record<string, unknown>
+        ) => {
+          shown.push({ uri, options });
+          return undefined;
+        },
+      },
+    } as never);
+    const { revealFindingSource } = await import('../commands/navigation');
+    const finding = makeFinding();
+
+    await revealFindingSource(finding, { preserveFocus: true, preview: true });
+
+    assert.strictEqual(shown.length, 1);
+    assert.strictEqual(shown[0].uri.fsPath, '/tmp/Example.java');
+    assert.strictEqual(shown[0].options.preserveFocus, true);
+    assert.strictEqual(shown[0].options.preview, true);
+  });
+});
+
+function makeFinding(): Finding {
+  return {
+    patternId: 'NP_ALWAYS_NULL',
+    type: 'NP_ALWAYS_NULL',
+    abbrev: 'NP',
+    message: 'Null pointer',
+    location: {
+      fullPath: '/tmp/Example.java',
+      startLine: 10,
+    },
+  };
+}

--- a/src/test/L1.navigation.test.ts
+++ b/src/test/L1.navigation.test.ts
@@ -56,9 +56,34 @@ describe('navigation', () => {
     assert.strictEqual(shown[0].options.preserveFocus, true);
     assert.strictEqual(shown[0].options.preview, true);
   });
+
+  it('does not open source when a preview request becomes stale', async () => {
+    const shown: Array<{ uri: { fsPath: string }; options: Record<string, unknown> }> = [];
+    resetVscodeMock({
+      window: {
+        showTextDocument: async (
+          uri: { fsPath: string },
+          options: Record<string, unknown>
+        ) => {
+          shown.push({ uri, options });
+          return undefined;
+        },
+      },
+    } as never);
+    const { revealFindingSource } = await import('../commands/navigation');
+    const finding = makeFinding();
+
+    await revealFindingSource(finding, {
+      preserveFocus: true,
+      preview: true,
+      isCurrentRequest: () => false,
+    });
+
+    assert.deepStrictEqual(shown, []);
+  });
 });
 
-function makeFinding(): Finding {
+function makeFinding(overrides: Partial<Finding> = {}): Finding {
   return {
     patternId: 'NP_ALWAYS_NULL',
     type: 'NP_ALWAYS_NULL',
@@ -68,5 +93,6 @@ function makeFinding(): Finding {
       fullPath: '/tmp/Example.java',
       startLine: 10,
     },
+    ...overrides,
   };
 }

--- a/src/test/L1.packageContributions.test.ts
+++ b/src/test/L1.packageContributions.test.ts
@@ -5,6 +5,17 @@ import * as path from 'path';
 type PackageJson = {
   contributes: {
     views: Record<string, Array<{ id: string; name: string; type?: string }>>;
+    configuration: Array<{
+      properties?: Record<
+        string,
+        {
+          type?: string;
+          default?: unknown;
+          markdownDescription?: string;
+          scope?: string;
+        }
+      >;
+    }>;
     commands: Array<{ command: string; title: string; icon?: string }>;
     menus: Record<string, Array<{ command?: string; when?: string; group?: string }>>;
   };
@@ -39,6 +50,26 @@ describe('package contributions', () => {
     assert.strictEqual(commands.get('spotbugs.exportSarif')?.title, 'Export SpotBugs Results (SARIF)');
     assert.strictEqual(commands.get('spotbugs.filterResults')?.title, 'Filter SpotBugs Results');
     assert.strictEqual(commands.get('spotbugs.resetResults')?.title, 'Reset SpotBugs Results');
+  });
+
+  it('contributes a setting for source reveal on result selection', () => {
+    const properties = Object.assign(
+      {},
+      ...manifest.contributes.configuration.map((group) => group.properties ?? {})
+    ) as Record<
+      string,
+      { type?: string; default?: unknown; markdownDescription?: string; scope?: string }
+    >;
+    const setting = properties['spotbugs.results.revealSourceOnSelection'];
+
+    assert.ok(setting);
+    assert.strictEqual(setting.type, 'boolean');
+    assert.strictEqual(setting.default, true);
+    assert.strictEqual(setting.scope, 'window');
+    assert.strictEqual(
+      setting.markdownDescription,
+      'Reveal the source location in a preview editor when selecting a SpotBugs finding in the results tree.'
+    );
   });
 
   it('adds finding leaf context fallbacks for source and details', () => {

--- a/src/test/helpers/mockVscode.ts
+++ b/src/test/helpers/mockVscode.ts
@@ -71,6 +71,20 @@ class MockThemeIcon {
   constructor(public readonly id: string) {}
 }
 
+class MockPosition {
+  constructor(
+    public readonly line: number,
+    public readonly character: number
+  ) {}
+}
+
+class MockRange {
+  constructor(
+    public readonly start: MockPosition,
+    public readonly end: MockPosition
+  ) {}
+}
+
 class MockTreeItem {
   public description?: string;
   public tooltip?: string;
@@ -96,8 +110,13 @@ type VscodeMock = {
   TreeItem: typeof MockTreeItem;
   TreeItemCollapsibleState: typeof MockTreeItemCollapsibleState;
   ThemeIcon: typeof MockThemeIcon;
+  Position: typeof MockPosition;
+  Range: typeof MockRange;
   workspace: {
     workspaceFolders: WorkspaceFolder[];
+    getConfiguration: (section?: string) => {
+      get: <T>(key: string) => T | undefined;
+    };
     getWorkspaceFolder: (uri: MockUri) => WorkspaceFolder | undefined;
     fs: {
       stat: (uri: MockUri) => Promise<unknown>;
@@ -126,7 +145,10 @@ type VscodeMock = {
       dispose: () => void;
       onDidDispose: (listener: () => unknown) => { dispose: () => void };
     };
+    showTextDocument: (uri: MockUri, options?: unknown) => Promise<unknown>;
     showInformationMessage: (message: string) => Promise<string | undefined>;
+    showWarningMessage: (message: string) => Promise<string | undefined>;
+    showErrorMessage: (message: string) => Promise<string | undefined>;
     activeTextEditor?: { document: { uri: MockUri } };
     registerWebviewViewProvider: (
       viewId: string,
@@ -192,6 +214,7 @@ export function resetVscodeMock(overrides: Partial<VscodeMock> = {}): VscodeMock
 function updateVscodeMock(target: VscodeMock, source: VscodeMock): void {
   Object.assign(target.workspace.fs, source.workspace.fs);
   target.workspace.workspaceFolders = source.workspace.workspaceFolders;
+  target.workspace.getConfiguration = source.workspace.getConfiguration;
   target.workspace.getWorkspaceFolder = source.workspace.getWorkspaceFolder;
   Object.assign(target.window, source.window);
   Object.assign(target.commands, source.commands);
@@ -205,6 +228,11 @@ function createVscodeMock(overrides: Partial<VscodeMock> = {}): VscodeMock {
   const workspaceFolders = overrides.workspace?.workspaceFolders ?? [];
   const workspace = {
     workspaceFolders,
+    getConfiguration:
+      overrides.workspace?.getConfiguration ??
+      (() => ({
+        get: () => undefined,
+      })),
     getWorkspaceFolder:
       overrides.workspace?.getWorkspaceFolder ??
       ((uri: MockUri) =>
@@ -238,6 +266,12 @@ function createVscodeMock(overrides: Partial<VscodeMock> = {}): VscodeMock {
       })),
     showInformationMessage:
       overrides.window?.showInformationMessage ?? (async () => undefined),
+    showWarningMessage:
+      overrides.window?.showWarningMessage ?? (async () => undefined),
+    showErrorMessage:
+      overrides.window?.showErrorMessage ?? (async () => undefined),
+    showTextDocument:
+      overrides.window?.showTextDocument ?? (async () => undefined),
     activeTextEditor: overrides.window?.activeTextEditor,
     registerWebviewViewProvider:
       overrides.window?.registerWebviewViewProvider ??
@@ -261,6 +295,8 @@ function createVscodeMock(overrides: Partial<VscodeMock> = {}): VscodeMock {
     TreeItem: MockTreeItem,
     TreeItemCollapsibleState: MockTreeItemCollapsibleState,
     ThemeIcon: MockThemeIcon,
+    Position: MockPosition,
+    Range: MockRange,
     workspace,
     window,
     commands: {

--- a/src/ui/findingInspectorController.ts
+++ b/src/ui/findingInspectorController.ts
@@ -10,6 +10,7 @@ import { Finding } from '../model/finding';
 export interface FindingSourcePreviewOptions {
   preserveFocus?: boolean;
   preview?: boolean;
+  isCurrentRequest: () => boolean;
 }
 
 export interface FindingInspectorTreeBindingOptions {
@@ -25,7 +26,10 @@ export function bindFindingInspectorToTree(
   inspectorState: FindingInspectorState,
   options: FindingInspectorTreeBindingOptions = {}
 ): Disposable {
+  let sourcePreviewRequestId = 0;
+
   return treeView.onDidChangeSelection(async (event) => {
+    const requestId = ++sourcePreviewRequestId;
     const selected = event.selection[0];
     if (selected instanceof FindingItem) {
       inspectorState.select(selected.finding);
@@ -33,6 +37,7 @@ export function bindFindingInspectorToTree(
         await options.revealFindingSource(selected.finding, {
           preserveFocus: true,
           preview: true,
+          isCurrentRequest: () => requestId === sourcePreviewRequestId,
         });
       }
       return;

--- a/src/ui/findingInspectorController.ts
+++ b/src/ui/findingInspectorController.ts
@@ -5,15 +5,36 @@ import {
   PatternGroupItem,
 } from './findingTreeItem';
 import { FindingInspectorState } from './findingInspectorState';
+import { Finding } from '../model/finding';
+
+export interface FindingSourcePreviewOptions {
+  preserveFocus?: boolean;
+  preview?: boolean;
+}
+
+export interface FindingInspectorTreeBindingOptions {
+  revealSourceOnSelection?: () => boolean;
+  revealFindingSource?: (
+    finding: Finding,
+    options: FindingSourcePreviewOptions
+  ) => Promise<void> | void;
+}
 
 export function bindFindingInspectorToTree(
   treeView: TreeView<TreeItem>,
-  inspectorState: FindingInspectorState
+  inspectorState: FindingInspectorState,
+  options: FindingInspectorTreeBindingOptions = {}
 ): Disposable {
-  return treeView.onDidChangeSelection((event) => {
+  return treeView.onDidChangeSelection(async (event) => {
     const selected = event.selection[0];
     if (selected instanceof FindingItem) {
       inspectorState.select(selected.finding);
+      if (options.revealSourceOnSelection?.() === true && options.revealFindingSource) {
+        await options.revealFindingSource(selected.finding, {
+          preserveFocus: true,
+          preview: true,
+        });
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary

- Reveal finding source when the Results selection changes.
- Ignore stale source previews after a newer selection.