### PR TITLE
chore: sync Java backend version

### DIFF
--- a/javaext/com.spotbugs.runner/META-INF/MANIFEST.MF
+++ b/javaext/com.spotbugs.runner/META-INF/MANIFEST.MF
@@ -2,7 +2,9 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Spotbugs Runner Plugin
 Bundle-SymbolicName: com.spotbugs.runner;singleton:=true
-Bundle-Version: 0.0.1.qualifier
+x-release-please-start-version: marker
+Bundle-Version: 0.5.2
+x-release-please-end: marker
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.jdt.ls.core,
  org.eclipse.core.runtime

--- a/javaext/com.spotbugs.runner/pom.xml
+++ b/javaext/com.spotbugs.runner/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.spotbugs</groupId>
         <artifactId>parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>0.5.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>com.spotbugs.runner</artifactId>

--- a/javaext/com.spotbugs.target/pom.xml
+++ b/javaext/com.spotbugs.target/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.spotbugs</groupId>
         <artifactId>parent</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>0.5.2</version>
     </parent>
     <artifactId>com.spotbugs.target</artifactId>
     <name>${base.name} :: Target Platform</name>

--- a/javaext/pom.xml
+++ b/javaext/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.spotbugs</groupId>
     <artifactId>parent</artifactId>
     <name>${base.name} :: Parent</name>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.5.2</version>
     <packaging>pom</packaging>
     <properties>
         <base.name>Java Spotbugs Runner</base.name>

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,28 @@
   "packages": {
     ".": {
       "release-type": "node",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "xml",
+          "path": "javaext/pom.xml",
+          "xpath": "/*[local-name()='project']/*[local-name()='version']"
+        },
+        {
+          "type": "xml",
+          "path": "javaext/com.spotbugs.runner/pom.xml",
+          "xpath": "/*[local-name()='project']/*[local-name()='parent']/*[local-name()='version']"
+        },
+        {
+          "type": "xml",
+          "path": "javaext/com.spotbugs.target/pom.xml",
+          "xpath": "/*[local-name()='project']/*[local-name()='parent']/*[local-name()='version']"
+        },
+        {
+          "type": "generic",
+          "path": "javaext/com.spotbugs.runner/META-INF/MANIFEST.MF"
+        }
+      ]
     }
   }
 }

--- a/scripts/buildJdtlsExt.js
+++ b/scripts/buildJdtlsExt.js
@@ -1,8 +1,16 @@
 const cp = require('child_process');
 const path = require('path');
 const fse = require('fs-extra');
+const { assertJavaBackendVersions } = require('./validateJavaBackendVersion');
 
 const server_dir = path.resolve('./javaext');
+
+try {
+  assertJavaBackendVersions(path.resolve('.'));
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}
 
 // Run Maven build
 cp.execSync(mvnw() + ' clean package', { cwd: server_dir, stdio: 'inherit' });

--- a/scripts/validateJavaBackendVersion.js
+++ b/scripts/validateJavaBackendVersion.js
@@ -1,0 +1,120 @@
+const fs = require('fs');
+const path = require('path');
+
+function assertJavaBackendVersions(rootDir = process.cwd()) {
+  const versions = readJavaBackendVersions(rootDir);
+  const errors = validateJavaBackendVersions(versions);
+
+  if (errors.length > 0) {
+    throw new Error(`Java backend version validation failed:\n${errors.join('\n')}`);
+  }
+}
+
+function readJavaBackendVersions(rootDir) {
+  const packageJson = JSON.parse(readFile(rootDir, 'package.json'));
+  const rootPom = readFile(rootDir, 'javaext/pom.xml');
+  const runnerPom = readFile(rootDir, 'javaext/com.spotbugs.runner/pom.xml');
+  const targetPom = readFile(rootDir, 'javaext/com.spotbugs.target/pom.xml');
+  const manifest = readFile(rootDir, 'javaext/com.spotbugs.runner/META-INF/MANIFEST.MF');
+
+  return {
+    packageVersion: packageJson.version,
+    rootPomVersion: extractFirstTag(rootPom, 'version', 'javaext/pom.xml'),
+    runnerParentVersion: extractParentVersion(
+      runnerPom,
+      'javaext/com.spotbugs.runner/pom.xml'
+    ),
+    targetParentVersion: extractParentVersion(
+      targetPom,
+      'javaext/com.spotbugs.target/pom.xml'
+    ),
+    bundleVersion: extractBundleVersion(manifest),
+  };
+}
+
+function validateJavaBackendVersions(versions) {
+  const expected = versions.packageVersion;
+  const checks = [
+    ['javaext/pom.xml version', versions.rootPomVersion],
+    ['javaext/com.spotbugs.runner/pom.xml parent version', versions.runnerParentVersion],
+    ['javaext/com.spotbugs.target/pom.xml parent version', versions.targetParentVersion],
+    ['javaext/com.spotbugs.runner/META-INF/MANIFEST.MF Bundle-Version', versions.bundleVersion],
+  ];
+  const errors = [];
+
+  if (!/^\d+\.\d+\.\d+$/.test(expected)) {
+    errors.push(`package.json version must be X.Y.Z for Java backend metadata but was ${expected}`);
+  }
+
+  for (const [label, actual] of checks) {
+    if (actual.includes('SNAPSHOT')) {
+      errors.push(`${label} must be ${expected} but was ${actual}; SNAPSHOT is not allowed`);
+      continue;
+    }
+    if (actual.includes('qualifier')) {
+      errors.push(`${label} must be ${expected} but was ${actual}; qualifier is not allowed`);
+      continue;
+    }
+    if (actual !== expected) {
+      errors.push(`${label} must be ${expected} but was ${actual}`);
+    }
+  }
+
+  return errors;
+}
+
+function readFile(rootDir, relativePath) {
+  return fs.readFileSync(path.join(rootDir, relativePath), 'utf8');
+}
+
+function extractParentVersion(xml, label) {
+  const parentMatch = xml.match(/<parent(?:\s[^>]*)?>([\s\S]*?)<\/parent>/);
+  if (!parentMatch) {
+    throw new Error(`${label} is missing <parent>`);
+  }
+  return extractFirstTag(parentMatch[1], 'version', `${label} parent`);
+}
+
+function extractFirstTag(xml, tagName, label) {
+  const tagPattern = new RegExp(`<${tagName}(?:\\s[^>]*)?>([^<]+)</${tagName}>`);
+  const match = xml.match(tagPattern);
+  if (!match) {
+    throw new Error(`${label} is missing <${tagName}>`);
+  }
+  return match[1].trim();
+}
+
+function extractBundleVersion(manifest) {
+  const match = manifest.match(/^Bundle-Version:\s*(\S+)\s*$/m);
+  if (!match) {
+    throw new Error('javaext/com.spotbugs.runner/META-INF/MANIFEST.MF is missing Bundle-Version');
+  }
+  return match[1].trim();
+}
+
+function parseRootArg(argv) {
+  const rootIndex = argv.indexOf('--root');
+  if (rootIndex === -1) {
+    return process.cwd();
+  }
+  const root = argv[rootIndex + 1];
+  if (!root) {
+    throw new Error('--root requires a path');
+  }
+  return root;
+}
+
+if (require.main === module) {
+  try {
+    assertJavaBackendVersions(parseRootArg(process.argv.slice(2)));
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  assertJavaBackendVersions,
+  readJavaBackendVersions,
+  validateJavaBackendVersions,
+};


### PR DESCRIPTION
## Summary

- Keep Java backend versions synchronized across Maven and OSGi metadata.
- Add build and release validation for version consistency.