### PR TITLE
fix(inspector): use source navigation in inspector title toolbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -283,24 +283,9 @@
           "group": "3_results@3"
         },
         {
-          "command": "spotbugs.runWorkspace",
+          "command": "spotbugs.revealFindingSource",
           "when": "view == spotbugs-inspector-view",
-          "group": "navigation"
-        },
-        {
-          "command": "spotbugs.exportSarif",
-          "when": "view == spotbugs-inspector-view",
-          "group": "2_spotbugs@1"
-        },
-        {
-          "command": "spotbugs.filterResults",
-          "when": "view == spotbugs-inspector-view",
-          "group": "2_spotbugs@2"
-        },
-        {
-          "command": "spotbugs.resetResults",
-          "when": "view == spotbugs-inspector-view",
-          "group": "2_spotbugs@3"
+          "group": "navigation@1"
         }
       ],
       "explorer/context": [

--- a/src/test/L1.packageContributions.test.ts
+++ b/src/test/L1.packageContributions.test.ts
@@ -160,7 +160,7 @@ describe('package contributions', () => {
     );
   });
 
-  it('adds result exploration actions only to the results view title', () => {
+  it('keeps result exploration actions on results and source navigation on inspector titles', () => {
     const titleMenus = manifest.contributes.menus['view/title'];
 
     assert.deepStrictEqual(commandIdsForView(titleMenus, 'spotbugs-view'), [
@@ -174,10 +174,7 @@ describe('package contributions', () => {
       'spotbugs.clearSearch',
     ]);
     assert.deepStrictEqual(commandIdsForView(titleMenus, 'spotbugs-inspector-view'), [
-      'spotbugs.runWorkspace',
-      'spotbugs.exportSarif',
-      'spotbugs.filterResults',
-      'spotbugs.resetResults',
+      'spotbugs.revealFindingSource',
     ]);
 
     const resultMenus = titleMenus.filter((entry) => entry.when === 'view == spotbugs-view');


### PR DESCRIPTION
## Summary

- Route the Inspector title action through source navigation.
- Keep the toolbar contribution aligned with finding navigation behavior.