### PR TITLE
test: prune redundant analysis coverage

### DIFF
--- a/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisActionTest.java
+++ b/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisActionTest.java
@@ -2,15 +2,10 @@ package com.spotbugs.vscode.runner.internal.command;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -21,18 +16,15 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.spotbugs.vscode.runner.api.BugInfo;
 import com.spotbugs.vscode.runner.internal.AnalyzerService;
-import com.spotbugs.vscode.runner.internal.config.AnalysisConfig;
-import com.spotbugs.vscode.runner.internal.config.Effort;
 
 public class RunAnalysisActionTest {
 
     @Test
-    public void executeWrapsAnalyzerFailuresAsAnalysisFailedEnvelope() {
+    public void executeWrapsAnalyzerFailuresWithRootCauseAsAnalysisFailedEnvelope() {
         RunAnalysisAction action = new RunAnalysisAction(() -> new AnalyzerService() {
             @Override
-            public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths)
-                    throws IOException, InterruptedException {
-                throw new IOException("analysis boom");
+            public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths) {
+                throw new RuntimeException("outer", new IllegalStateException("inner"));
             }
         });
 
@@ -41,43 +33,7 @@ public class RunAnalysisActionTest {
         assertEquals(2, response.get("schemaVersion").getAsInt());
         assertEquals(0, response.getAsJsonArray("results").size());
         assertEquals("ANALYSIS_FAILED", firstError(response).get("code").getAsString());
-        assertEquals("analysis boom", firstError(response).get("message").getAsString());
-        assertEquals(0, response.getAsJsonObject("stats").get("findingCount").getAsInt());
-    }
-
-    @Test
-    public void executeWrapsAnalyzerCancellationsAsAnalysisCancelledEnvelope() {
-        RunAnalysisAction action = new RunAnalysisAction(() -> new AnalyzerService() {
-            @Override
-            public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths)
-                    throws IOException, InterruptedException {
-                throw new CancellationException("Command cancelled");
-            }
-        });
-
-        JsonObject response = executeDefault(action);
-
-        assertEquals(2, response.get("schemaVersion").getAsInt());
-        assertEquals(0, response.getAsJsonArray("results").size());
-        assertEquals("ANALYSIS_CANCELLED", firstError(response).get("code").getAsString());
-        assertEquals("Command cancelled", firstError(response).get("message").getAsString());
-        assertEquals(0, response.getAsJsonObject("stats").get("findingCount").getAsInt());
-    }
-
-    @Test
-    public void executeReportsSuccessFindingCountFromResults() {
-        RunAnalysisAction action = new RunAnalysisAction(() -> new AnalyzerService() {
-            @Override
-            public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths) {
-                return Collections.emptyList();
-            }
-        });
-
-        JsonObject response = executeDefault(action);
-
-        assertEquals(2, response.get("schemaVersion").getAsInt());
-        assertEquals(0, response.getAsJsonArray("errors").size());
-        assertEquals(0, response.getAsJsonArray("results").size());
+        assertEquals("inner", firstError(response).get("message").getAsString());
         assertEquals(0, response.getAsJsonObject("stats").get("findingCount").getAsInt());
     }
 
@@ -99,32 +55,11 @@ public class RunAnalysisActionTest {
     }
 
     @Test
-    public void executeTreatsMissingBlankAndNonStringConfigAsDefaultConfig() {
-        List<CapturingAnalyzerService> analyzers = new ArrayList<>();
-        RunAnalysisAction action = new RunAnalysisAction(() -> {
-            CapturingAnalyzerService analyzer = new CapturingAnalyzerService();
-            analyzers.add(analyzer);
-            return analyzer;
-        });
-
-        execute(action, "/workspace/build/classes");
-        execute(action, "/workspace/build/classes", "   ");
-        execute(action, "/workspace/build/classes", Integer.valueOf(7));
-
-        assertEquals(3, analyzers.size());
-        for (CapturingAnalyzerService analyzer : analyzers) {
-            assertEquals(1, analyzer.analyzeCalls);
-            assertNotNull(analyzer.config);
-            assertEquals(Effort.DEFAULT, analyzer.config.getEffort());
-        }
-    }
-
-    @Test
     public void executeReturnsInvalidArgumentForMissingEmptyOrNonStringTargetPath() {
         AtomicInteger analyzerCreations = new AtomicInteger(0);
         RunAnalysisAction action = new RunAnalysisAction(() -> {
             analyzerCreations.incrementAndGet();
-            return new CapturingAnalyzerService();
+            return emptyAnalyzer();
         });
 
         JsonObject missing = execute(action);
@@ -145,7 +80,7 @@ public class RunAnalysisActionTest {
         AtomicInteger analyzerCreations = new AtomicInteger(0);
         RunAnalysisAction action = new RunAnalysisAction(() -> {
             analyzerCreations.incrementAndGet();
-            return new CapturingAnalyzerService();
+            return emptyAnalyzer();
         });
 
         JsonObject response = execute(action, "/workspace/build/classes", "{");
@@ -156,71 +91,6 @@ public class RunAnalysisActionTest {
         assertEquals("Invalid config JSON", firstError(response).get("message").getAsString());
         assertFalse(response.has("stats"));
         assertEquals(0, analyzerCreations.get());
-    }
-
-    @Test
-    public void executeReturnsConfigValidationErrorsWithoutInvokingAnalyzer() {
-        AtomicInteger analyzerCreations = new AtomicInteger(0);
-        RunAnalysisAction action = new RunAnalysisAction(() -> {
-            analyzerCreations.incrementAndGet();
-            return new CapturingAnalyzerService();
-        });
-        String missingPath = new File(
-                System.getProperty("java.io.tmpdir"),
-                "spotbugs-missing-" + System.nanoTime() + ".jar"
-        ).getAbsolutePath();
-        String configJson = "{\"extraAuxClasspaths\":[\"" + jsonString(missingPath) + "\"]}";
-
-        JsonObject response = execute(action, "/workspace/build/classes", configJson);
-
-        assertEquals(2, response.get("schemaVersion").getAsInt());
-        assertEquals("CFG_AUX_CLASSPATH_NOT_FOUND", firstError(response).get("code").getAsString());
-        assertTrue(firstError(response).get("message").getAsString().contains(missingPath));
-        assertFalse(response.has("stats"));
-        assertEquals(0, analyzerCreations.get());
-    }
-
-    @Test
-    public void executeNormalizesNullAnalyzerResultsToEmptySuccessResults() {
-        RunAnalysisAction action = new RunAnalysisAction(() -> new AnalyzerService() {
-            @Override
-            public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths) {
-                return null;
-            }
-        });
-
-        JsonObject response = executeDefault(action);
-
-        assertEquals(2, response.get("schemaVersion").getAsInt());
-        assertEquals(0, response.getAsJsonArray("errors").size());
-        assertEquals(0, response.getAsJsonArray("results").size());
-        assertEquals(0, response.getAsJsonObject("stats").get("findingCount").getAsInt());
-    }
-
-    @Test
-    public void executeWrapsInterruptedExceptionsAsCancelledAndRestoresInterruptStatus() {
-        RunAnalysisAction action = new RunAnalysisAction(() -> new AnalyzerService() {
-            @Override
-            public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths)
-                    throws IOException, InterruptedException {
-                throw new InterruptedException("stop");
-            }
-        });
-
-        JsonObject response = null;
-        boolean wasInterrupted = false;
-        try {
-            response = executeDefault(action);
-            wasInterrupted = Thread.currentThread().isInterrupted();
-        } finally {
-            Thread.interrupted();
-        }
-
-        assertTrue(wasInterrupted);
-        assertNotNull(response);
-        assertEquals("ANALYSIS_CANCELLED", firstError(response).get("code").getAsString());
-        assertEquals("Command cancelled", firstError(response).get("message").getAsString());
-        assertEquals(0, response.getAsJsonObject("stats").get("findingCount").getAsInt());
     }
 
     @Test
@@ -241,22 +111,6 @@ public class RunAnalysisActionTest {
         assertEquals("Command cancelled", firstError(response).get("message").getAsString());
         assertTrue(response.has("stats"));
         assertEquals(0, response.getAsJsonObject("stats").get("findingCount").getAsInt());
-    }
-
-    @Test
-    public void executeUsesRootCauseMessageForAnalysisFailures() {
-        RunAnalysisAction action = new RunAnalysisAction(() -> new AnalyzerService() {
-            @Override
-            public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths)
-                    throws IOException, InterruptedException {
-                throw new RuntimeException("outer", new IllegalStateException("inner"));
-            }
-        });
-
-        JsonObject response = executeDefault(action);
-
-        assertEquals("ANALYSIS_FAILED", firstError(response).get("code").getAsString());
-        assertEquals("inner", firstError(response).get("message").getAsString());
     }
 
     @Test
@@ -313,20 +167,13 @@ public class RunAnalysisActionTest {
         return value.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 
-    private static class CapturingAnalyzerService extends AnalyzerService {
-        private AnalysisConfig config;
-        private int analyzeCalls;
-
-        @Override
-        public void setConfiguration(AnalysisConfig cfg) {
-            this.config = cfg;
-        }
-
-        @Override
-        public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths) {
-            analyzeCalls++;
-            return Collections.emptyList();
-        }
+    private static AnalyzerService emptyAnalyzer() {
+        return new AnalyzerService() {
+            @Override
+            public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths) {
+                return Collections.emptyList();
+            }
+        };
     }
 
     private static final class CountingAnalyzerService extends AnalyzerService {

--- a/src/test/L1.analysisRunner.test.ts
+++ b/src/test/L1.analysisRunner.test.ts
@@ -279,241 +279,136 @@ describe('analysisRunner', () => {
     }
   });
 
-  it('clears workspace progress tree state on cancellation without touching diagnostics', async () => {
-    const vscode = installVscodeMock();
-    resetVscodeMock({
-      workspace: {
-        workspaceFolders: [
-          {
-            name: 'workspace',
-            uri: vscode.Uri.file('/workspace') as any,
-          },
-        ],
-      } as any,
-    });
-    const workspaceBuildService =
-      require('../services/workspaceBuildService') as typeof import('../services/workspaceBuildService');
-    const projectDiscovery =
-      require('../workspace/projectDiscovery') as typeof import('../workspace/projectDiscovery');
-    const analysisService =
-      require('../services/analysisService') as typeof import('../services/analysisService');
-    const originalBuildWorkspaceAuto = workspaceBuildService.buildWorkspaceAuto;
-    const originalGetWorkspaceProjectDiscovery = projectDiscovery.getWorkspaceProjectDiscovery;
-    const originalAnalyzeWorkspaceFromProjectsDetailed =
-      analysisService.analyzeWorkspaceFromProjectsDetailed;
-
-    workspaceBuildService.buildWorkspaceAuto = (async () => 0) as typeof workspaceBuildService.buildWorkspaceAuto;
-    projectDiscovery.getWorkspaceProjectDiscovery = (async () => ({
-      projectUris: ['file:///workspace/project-a'],
-      issues: [],
-    })) as typeof projectDiscovery.getWorkspaceProjectDiscovery;
-    analysisService.analyzeWorkspaceFromProjectsDetailed = (async () => ({
-      results: [],
-      cancelled: true,
-      context: {
-        resolutionIssues: [],
-      },
-    })) as typeof analysisService.analyzeWorkspaceFromProjectsDetailed;
-
-    try {
-      const runner =
-        require('../orchestration/analysisRunner') as typeof import('../orchestration/analysisRunner');
-      const calls: string[] = [];
-
-      await runner.runWorkspaceAnalysis({
-        config: { getAnalysisSettings: () => ({}) } as any,
-        tree: {
-          showWorkspaceProgress: (projectUris: string[]) =>
-            calls.push(`progress:${projectUris.length}`),
-          updateProjectStatus: () => undefined,
-          showWorkspaceCancelled: () => calls.push('cancelled'),
-          showWorkspaceResults: (projectResults: unknown[]) =>
-            calls.push(`workspaceResults:${projectResults.length}`),
-        } as any,
-        diagnostics: {
-          replaceAll: (findings: unknown[]) => calls.push(`diagnostics:${findings.length}`),
-        } as any,
-        notifier: {
-          info: () => undefined,
-          warn: () => undefined,
-          error: () => undefined,
+  for (const scenario of [
+    {
+      name: 'service cancellation flag',
+      tokenCancelled: false,
+      analysisResult: () => ({
+        results: [],
+        cancelled: true,
+        context: {
+          resolutionIssues: [],
         },
-      });
-
-      assert.deepStrictEqual(calls, ['progress:1', 'cancelled']);
-    } finally {
-      workspaceBuildService.buildWorkspaceAuto = originalBuildWorkspaceAuto;
-      projectDiscovery.getWorkspaceProjectDiscovery = originalGetWorkspaceProjectDiscovery;
-      analysisService.analyzeWorkspaceFromProjectsDetailed =
-        originalAnalyzeWorkspaceFromProjectsDetailed;
-    }
-  });
-
-  it('clears workspace progress tree state on VS Code token cancellation', async () => {
-    const vscode = installVscodeMock();
-    resetVscodeMock({
-      workspace: {
-        workspaceFolders: [
+      }),
+    },
+    {
+      name: 'VS Code token cancellation',
+      tokenCancelled: true,
+      analysisResult: () => ({
+        results: [],
+        cancelled: false,
+        context: {
+          resolutionIssues: [],
+        },
+      }),
+    },
+    {
+      name: 'backend cancellation envelope',
+      tokenCancelled: false,
+      analysisResult: () => ({
+        results: [
           {
-            name: 'workspace',
-            uri: vscode.Uri.file('/workspace') as any,
+            projectUri: 'file:///workspace/project-a',
+            findings: [],
+            error: 'SpotBugs analysis failed: [ANALYSIS_CANCELLED] Command cancelled',
+            errorCode: 'ANALYSIS_CANCELLED',
           },
         ],
-      } as any,
-      window: {
-        withProgress: async (
-          _options: unknown,
-          task: (
-            progress: { report: () => void },
-            token: { isCancellationRequested: boolean }
-          ) => Promise<unknown>
-        ) =>
-          task(
+        cancelled: false,
+        context: {
+          resolutionIssues: [],
+        },
+      }),
+    },
+  ]) {
+    it(`clears workspace progress tree state on ${scenario.name}`, async () => {
+      const vscode = installVscodeMock();
+      resetVscodeMock({
+        workspace: {
+          workspaceFolders: [
             {
-              report: () => undefined,
+              name: 'workspace',
+              uri: vscode.Uri.file('/workspace') as any,
             },
-            {
-              isCancellationRequested: true,
+          ],
+        } as any,
+        ...(scenario.tokenCancelled
+          ? {
+              window: {
+                withProgress: async (
+                  _options: unknown,
+                  task: (
+                    progress: { report: () => void },
+                    token: { isCancellationRequested: boolean }
+                  ) => Promise<unknown>
+                ) =>
+                  task(
+                    {
+                      report: () => undefined,
+                    },
+                    {
+                      isCancellationRequested: true,
+                    }
+                  ),
+              } as any,
             }
-          ),
-      } as any,
-    });
-    const workspaceBuildService =
-      require('../services/workspaceBuildService') as typeof import('../services/workspaceBuildService');
-    const projectDiscovery =
-      require('../workspace/projectDiscovery') as typeof import('../workspace/projectDiscovery');
-    const analysisService =
-      require('../services/analysisService') as typeof import('../services/analysisService');
-    const originalBuildWorkspaceAuto = workspaceBuildService.buildWorkspaceAuto;
-    const originalGetWorkspaceProjectDiscovery = projectDiscovery.getWorkspaceProjectDiscovery;
-    const originalAnalyzeWorkspaceFromProjectsDetailed =
-      analysisService.analyzeWorkspaceFromProjectsDetailed;
-
-    workspaceBuildService.buildWorkspaceAuto = (async () => 0) as typeof workspaceBuildService.buildWorkspaceAuto;
-    projectDiscovery.getWorkspaceProjectDiscovery = (async () => ({
-      projectUris: ['file:///workspace/project-a'],
-      issues: [],
-    })) as typeof projectDiscovery.getWorkspaceProjectDiscovery;
-    analysisService.analyzeWorkspaceFromProjectsDetailed = (async () => ({
-      results: [],
-      cancelled: false,
-      context: {
-        resolutionIssues: [],
-      },
-    })) as typeof analysisService.analyzeWorkspaceFromProjectsDetailed;
-
-    try {
-      const runner =
-        require('../orchestration/analysisRunner') as typeof import('../orchestration/analysisRunner');
-      const calls: string[] = [];
-
-      await runner.runWorkspaceAnalysis({
-        config: { getAnalysisSettings: () => ({}) } as any,
-        tree: {
-          showWorkspaceProgress: (projectUris: string[]) =>
-            calls.push(`progress:${projectUris.length}`),
-          updateProjectStatus: () => undefined,
-          showWorkspaceCancelled: () => calls.push('cancelled'),
-          showWorkspaceResults: (projectResults: unknown[]) =>
-            calls.push(`workspaceResults:${projectResults.length}`),
-        } as any,
-        diagnostics: {
-          replaceAll: (findings: unknown[]) => calls.push(`diagnostics:${findings.length}`),
-        } as any,
-        notifier: {
-          info: () => undefined,
-          warn: () => undefined,
-          error: () => undefined,
-        },
+          : {}),
       });
+      const workspaceBuildService =
+        require('../services/workspaceBuildService') as typeof import('../services/workspaceBuildService');
+      const projectDiscovery =
+        require('../workspace/projectDiscovery') as typeof import('../workspace/projectDiscovery');
+      const analysisService =
+        require('../services/analysisService') as typeof import('../services/analysisService');
+      const originalBuildWorkspaceAuto = workspaceBuildService.buildWorkspaceAuto;
+      const originalGetWorkspaceProjectDiscovery = projectDiscovery.getWorkspaceProjectDiscovery;
+      const originalAnalyzeWorkspaceFromProjectsDetailed =
+        analysisService.analyzeWorkspaceFromProjectsDetailed;
 
-      assert.deepStrictEqual(calls, ['progress:1', 'cancelled']);
-    } finally {
-      workspaceBuildService.buildWorkspaceAuto = originalBuildWorkspaceAuto;
-      projectDiscovery.getWorkspaceProjectDiscovery = originalGetWorkspaceProjectDiscovery;
-      analysisService.analyzeWorkspaceFromProjectsDetailed =
-        originalAnalyzeWorkspaceFromProjectsDetailed;
-    }
-  });
+      workspaceBuildService.buildWorkspaceAuto = (async () => 0) as typeof workspaceBuildService.buildWorkspaceAuto;
+      projectDiscovery.getWorkspaceProjectDiscovery = (async () => ({
+        projectUris: ['file:///workspace/project-a'],
+        issues: [],
+      })) as typeof projectDiscovery.getWorkspaceProjectDiscovery;
+      analysisService.analyzeWorkspaceFromProjectsDetailed = (async () =>
+        scenario.analysisResult()) as typeof analysisService.analyzeWorkspaceFromProjectsDetailed;
 
-  it('clears workspace progress tree state on backend cancellation envelopes', async () => {
-    const vscode = installVscodeMock();
-    resetVscodeMock({
-      workspace: {
-        workspaceFolders: [
-          {
-            name: 'workspace',
-            uri: vscode.Uri.file('/workspace') as any,
+      try {
+        const runner =
+          require('../orchestration/analysisRunner') as typeof import('../orchestration/analysisRunner');
+        const calls: string[] = [];
+        const errors: string[] = [];
+
+        await runner.runWorkspaceAnalysis({
+          config: { getAnalysisSettings: () => ({}) } as any,
+          tree: {
+            showWorkspaceProgress: (projectUris: string[]) =>
+              calls.push(`progress:${projectUris.length}`),
+            updateProjectStatus: () => undefined,
+            showWorkspaceCancelled: () => calls.push('cancelled'),
+            showWorkspaceResults: (projectResults: unknown[]) =>
+              calls.push(`workspaceResults:${projectResults.length}`),
+          } as any,
+          diagnostics: {
+            replaceAll: (findings: unknown[]) => calls.push(`diagnostics:${findings.length}`),
+          } as any,
+          notifier: {
+            info: () => undefined,
+            warn: () => undefined,
+            error: (message: string) => errors.push(message),
           },
-        ],
-      } as any,
+        });
+
+        assert.deepStrictEqual(calls, ['progress:1', 'cancelled']);
+        assert.deepStrictEqual(errors, []);
+      } finally {
+        workspaceBuildService.buildWorkspaceAuto = originalBuildWorkspaceAuto;
+        projectDiscovery.getWorkspaceProjectDiscovery = originalGetWorkspaceProjectDiscovery;
+        analysisService.analyzeWorkspaceFromProjectsDetailed =
+          originalAnalyzeWorkspaceFromProjectsDetailed;
+      }
     });
-    const workspaceBuildService =
-      require('../services/workspaceBuildService') as typeof import('../services/workspaceBuildService');
-    const projectDiscovery =
-      require('../workspace/projectDiscovery') as typeof import('../workspace/projectDiscovery');
-    const analysisService =
-      require('../services/analysisService') as typeof import('../services/analysisService');
-    const originalBuildWorkspaceAuto = workspaceBuildService.buildWorkspaceAuto;
-    const originalGetWorkspaceProjectDiscovery = projectDiscovery.getWorkspaceProjectDiscovery;
-    const originalAnalyzeWorkspaceFromProjectsDetailed =
-      analysisService.analyzeWorkspaceFromProjectsDetailed;
-
-    workspaceBuildService.buildWorkspaceAuto = (async () => 0) as typeof workspaceBuildService.buildWorkspaceAuto;
-    projectDiscovery.getWorkspaceProjectDiscovery = (async () => ({
-      projectUris: ['file:///workspace/project-a'],
-      issues: [],
-    })) as typeof projectDiscovery.getWorkspaceProjectDiscovery;
-    analysisService.analyzeWorkspaceFromProjectsDetailed = (async () => ({
-      results: [
-        {
-          projectUri: 'file:///workspace/project-a',
-          findings: [],
-          error: 'SpotBugs analysis failed: [ANALYSIS_CANCELLED] Command cancelled',
-          errorCode: 'ANALYSIS_CANCELLED',
-        },
-      ],
-      cancelled: false,
-      context: {
-        resolutionIssues: [],
-      },
-    })) as typeof analysisService.analyzeWorkspaceFromProjectsDetailed;
-
-    try {
-      const runner =
-        require('../orchestration/analysisRunner') as typeof import('../orchestration/analysisRunner');
-      const calls: string[] = [];
-      const errors: string[] = [];
-
-      await runner.runWorkspaceAnalysis({
-        config: { getAnalysisSettings: () => ({}) } as any,
-        tree: {
-          showWorkspaceProgress: (projectUris: string[]) =>
-            calls.push(`progress:${projectUris.length}`),
-          updateProjectStatus: () => undefined,
-          showWorkspaceCancelled: () => calls.push('cancelled'),
-          showWorkspaceResults: (projectResults: unknown[]) =>
-            calls.push(`workspaceResults:${projectResults.length}`),
-        } as any,
-        diagnostics: {
-          replaceAll: (findings: unknown[]) => calls.push(`diagnostics:${findings.length}`),
-        } as any,
-        notifier: {
-          info: () => undefined,
-          warn: () => undefined,
-          error: (message: string) => errors.push(message),
-        },
-      });
-
-      assert.deepStrictEqual(calls, ['progress:1', 'cancelled']);
-      assert.deepStrictEqual(errors, []);
-    } finally {
-      workspaceBuildService.buildWorkspaceAuto = originalBuildWorkspaceAuto;
-      projectDiscovery.getWorkspaceProjectDiscovery = originalGetWorkspaceProjectDiscovery;
-      analysisService.analyzeWorkspaceFromProjectsDetailed =
-        originalAnalyzeWorkspaceFromProjectsDetailed;
-    }
-  });
+  }
 
   it('renders workspace analysis exceptions as failure state without touching diagnostics', async () => {
     const vscode = installVscodeMock();

--- a/src/test/L1.analysisService.test.ts
+++ b/src/test/L1.analysisService.test.ts
@@ -5,6 +5,29 @@ function clearModule(moduleId: string): void {
   delete require.cache[require.resolve(moduleId)];
 }
 
+function backendErrorEnvelope(
+  code: string,
+  message: string,
+  targetPath: string,
+  durationMs = 9
+): string {
+  return JSON.stringify({
+    schemaVersion: 2,
+    results: [],
+    errors: [
+      {
+        code,
+        message,
+      },
+    ],
+    stats: {
+      target: targetPath,
+      durationMs,
+      spotbugsVersion: '4.8.3',
+    },
+  });
+}
+
 describe('analysisService', () => {
   beforeEach(() => {
     installVscodeMock();
@@ -212,21 +235,11 @@ describe('analysisService', () => {
       issues: [],
     })) as typeof resolverModule.resolveFileAnalysisTargetDetailed;
     spotbugsClient.runSpotBugsAnalysis = (async () =>
-      JSON.stringify({
-        schemaVersion: 2,
-        results: [],
-        errors: [
-          {
-            code: 'ANALYSIS_FAILED',
-            message: 'boom',
-          },
-        ],
-        stats: {
-          target: '/workspace/build/classes',
-          durationMs: 9,
-          spotbugsVersion: '4.8.3',
-        },
-      })) as typeof spotbugsClient.runSpotBugsAnalysis;
+      backendErrorEnvelope(
+        'ANALYSIS_FAILED',
+        'boom',
+        '/workspace/build/classes'
+      )) as typeof spotbugsClient.runSpotBugsAnalysis;
 
     const result = await service.analyzeFileDetailed(
       { getAnalysisSettings: () => ({ effort: 'default' }) } as any,
@@ -242,60 +255,6 @@ describe('analysisService', () => {
       'SpotBugs analysis failed: [ANALYSIS_FAILED] boom'
     );
     assert.strictEqual(result.outcome.errors?.[0]?.code, 'ANALYSIS_FAILED');
-    assert.strictEqual(result.outcome.stats?.target, '/workspace/build/classes');
-    assert.strictEqual(result.outcome.schemaVersion, 2);
-  });
-
-  it('preserves backend ANALYSIS_CANCELLED envelopes in file analysis outcomes', async () => {
-    const vscode = installVscodeMock();
-    const resolverModule =
-      require('../workspace/analysisTargetResolver') as typeof import('../workspace/analysisTargetResolver');
-    const spotbugsClient =
-      require('../lsp/spotbugsClient') as typeof import('../lsp/spotbugsClient');
-    const service = require('../services/analysisService') as typeof import('../services/analysisService');
-
-    resolverModule.resolveFileAnalysisTargetDetailed = (async () => ({
-      resolution: {
-        status: 'ok',
-        target: {
-          targetPath: '/workspace/build/classes',
-          preferredProject: vscode.Uri.file('/workspace/src/Foo.java') as any,
-          targetResolutionRoots: ['/workspace/build/classes'],
-          runtimeClasspaths: ['/workspace/build/classes'],
-          sourcepaths: ['/workspace/src/main/java'],
-        },
-      },
-      issues: [],
-    })) as typeof resolverModule.resolveFileAnalysisTargetDetailed;
-    spotbugsClient.runSpotBugsAnalysis = (async () =>
-      JSON.stringify({
-        schemaVersion: 2,
-        results: [],
-        errors: [
-          {
-            code: 'ANALYSIS_CANCELLED',
-            message: 'Command cancelled',
-          },
-        ],
-        stats: {
-          target: '/workspace/build/classes',
-          durationMs: 4,
-          spotbugsVersion: '4.8.3',
-        },
-      })) as typeof spotbugsClient.runSpotBugsAnalysis;
-
-    const result = await service.analyzeFileDetailed(
-      { getAnalysisSettings: () => ({ effort: 'default' }) } as any,
-      vscode.Uri.file('/workspace/src/Foo.java') as any
-    );
-
-    assert.deepStrictEqual(result.outcome.findings, []);
-    assert.strictEqual(result.outcome.failure?.kind, 'analysis-error');
-    assert.strictEqual(result.outcome.failure?.code, 'ANALYSIS_CANCELLED');
-    assert.strictEqual(
-      result.outcome.failure?.message,
-      'SpotBugs analysis failed: [ANALYSIS_CANCELLED] Command cancelled'
-    );
     assert.strictEqual(result.outcome.stats?.target, '/workspace/build/classes');
     assert.strictEqual(result.outcome.schemaVersion, 2);
   });
@@ -377,21 +336,12 @@ describe('analysisService', () => {
       issues: [],
     })) as typeof resolverModule.resolveProjectAnalysisTargetDetailed;
     spotbugsClient.runSpotBugsAnalysis = (async () =>
-      JSON.stringify({
-        schemaVersion: 2,
-        results: [],
-        errors: [
-          {
-            code: 'ANALYSIS_FAILED',
-            message: 'workspace boom',
-          },
-        ],
-        stats: {
-          target: '/workspace/project/target/classes',
-          durationMs: 12,
-          spotbugsVersion: '4.8.3',
-        },
-      })) as typeof spotbugsClient.runSpotBugsAnalysis;
+      backendErrorEnvelope(
+        'ANALYSIS_FAILED',
+        'workspace boom',
+        '/workspace/project/target/classes',
+        12
+      )) as typeof spotbugsClient.runSpotBugsAnalysis;
 
     const result = await service.analyzeWorkspaceFromProjectsDetailed(
       { getAnalysisSettings: () => ({ effort: 'default' }) } as any,

--- a/src/test/L1.packageContributions.test.ts
+++ b/src/test/L1.packageContributions.test.ts
@@ -11,12 +11,11 @@ type PackageJson = {
         {
           type?: string;
           default?: unknown;
-          markdownDescription?: string;
           scope?: string;
         }
       >;
     }>;
-    commands: Array<{ command: string; title: string; icon?: string }>;
+    commands: Array<{ command: string }>;
     menus: Record<string, Array<{ command?: string; when?: string; group?: string }>>;
   };
 };
@@ -33,96 +32,25 @@ describe('package contributions', () => {
     assert.strictEqual(inspector.type, 'webview');
   });
 
-  it('contributes split finding commands and removes openBugLocation', () => {
+  it('contributes command ids used by result tree actions and removes openBugLocation', () => {
     const commands = manifest.contributes.commands.map((entry) => entry.command);
 
-    assert.ok(commands.includes('spotbugs.revealFindingSource'));
-    assert.ok(commands.includes('spotbugs.openFindingDetails'));
+    for (const command of [
+      'spotbugs.runWorkspace',
+      'spotbugs.revealFindingSource',
+      'spotbugs.openFindingDetails',
+      'spotbugs.filterResults',
+      'spotbugs.exportSarif',
+      'spotbugs.resetResults',
+      'spotbugs.searchResults',
+      'spotbugs.clearSearch',
+      'spotbugs.groupResultsBy',
+      'spotbugs.sortResultsBy',
+      'spotbugs.openSettings',
+    ]) {
+      assert.ok(commands.includes(command), `${command} missing from contributes.commands`);
+    }
     assert.ok(!commands.includes('spotbugs.openBugLocation'));
-  });
-
-  it('uses SpotBugs results wording for shared toolbar commands', () => {
-    const commands = new Map(
-      manifest.contributes.commands.map((entry) => [entry.command, entry])
-    );
-
-    assert.deepStrictEqual(
-      {
-        title: commands.get('spotbugs.runWorkspace')?.title,
-        icon: commands.get('spotbugs.runWorkspace')?.icon,
-      },
-      {
-        title: 'Analyze SpotBugs Workspace',
-        icon: '$(bug)',
-      }
-    );
-    assert.strictEqual(commands.get('spotbugs.exportSarif')?.title, 'Export SpotBugs Results (SARIF)');
-    assert.strictEqual(commands.get('spotbugs.filterResults')?.title, 'Filter SpotBugs Results');
-    assert.strictEqual(commands.get('spotbugs.resetResults')?.title, 'Reset SpotBugs Results');
-  });
-
-  it('contributes result exploration commands', () => {
-    const commands = new Map(
-      manifest.contributes.commands.map((entry) => [entry.command, entry])
-    );
-
-    assert.deepStrictEqual(
-      {
-        title: commands.get('spotbugs.searchResults')?.title,
-        icon: commands.get('spotbugs.searchResults')?.icon,
-      },
-      {
-        title: 'SpotBugs: Search Results',
-        icon: '$(search)',
-      }
-    );
-    assert.deepStrictEqual(
-      {
-        title: commands.get('spotbugs.clearSearch')?.title,
-        icon: commands.get('spotbugs.clearSearch')?.icon,
-      },
-      {
-        title: 'SpotBugs: Clear Search',
-        icon: '$(clear-all)',
-      }
-    );
-    assert.deepStrictEqual(
-      {
-        title: commands.get('spotbugs.groupResultsBy')?.title,
-        icon: commands.get('spotbugs.groupResultsBy')?.icon,
-      },
-      {
-        title: 'SpotBugs: Group Results By...',
-        icon: '$(group-by-ref-type)',
-      }
-    );
-    assert.deepStrictEqual(
-      {
-        title: commands.get('spotbugs.sortResultsBy')?.title,
-        icon: commands.get('spotbugs.sortResultsBy')?.icon,
-      },
-      {
-        title: 'SpotBugs: Sort Results By...',
-        icon: '$(sort-precedence)',
-      }
-    );
-  });
-
-  it('contributes the settings command', () => {
-    const commands = new Map(
-      manifest.contributes.commands.map((entry) => [entry.command, entry])
-    );
-
-    assert.deepStrictEqual(
-      {
-        title: commands.get('spotbugs.openSettings')?.title,
-        icon: commands.get('spotbugs.openSettings')?.icon,
-      },
-      {
-        title: 'SpotBugs: Open Settings',
-        icon: '$(gear)',
-      }
-    );
   });
 
   it('contributes a setting for source reveal on result selection', () => {
@@ -131,7 +59,7 @@ describe('package contributions', () => {
       ...manifest.contributes.configuration.map((group) => group.properties ?? {})
     ) as Record<
       string,
-      { type?: string; default?: unknown; markdownDescription?: string; scope?: string }
+      { type?: string; default?: unknown; scope?: string }
     >;
     const setting = properties['spotbugs.results.revealSourceOnSelection'];
 
@@ -139,10 +67,6 @@ describe('package contributions', () => {
     assert.strictEqual(setting.type, 'boolean');
     assert.strictEqual(setting.default, true);
     assert.strictEqual(setting.scope, 'window');
-    assert.strictEqual(
-      setting.markdownDescription,
-      'Reveal the source location in a preview editor when selecting a SpotBugs finding in the results tree.'
-    );
   });
 
   it('adds finding leaf context fallbacks for source and details', () => {

--- a/src/test/L1.resultsExplorerCommands.test.ts
+++ b/src/test/L1.resultsExplorerCommands.test.ts
@@ -167,47 +167,6 @@ describe('resultsExplorerCommands', () => {
     ]);
   });
 
-  it('registers SpotBugs toolbar commands during extension activation', async () => {
-    const registeredCommands = new Map<string, (...args: unknown[]) => unknown>();
-    resetTelemetryWrapperMock({
-      instrumentOperationAsVsCodeCommand: (
-        commandId: string,
-        callback: (...args: unknown[]) => unknown
-      ) => {
-        registeredCommands.set(commandId, callback);
-        return { dispose: () => undefined };
-      },
-    });
-    delete require.cache[require.resolve('../extension')];
-    const { activate } = require('../extension') as typeof import('../extension');
-
-    await activate({
-      asAbsolutePath: (relativePath: string) => `/extension/${relativePath}`,
-      subscriptions: [],
-    } as never);
-
-    for (const commandId of [
-      'spotbugs.run',
-      'spotbugs.runWorkspace',
-      'spotbugs.revealFindingSource',
-      'spotbugs.openFindingDetails',
-      'spotbugs.filterResults',
-      'spotbugs.exportSarif',
-      'spotbugs.resetResults',
-      'spotbugs.searchResults',
-      'spotbugs.clearSearch',
-      'spotbugs.groupResultsBy',
-      'spotbugs.sortResultsBy',
-      'spotbugs.openSettings',
-    ]) {
-      assert.strictEqual(
-        typeof registeredCommands.get(commandId),
-        'function',
-        `${commandId} was not registered`
-      );
-    }
-  });
-
   it('wraps result exploration command callbacks with inspector reconciliation', async () => {
     const lifecycle =
       require('../commands/findingInspectorLifecycle') as typeof import('../commands/findingInspectorLifecycle');


### PR DESCRIPTION
## Summary

- Remove redundant analysis tests and duplicated setup.
- Retain coverage at the relevant service and integration boundaries.