### PR TITLE
refactor(front): split analysis execution from service orchestration

### DIFF
--- a/src/services/analysisExecution.ts
+++ b/src/services/analysisExecution.ts
@@ -1,0 +1,312 @@
+import type { Uri } from 'vscode';
+import { Logger } from '../core/logger';
+import type { AnalysisSettings, Config } from '../core/config';
+import type { AnalysisOutcome } from '../model/analysisOutcome';
+import { formatAnalysisErrors } from '../model/analysisErrors';
+import {
+  ANALYSIS_PROTOCOL_SCHEMA_VERSION,
+  type AnalysisStats,
+} from '../model/analysisProtocol';
+import * as pathResolver from '../workspace/pathResolver';
+import * as spotbugsClient from '../lsp/spotbugsClient';
+import type { ParsedAnalysis, ParseResult } from '../lsp/spotbugsParser';
+import * as spotbugsParser from '../lsp/spotbugsParser';
+import * as analysisRequestBuilder from '../lsp/analysisRequestBuilder';
+import * as spotbugsMapper from '../lsp/spotbugsMapper';
+import * as filterFileValidation from './filterFileValidation';
+
+const ERROR_ANALYSIS_NO_RESPONSE = 'ANALYSIS_NO_RESPONSE';
+
+export interface AnalysisExecutionTarget {
+  targetPath: string;
+  preferredProject?: Uri;
+  targetResolutionRoots?: string[] | null;
+  runtimeClasspaths?: string[] | null;
+  sourcepaths?: string[] | null;
+}
+
+export interface AnalysisConfigProvider {
+  getAnalysisSettings(resource?: Uri): AnalysisSettings;
+}
+
+type LoggerLike = Pick<typeof Logger, 'log' | 'error'>;
+
+export interface AnalysisExecutorDeps {
+  validateFilterFilesPreflight: typeof filterFileValidation.validateFilterFilesPreflight;
+  validateExtraAuxClasspathPreflight: typeof filterFileValidation.validateExtraAuxClasspathPreflight;
+  buildAnalysisRequestPayload: typeof analysisRequestBuilder.buildAnalysisRequestPayload;
+  runSpotBugsAnalysis: typeof spotbugsClient.runSpotBugsAnalysis;
+  parseAnalysisResponse: typeof spotbugsParser.parseAnalysisResponse;
+  mapBugsToFindings: typeof spotbugsMapper.mapBugsToFindings;
+  addFullPaths: typeof pathResolver.addFullPaths;
+  logger: LoggerLike;
+}
+
+function createDefaultDeps(): AnalysisExecutorDeps {
+  return {
+    validateFilterFilesPreflight:
+      filterFileValidation.validateFilterFilesPreflight,
+    validateExtraAuxClasspathPreflight:
+      filterFileValidation.validateExtraAuxClasspathPreflight,
+    buildAnalysisRequestPayload:
+      analysisRequestBuilder.buildAnalysisRequestPayload,
+    runSpotBugsAnalysis: spotbugsClient.runSpotBugsAnalysis,
+    parseAnalysisResponse: spotbugsParser.parseAnalysisResponse,
+    mapBugsToFindings: spotbugsMapper.mapBugsToFindings,
+    addFullPaths: pathResolver.addFullPaths,
+    logger: Logger,
+  };
+}
+
+export function createAnalysisExecutor(overrides: Partial<AnalysisExecutorDeps> = {}) {
+  const deps: AnalysisExecutorDeps = { ...createDefaultDeps(), ...overrides };
+
+  async function run(
+    config: AnalysisConfigProvider,
+    context: AnalysisExecutionTarget
+  ): Promise<AnalysisOutcome> {
+    const settings = config.getAnalysisSettings(context.preferredProject);
+    const preflightFailure = await validateAnalysisPreflight(
+      settings,
+      context.targetPath
+    );
+    if (preflightFailure) {
+      return preflightFailure;
+    }
+
+    const raw = await executeAnalysisRequest(settings, context);
+    return analysisOutcomeFromRawResponse(raw, context);
+  }
+
+  async function validateAnalysisPreflight(
+    settings: AnalysisSettings,
+    targetPath: string
+  ): Promise<AnalysisOutcome | undefined> {
+    const preflightFilterError = await deps.validateFilterFilesPreflight(settings);
+    if (preflightFilterError) {
+      const combined = formatAnalysisErrors([preflightFilterError]);
+      deps.logger.error(`SpotBugs filter configuration error: ${combined}`);
+      return {
+        findings: [],
+        errors: [preflightFilterError],
+        targetPath,
+        failure: {
+          kind: 'analysis-error',
+          level: 'error',
+          code: preflightFilterError.code,
+          message: `SpotBugs analysis failed: ${combined}`,
+        },
+      };
+    }
+
+    const preflightAuxClasspathError =
+      await deps.validateExtraAuxClasspathPreflight(settings);
+    if (preflightAuxClasspathError) {
+      const combined = formatAnalysisErrors([preflightAuxClasspathError]);
+      deps.logger.error(
+        `SpotBugs extra aux classpath configuration error: ${combined}`
+      );
+      return {
+        findings: [],
+        errors: [preflightAuxClasspathError],
+        targetPath,
+        failure: {
+          kind: 'analysis-error',
+          level: 'error',
+          code: preflightAuxClasspathError.code,
+          message: `SpotBugs analysis failed: ${combined}`,
+        },
+      };
+    }
+
+    return undefined;
+  }
+
+  async function executeAnalysisRequest(
+    settings: AnalysisSettings,
+    context: AnalysisExecutionTarget
+  ): Promise<string | undefined> {
+    const payload = deps.buildAnalysisRequestPayload(settings, {
+      targetResolutionRoots: context.targetResolutionRoots ?? null,
+      runtimeClasspaths: context.runtimeClasspaths ?? null,
+      extraAuxClasspaths: settings.extraAuxClasspaths ?? null,
+      sourcepaths: context.sourcepaths ?? null,
+    });
+    return deps.runSpotBugsAnalysis({
+      targetPath: context.targetPath,
+      payload,
+    });
+  }
+
+  async function analysisOutcomeFromRawResponse(
+    raw: string | undefined,
+    context: AnalysisExecutionTarget
+  ): Promise<AnalysisOutcome> {
+    const targetPath = context.targetPath;
+    if (!raw) {
+      return createAnalysisFailureOutcome(
+        targetPath,
+        ERROR_ANALYSIS_NO_RESPONSE,
+        'No response from SpotBugs backend.'
+      );
+    }
+
+    const parsed = deps.parseAnalysisResponse(raw);
+    if (!parsed.ok) {
+      return analysisOutcomeFromParseError(parsed, targetPath);
+    }
+
+    return analysisOutcomeFromParsedResponse(parsed.value, context);
+  }
+
+  function analysisOutcomeFromParseError(
+    parsed: Extract<ParseResult, { ok: false }>,
+    targetPath: string
+  ): AnalysisOutcome {
+    if (parsed.error.kind === 'invalid-json') {
+      deps.logger.error(
+        'Failed to parse analysis result',
+        parsed.error.cause ?? parsed.error.message
+      );
+      return {
+        findings: [],
+        targetPath,
+        failure: {
+          kind: 'invalid-json',
+          level: 'error',
+          message: 'SpotBugs analysis failed: Invalid response payload.',
+        },
+      };
+    }
+
+    deps.logger.error(`SpotBugs analysis error: ${parsed.error.message}`);
+    return {
+      findings: [],
+      targetPath,
+      failure: {
+        kind: 'analysis-error',
+        level: 'error',
+        message: `SpotBugs analysis failed: ${parsed.error.message}`,
+      },
+    };
+  }
+
+  async function analysisOutcomeFromParsedResponse(
+    parsed: ParsedAnalysis,
+    context: AnalysisExecutionTarget
+  ): Promise<AnalysisOutcome> {
+    const targetPath = context.targetPath;
+    const { bugs, errors, stats, schemaVersion } = parsed;
+
+    if (
+      typeof schemaVersion === 'number' &&
+      schemaVersion !== ANALYSIS_PROTOCOL_SCHEMA_VERSION
+    ) {
+      deps.logger.log(`Unexpected analysis response schemaVersion=${schemaVersion}`);
+    }
+    if (Array.isArray(errors) && errors.length > 0) {
+      const combined = formatAnalysisErrors(errors);
+      deps.logger.error(`SpotBugs analysis error: ${combined}`);
+      const hasResults = bugs.length > 0;
+      if (!hasResults) {
+        const firstErrorCode = errors.find((error) => !!error.code)?.code;
+        return {
+          findings: [],
+          errors,
+          stats,
+          targetPath,
+          schemaVersion,
+          failure: {
+            kind: 'analysis-error',
+            level: 'error',
+            code: firstErrorCode,
+            message: `SpotBugs analysis failed: ${combined}`,
+          },
+        };
+      }
+    }
+
+    const findings = deps.mapBugsToFindings(bugs);
+    const withFullPaths = await deps.addFullPaths(
+      findings,
+      context.preferredProject
+    );
+    logSuccessfulAnalysis(withFullPaths.length, stats);
+    const outcome: AnalysisOutcome = {
+      findings: withFullPaths,
+      stats,
+      targetPath,
+      schemaVersion,
+    };
+    if (Array.isArray(errors) && errors.length > 0) {
+      outcome.errors = errors;
+    }
+    return outcome;
+  }
+
+  function logSuccessfulAnalysis(
+    findingCount: number,
+    stats: AnalysisStats | undefined
+  ): void {
+    const logParts: string[] = [];
+    logParts.push(`findings=${findingCount}`);
+    if (typeof stats?.durationMs === 'number') {
+      logParts.push(`durationMs=${stats.durationMs}`);
+    }
+    if (typeof stats?.target === 'string') {
+      logParts.push(`target=${stats.target}`);
+    }
+    if (typeof stats?.spotbugsVersion === 'string') {
+      logParts.push(`spotbugsVersion=${stats.spotbugsVersion}`);
+    }
+    if (typeof stats?.targetResolutionRootCount === 'number') {
+      logParts.push(`targetResolutionRootCount=${stats.targetResolutionRootCount}`);
+    }
+    if (typeof stats?.runtimeClasspathCount === 'number') {
+      logParts.push(`runtimeClasspathCount=${stats.runtimeClasspathCount}`);
+    }
+    if (typeof stats?.extraAuxClasspathCount === 'number') {
+      logParts.push(`extraAuxClasspathCount=${stats.extraAuxClasspathCount}`);
+    }
+    if (typeof stats?.auxClasspathCount === 'number') {
+      logParts.push(`auxClasspathCount=${stats.auxClasspathCount}`);
+    }
+    if (typeof stats?.targetCount === 'number') {
+      logParts.push(`targetCount=${stats.targetCount}`);
+    }
+    if (typeof stats?.pluginCount === 'number') {
+      logParts.push(`pluginCount=${stats.pluginCount}`);
+    }
+    deps.logger.log(
+      `Successfully parsed and added full paths (${logParts.join(', ')}).`
+    );
+  }
+
+  return {
+    run,
+  };
+}
+
+export function runAnalysisTarget(
+  config: Config,
+  context: AnalysisExecutionTarget
+): Promise<AnalysisOutcome> {
+  return createAnalysisExecutor().run(config, context);
+}
+
+export function createAnalysisFailureOutcome(
+  targetPath: string,
+  code: string,
+  message: string
+): AnalysisOutcome {
+  return {
+    findings: [],
+    targetPath,
+    failure: {
+      kind: 'analysis-error',
+      level: 'error',
+      code,
+      message: `SpotBugs analysis failed: ${message}`,
+    },
+  };
+}

--- a/src/services/analysisService.ts
+++ b/src/services/analysisService.ts
@@ -3,20 +3,14 @@ import { Logger } from '../core/logger';
 import { Config } from '../core/config';
 import type { AnalysisResolutionIssue } from '../lsp/javaLsOutcome';
 import { AnalysisOutcome } from '../model/analysisOutcome';
-import { formatAnalysisErrors } from '../model/analysisErrors';
-import { ANALYSIS_PROTOCOL_SCHEMA_VERSION } from '../model/analysisProtocol';
 import { ProjectRef } from '../workspace/classpathService';
-import { addFullPaths } from '../workspace/pathResolver';
-import { runSpotBugsAnalysis } from '../lsp/spotbugsClient';
-import { parseAnalysisResponse } from '../lsp/spotbugsParser';
-import { buildAnalysisRequestPayload } from '../lsp/analysisRequestBuilder';
-import { mapBugsToFindings } from '../lsp/spotbugsMapper';
 import type { ProjectResult } from './projectResult';
 import { projectResultFromOutcome } from './projectResult';
 import {
-  validateExtraAuxClasspathPreflight,
-  validateFilterFilesPreflight,
-} from './filterFileValidation';
+  AnalysisExecutionTarget,
+  createAnalysisFailureOutcome,
+  runAnalysisTarget,
+} from './analysisExecution';
 import {
   resolveFileAnalysisTarget,
   resolveFileAnalysisTargetDetailed,
@@ -27,15 +21,6 @@ import { getWorkspaceProjectUris } from '../workspace/projectDiscovery';
 
 const ERROR_ANALYSIS_FAILED = 'ANALYSIS_FAILED';
 const ERROR_ANALYSIS_CANCELLED = 'ANALYSIS_CANCELLED';
-const ERROR_ANALYSIS_NO_RESPONSE = 'ANALYSIS_NO_RESPONSE';
-
-type AnalysisContext = {
-  targetPath: string;
-  preferredProject?: Uri;
-  targetResolutionRoots?: string[] | null;
-  runtimeClasspaths?: string[] | null;
-  sourcepaths?: string[] | null;
-};
 
 export { NO_CLASS_TARGETS_CODE } from '../workspace/analysisTargetCodes';
 export type { ProjectResult } from './projectResult';
@@ -269,177 +254,9 @@ async function analyzeProjectDetailed(
 
 async function runAnalysis(
   config: Config,
-  context: AnalysisContext
+  context: AnalysisExecutionTarget
 ): Promise<AnalysisOutcome> {
-  const targetPath = context.targetPath;
-  const settings = config.getAnalysisSettings(context.preferredProject);
-  const preflightFilterError = await validateFilterFilesPreflight(settings);
-  if (preflightFilterError) {
-    const combined = formatAnalysisErrors([preflightFilterError]);
-    Logger.error(`SpotBugs filter configuration error: ${combined}`);
-    return {
-      findings: [],
-      errors: [preflightFilterError],
-      targetPath,
-      failure: {
-        kind: 'analysis-error',
-        level: 'error',
-        code: preflightFilterError.code,
-        message: `SpotBugs analysis failed: ${combined}`,
-      },
-    };
-  }
-  const preflightAuxClasspathError = await validateExtraAuxClasspathPreflight(settings);
-  if (preflightAuxClasspathError) {
-    const combined = formatAnalysisErrors([preflightAuxClasspathError]);
-    Logger.error(`SpotBugs extra aux classpath configuration error: ${combined}`);
-    return {
-      findings: [],
-      errors: [preflightAuxClasspathError],
-      targetPath,
-      failure: {
-        kind: 'analysis-error',
-        level: 'error',
-        code: preflightAuxClasspathError.code,
-        message: `SpotBugs analysis failed: ${combined}`,
-      },
-    };
-  }
-
-  const payload = buildAnalysisRequestPayload(settings, {
-    targetResolutionRoots: context.targetResolutionRoots ?? null,
-    runtimeClasspaths: context.runtimeClasspaths ?? null,
-    extraAuxClasspaths: settings.extraAuxClasspaths ?? null,
-    sourcepaths: context.sourcepaths ?? null,
-  });
-  const result = await runSpotBugsAnalysis({
-    targetPath: context.targetPath,
-    payload,
-  });
-
-  if (!result) {
-    return createAnalysisFailureOutcome(
-      targetPath,
-      ERROR_ANALYSIS_NO_RESPONSE,
-      'No response from SpotBugs backend.'
-    );
-  }
-
-  const parsed = parseAnalysisResponse(result);
-  if (!parsed.ok) {
-    if (parsed.error.kind === 'invalid-json') {
-      Logger.error('Failed to parse analysis result', parsed.error.cause ?? parsed.error.message);
-      return {
-        findings: [],
-        targetPath,
-        failure: {
-          kind: 'invalid-json',
-          level: 'error',
-          message: 'SpotBugs analysis failed: Invalid response payload.',
-        },
-      };
-    }
-    Logger.error(`SpotBugs analysis error: ${parsed.error.message}`);
-    return {
-      findings: [],
-      targetPath,
-      failure: {
-        kind: 'analysis-error',
-        level: 'error',
-        message: `SpotBugs analysis failed: ${parsed.error.message}`,
-      },
-    };
-  }
-
-  const { bugs, errors, stats, schemaVersion } = parsed.value;
-
-  if (
-    typeof schemaVersion === 'number' &&
-    schemaVersion !== ANALYSIS_PROTOCOL_SCHEMA_VERSION
-  ) {
-    Logger.log(`Unexpected analysis response schemaVersion=${schemaVersion}`);
-  }
-  if (Array.isArray(errors) && errors.length > 0) {
-    const combined = formatAnalysisErrors(errors);
-    Logger.error(`SpotBugs analysis error: ${combined}`);
-    const hasResults = bugs.length > 0;
-    if (!hasResults) {
-      const firstErrorCode = errors.find((error) => !!error.code)?.code;
-      return {
-        findings: [],
-        errors,
-        stats,
-        targetPath,
-        schemaVersion,
-        failure: {
-          kind: 'analysis-error',
-          level: 'error',
-          code: firstErrorCode,
-          message: `SpotBugs analysis failed: ${combined}`,
-        },
-      };
-    }
-  }
-
-  const findings = mapBugsToFindings(bugs);
-  const withFullPaths = await addFullPaths(findings, context.preferredProject);
-  const logParts: string[] = [];
-  logParts.push(`findings=${withFullPaths.length}`);
-  if (typeof stats?.durationMs === 'number') {
-    logParts.push(`durationMs=${stats.durationMs}`);
-  }
-  if (typeof stats?.target === 'string') {
-    logParts.push(`target=${stats.target}`);
-  }
-  if (typeof stats?.spotbugsVersion === 'string') {
-    logParts.push(`spotbugsVersion=${stats.spotbugsVersion}`);
-  }
-  if (typeof stats?.targetResolutionRootCount === 'number') {
-    logParts.push(`targetResolutionRootCount=${stats.targetResolutionRootCount}`);
-  }
-  if (typeof stats?.runtimeClasspathCount === 'number') {
-    logParts.push(`runtimeClasspathCount=${stats.runtimeClasspathCount}`);
-  }
-  if (typeof stats?.extraAuxClasspathCount === 'number') {
-    logParts.push(`extraAuxClasspathCount=${stats.extraAuxClasspathCount}`);
-  }
-  if (typeof stats?.auxClasspathCount === 'number') {
-    logParts.push(`auxClasspathCount=${stats.auxClasspathCount}`);
-  }
-  if (typeof stats?.targetCount === 'number') {
-    logParts.push(`targetCount=${stats.targetCount}`);
-  }
-  if (typeof stats?.pluginCount === 'number') {
-    logParts.push(`pluginCount=${stats.pluginCount}`);
-  }
-  Logger.log(`Successfully parsed and added full paths (${logParts.join(', ')}).`);
-  const outcome: AnalysisOutcome = {
-    findings: withFullPaths,
-    stats,
-    targetPath,
-    schemaVersion,
-  };
-  if (Array.isArray(errors) && errors.length > 0) {
-    outcome.errors = errors;
-  }
-  return outcome;
-}
-
-function createAnalysisFailureOutcome(
-  targetPath: string,
-  code: string,
-  message: string
-): AnalysisOutcome {
-  return {
-    findings: [],
-    targetPath,
-    failure: {
-      kind: 'analysis-error',
-      level: 'error',
-      code,
-      message: `SpotBugs analysis failed: ${message}`,
-    },
-  };
+  return runAnalysisTarget(config, context);
 }
 
 function messageFromUnknown(error: unknown): string {

--- a/src/test/L0.analysisExecution.test.ts
+++ b/src/test/L0.analysisExecution.test.ts
@@ -1,0 +1,350 @@
+import * as assert from 'assert';
+import type { Uri } from 'vscode';
+import type { AnalysisSettings } from '../core/config';
+import type {
+  AnalysisExecutionTarget,
+  AnalysisExecutorDeps,
+} from '../services/analysisExecution';
+import type { Finding } from '../model/finding';
+import { installVscodeMock, resetVscodeMock } from './helpers/mockVscode';
+
+type AnalysisExecutionModule = typeof import('../services/analysisExecution');
+
+function loadAnalysisExecution(): AnalysisExecutionModule {
+  delete require.cache[require.resolve('../services/analysisExecution')];
+  return require('../services/analysisExecution') as AnalysisExecutionModule;
+}
+
+function makeConfig(settings: AnalysisSettings = { effort: 'default' }) {
+  return {
+    getAnalysisSettings: (_resource?: Uri) => settings,
+  };
+}
+
+function makeTarget(
+  vscode: ReturnType<typeof installVscodeMock>
+): AnalysisExecutionTarget {
+  return {
+    targetPath: '/workspace/build/classes',
+    preferredProject: vscode.Uri.file('/workspace') as unknown as Uri,
+    targetResolutionRoots: ['/workspace/build/classes'],
+    runtimeClasspaths: ['/workspace/build/classes', '/workspace/lib/dependency.jar'],
+    sourcepaths: ['/workspace/src/main/java'],
+  };
+}
+
+function makeFinding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    patternId: 'NP',
+    type: 'NP_ALWAYS_NULL',
+    message: 'Null pointer',
+    location: {
+      realSourcePath: 'com/acme/Foo.java',
+    },
+    ...overrides,
+  };
+}
+
+function makeDeps(overrides: Partial<AnalysisExecutorDeps> = {}): AnalysisExecutorDeps {
+  return {
+    validateFilterFilesPreflight: async () => undefined,
+    validateExtraAuxClasspathPreflight: async () => undefined,
+    buildAnalysisRequestPayload: (settings, options) => ({
+      schemaVersion: 2,
+      effort: settings.effort,
+      targetResolutionRoots: options.targetResolutionRoots ?? null,
+      runtimeClasspaths: options.runtimeClasspaths ?? null,
+      extraAuxClasspaths: options.extraAuxClasspaths ?? null,
+      sourcepaths: options.sourcepaths ?? null,
+    }),
+    runSpotBugsAnalysis: async () =>
+      JSON.stringify({
+        schemaVersion: 2,
+        results: [],
+      }),
+    parseAnalysisResponse: () => ({
+      ok: true,
+      value: {
+        bugs: [],
+      },
+    }),
+    mapBugsToFindings: () => [],
+    addFullPaths: async (findings) => findings,
+    logger: {
+      log: () => undefined,
+      error: () => undefined,
+    },
+    ...overrides,
+  };
+}
+
+describe('analysisExecution', () => {
+  beforeEach(() => {
+    installVscodeMock();
+    resetVscodeMock();
+  });
+
+  it('short-circuits filter preflight failures before backend execution', async () => {
+    const { createAnalysisExecutor } = loadAnalysisExecution();
+    const backendCalls: unknown[] = [];
+    const executor = createAnalysisExecutor(
+      makeDeps({
+        validateFilterFilesPreflight: async () => ({
+          code: 'CFG_INCLUDE_FILTER_NOT_FOUND',
+          message: 'Include filter not found',
+        }),
+        runSpotBugsAnalysis: async (request) => {
+          backendCalls.push(request);
+          return JSON.stringify({ schemaVersion: 2, results: [] });
+        },
+      })
+    );
+
+    const outcome = await executor.run(
+      makeConfig(),
+      makeTarget(installVscodeMock())
+    );
+
+    assert.deepStrictEqual(backendCalls, []);
+    assert.deepStrictEqual(outcome.findings, []);
+    assert.strictEqual(outcome.targetPath, '/workspace/build/classes');
+    assert.strictEqual(outcome.errors?.[0]?.code, 'CFG_INCLUDE_FILTER_NOT_FOUND');
+    assert.strictEqual(outcome.failure?.kind, 'analysis-error');
+    assert.strictEqual(outcome.failure?.code, 'CFG_INCLUDE_FILTER_NOT_FOUND');
+    assert.strictEqual(
+      outcome.failure?.message,
+      'SpotBugs analysis failed: [CFG_INCLUDE_FILTER_NOT_FOUND] Include filter not found'
+    );
+  });
+
+  it('short-circuits extra aux classpath preflight failures before backend execution', async () => {
+    const { createAnalysisExecutor } = loadAnalysisExecution();
+    const callOrder: string[] = [];
+    const backendCalls: unknown[] = [];
+    const executor = createAnalysisExecutor(
+      makeDeps({
+        validateFilterFilesPreflight: async () => {
+          callOrder.push('filter');
+          return undefined;
+        },
+        validateExtraAuxClasspathPreflight: async () => {
+          callOrder.push('aux');
+          return {
+            code: 'CFG_AUX_CLASSPATH_NOT_FOUND',
+            message: 'Extra aux classpath not found',
+          };
+        },
+        runSpotBugsAnalysis: async (request) => {
+          backendCalls.push(request);
+          return JSON.stringify({ schemaVersion: 2, results: [] });
+        },
+      })
+    );
+
+    const outcome = await executor.run(
+      makeConfig(),
+      makeTarget(installVscodeMock())
+    );
+
+    assert.deepStrictEqual(callOrder, ['filter', 'aux']);
+    assert.deepStrictEqual(backendCalls, []);
+    assert.deepStrictEqual(outcome.findings, []);
+    assert.strictEqual(outcome.targetPath, '/workspace/build/classes');
+    assert.strictEqual(outcome.errors?.[0]?.code, 'CFG_AUX_CLASSPATH_NOT_FOUND');
+    assert.strictEqual(outcome.failure?.kind, 'analysis-error');
+    assert.strictEqual(outcome.failure?.code, 'CFG_AUX_CLASSPATH_NOT_FOUND');
+    assert.strictEqual(
+      outcome.failure?.message,
+      'SpotBugs analysis failed: [CFG_AUX_CLASSPATH_NOT_FOUND] Extra aux classpath not found'
+    );
+  });
+
+  it('passes resolved target settings into the backend request and parser', async () => {
+    const vscode = installVscodeMock();
+    const { createAnalysisExecutor } = loadAnalysisExecution();
+    const settings: AnalysisSettings = {
+      effort: 'max',
+      extraAuxClasspaths: ['/workspace/lib/extra.jar'],
+    };
+    const target = makeTarget(vscode);
+    const backendResponse = JSON.stringify({
+      schemaVersion: 2,
+      results: [],
+    });
+    const payload = {
+      schemaVersion: 2,
+      effort: 'max',
+      targetResolutionRoots: ['/payload/root'],
+      runtimeClasspaths: ['/payload/runtime'],
+      extraAuxClasspaths: ['/payload/extra.jar'],
+      sourcepaths: ['/payload/source'],
+    };
+    let builderSettings: AnalysisSettings | undefined;
+    let builderOptions:
+      | Parameters<AnalysisExecutorDeps['buildAnalysisRequestPayload']>[1]
+      | undefined;
+    let backendRequest:
+      | Parameters<AnalysisExecutorDeps['runSpotBugsAnalysis']>[0]
+      | undefined;
+    let parserInput: string | undefined;
+    let settingsResource: Uri | undefined;
+
+    const executor = createAnalysisExecutor(
+      makeDeps({
+        buildAnalysisRequestPayload: (receivedSettings, options) => {
+          builderSettings = receivedSettings;
+          builderOptions = options;
+          return payload;
+        },
+        runSpotBugsAnalysis: async (request) => {
+          backendRequest = request;
+          return backendResponse;
+        },
+        parseAnalysisResponse: (raw) => {
+          parserInput = raw;
+          return {
+            ok: true,
+            value: {
+              bugs: [],
+            },
+          };
+        },
+      })
+    );
+
+    await executor.run(
+      {
+        getAnalysisSettings: (resource?: Uri) => {
+          settingsResource = resource;
+          return settings;
+        },
+      },
+      target
+    );
+
+    assert.strictEqual(settingsResource, target.preferredProject);
+    assert.strictEqual(builderSettings, settings);
+    assert.deepStrictEqual(builderOptions, {
+      targetResolutionRoots: target.targetResolutionRoots,
+      runtimeClasspaths: target.runtimeClasspaths,
+      extraAuxClasspaths: settings.extraAuxClasspaths,
+      sourcepaths: target.sourcepaths,
+    });
+    assert.deepStrictEqual(backendRequest, {
+      targetPath: target.targetPath,
+      payload,
+    });
+    assert.strictEqual(backendRequest?.payload, payload);
+    assert.strictEqual(parserInput, backendResponse);
+  });
+
+  it('returns ANALYSIS_NO_RESPONSE when backend returns no payload', async () => {
+    const { createAnalysisExecutor } = loadAnalysisExecution();
+    const executor = createAnalysisExecutor(
+      makeDeps({
+        runSpotBugsAnalysis: async () => undefined,
+        addFullPaths: async () => {
+          throw new Error('addFullPaths should not run');
+        },
+      })
+    );
+
+    const outcome = await executor.run(
+      makeConfig(),
+      makeTarget(installVscodeMock())
+    );
+
+    assert.deepStrictEqual(outcome.findings, []);
+    assert.strictEqual(outcome.targetPath, '/workspace/build/classes');
+    assert.strictEqual(outcome.failure?.kind, 'analysis-error');
+    assert.strictEqual(outcome.failure?.code, 'ANALYSIS_NO_RESPONSE');
+    assert.strictEqual(
+      outcome.failure?.message,
+      'SpotBugs analysis failed: No response from SpotBugs backend.'
+    );
+  });
+
+  it('preserves terminal backend errors with stats and schemaVersion', async () => {
+    const { createAnalysisExecutor } = loadAnalysisExecution();
+    const executor = createAnalysisExecutor(
+      makeDeps({
+        parseAnalysisResponse: () => ({
+          ok: true,
+          value: {
+            bugs: [],
+            errors: [{ code: 'ANALYSIS_FAILED', message: 'boom' }],
+            stats: {
+              target: '/workspace/build/classes',
+              durationMs: 9,
+              spotbugsVersion: '4.9.8',
+            },
+            schemaVersion: 2,
+          },
+        }),
+      })
+    );
+
+    const outcome = await executor.run(
+      makeConfig(),
+      makeTarget(installVscodeMock())
+    );
+
+    assert.deepStrictEqual(outcome.findings, []);
+    assert.strictEqual(outcome.errors?.[0]?.code, 'ANALYSIS_FAILED');
+    assert.strictEqual(outcome.stats?.target, '/workspace/build/classes');
+    assert.strictEqual(outcome.schemaVersion, 2);
+    assert.strictEqual(outcome.failure?.code, 'ANALYSIS_FAILED');
+    assert.strictEqual(
+      outcome.failure?.message,
+      'SpotBugs analysis failed: [ANALYSIS_FAILED] boom'
+    );
+  });
+
+  it('returns partial-success findings with backend errors and enriched paths', async () => {
+    const vscode = installVscodeMock();
+    const { createAnalysisExecutor } = loadAnalysisExecution();
+    let addFullPathsProject: Uri | undefined;
+    const mappedFinding = makeFinding();
+    const enrichedFinding = makeFinding({
+      location: {
+        realSourcePath: 'com/acme/Foo.java',
+        fullPath: '/workspace/src/main/java/com/acme/Foo.java',
+      },
+    });
+    const executor = createAnalysisExecutor(
+      makeDeps({
+        parseAnalysisResponse: () => ({
+          ok: true,
+          value: {
+            bugs: [{ type: 'NP_ALWAYS_NULL' }],
+            errors: [{ code: 'ANALYSIS_WARNING', message: 'partial' }],
+            stats: {
+              target: '/workspace/build/classes',
+              durationMs: 12,
+            },
+            schemaVersion: 2,
+          },
+        }),
+        mapBugsToFindings: () => [mappedFinding],
+        addFullPaths: async (findings, preferredProject) => {
+          assert.deepStrictEqual(findings, [mappedFinding]);
+          addFullPathsProject = preferredProject;
+          return [enrichedFinding];
+        },
+      })
+    );
+
+    const target = makeTarget(vscode);
+    const outcome = await executor.run(makeConfig(), target);
+
+    assert.strictEqual(
+      addFullPathsProject?.toString(),
+      target.preferredProject?.toString()
+    );
+    assert.deepStrictEqual(outcome.findings, [enrichedFinding]);
+    assert.strictEqual(outcome.errors?.[0]?.code, 'ANALYSIS_WARNING');
+    assert.strictEqual(outcome.failure, undefined);
+    assert.strictEqual(outcome.stats?.durationMs, 12);
+    assert.strictEqual(outcome.schemaVersion, 2);
+  });
+});

--- a/src/test/L1.analysisService.test.ts
+++ b/src/test/L1.analysisService.test.ts
@@ -5,34 +5,12 @@ function clearModule(moduleId: string): void {
   delete require.cache[require.resolve(moduleId)];
 }
 
-function backendErrorEnvelope(
-  code: string,
-  message: string,
-  targetPath: string,
-  durationMs = 9
-): string {
-  return JSON.stringify({
-    schemaVersion: 2,
-    results: [],
-    errors: [
-      {
-        code,
-        message,
-      },
-    ],
-    stats: {
-      target: targetPath,
-      durationMs,
-      spotbugsVersion: '4.8.3',
-    },
-  });
-}
-
 describe('analysisService', () => {
   beforeEach(() => {
     installVscodeMock();
     resetVscodeMock();
     clearModule('../services/analysisService');
+    clearModule('../services/analysisExecution');
     clearModule('../workspace/analysisTargetResolver');
     clearModule('../workspace/pathResolver');
     clearModule('../lsp/spotbugsClient');
@@ -173,92 +151,6 @@ describe('analysisService', () => {
     assert.strictEqual(result.outcome.targetPath, '/workspace/build/classes');
   });
 
-  it('turns missing backend responses into file analysis failure outcomes', async () => {
-    const vscode = installVscodeMock();
-    const resolverModule =
-      require('../workspace/analysisTargetResolver') as typeof import('../workspace/analysisTargetResolver');
-    const spotbugsClient =
-      require('../lsp/spotbugsClient') as typeof import('../lsp/spotbugsClient');
-    const service = require('../services/analysisService') as typeof import('../services/analysisService');
-
-    resolverModule.resolveFileAnalysisTargetDetailed = (async () => ({
-      resolution: {
-        status: 'ok',
-        target: {
-          targetPath: '/workspace/build/classes',
-          preferredProject: vscode.Uri.file('/workspace/src/Foo.java') as any,
-          targetResolutionRoots: ['/workspace/build/classes'],
-          runtimeClasspaths: ['/workspace/build/classes'],
-          sourcepaths: ['/workspace/src/main/java'],
-        },
-      },
-      issues: [],
-    })) as typeof resolverModule.resolveFileAnalysisTargetDetailed;
-    spotbugsClient.runSpotBugsAnalysis = (async () =>
-      undefined) as typeof spotbugsClient.runSpotBugsAnalysis;
-
-    const result = await service.analyzeFileDetailed(
-      { getAnalysisSettings: () => ({ effort: 'default' }) } as any,
-      vscode.Uri.file('/workspace/src/Foo.java') as any
-    );
-
-    assert.deepStrictEqual(result.outcome.findings, []);
-    assert.strictEqual(result.outcome.failure?.kind, 'analysis-error');
-    assert.strictEqual(result.outcome.failure?.level, 'error');
-    assert.strictEqual(result.outcome.failure?.code, 'ANALYSIS_NO_RESPONSE');
-    assert.strictEqual(
-      result.outcome.failure?.message,
-      'SpotBugs analysis failed: No response from SpotBugs backend.'
-    );
-    assert.strictEqual(result.outcome.targetPath, '/workspace/build/classes');
-  });
-
-  it('turns backend ANALYSIS_FAILED envelopes into file analysis failure outcomes', async () => {
-    const vscode = installVscodeMock();
-    const resolverModule =
-      require('../workspace/analysisTargetResolver') as typeof import('../workspace/analysisTargetResolver');
-    const spotbugsClient =
-      require('../lsp/spotbugsClient') as typeof import('../lsp/spotbugsClient');
-    const service = require('../services/analysisService') as typeof import('../services/analysisService');
-
-    resolverModule.resolveFileAnalysisTargetDetailed = (async () => ({
-      resolution: {
-        status: 'ok',
-        target: {
-          targetPath: '/workspace/build/classes',
-          preferredProject: vscode.Uri.file('/workspace/src/Foo.java') as any,
-          targetResolutionRoots: ['/workspace/build/classes'],
-          runtimeClasspaths: ['/workspace/build/classes'],
-          sourcepaths: ['/workspace/src/main/java'],
-        },
-      },
-      issues: [],
-    })) as typeof resolverModule.resolveFileAnalysisTargetDetailed;
-    spotbugsClient.runSpotBugsAnalysis = (async () =>
-      backendErrorEnvelope(
-        'ANALYSIS_FAILED',
-        'boom',
-        '/workspace/build/classes'
-      )) as typeof spotbugsClient.runSpotBugsAnalysis;
-
-    const result = await service.analyzeFileDetailed(
-      { getAnalysisSettings: () => ({ effort: 'default' }) } as any,
-      vscode.Uri.file('/workspace/src/Foo.java') as any
-    );
-
-    assert.deepStrictEqual(result.outcome.findings, []);
-    assert.strictEqual(result.outcome.failure?.kind, 'analysis-error');
-    assert.strictEqual(result.outcome.failure?.level, 'error');
-    assert.strictEqual(result.outcome.failure?.code, 'ANALYSIS_FAILED');
-    assert.strictEqual(
-      result.outcome.failure?.message,
-      'SpotBugs analysis failed: [ANALYSIS_FAILED] boom'
-    );
-    assert.strictEqual(result.outcome.errors?.[0]?.code, 'ANALYSIS_FAILED');
-    assert.strictEqual(result.outcome.stats?.target, '/workspace/build/classes');
-    assert.strictEqual(result.outcome.schemaVersion, 2);
-  });
-
   it('preserves workspace/project resolution issues when analysis execution throws after target resolution', async () => {
     const vscode = installVscodeMock();
     const resolverModule =
@@ -312,50 +204,6 @@ describe('analysisService', () => {
       result.results.map((project) => project.error),
       ['analysis boom', 'analysis boom']
     );
-  });
-
-  it('marks workspace projects failed when backend returns ANALYSIS_FAILED envelopes', async () => {
-    const vscode = installVscodeMock();
-    const resolverModule =
-      require('../workspace/analysisTargetResolver') as typeof import('../workspace/analysisTargetResolver');
-    const spotbugsClient =
-      require('../lsp/spotbugsClient') as typeof import('../lsp/spotbugsClient');
-    const service = require('../services/analysisService') as typeof import('../services/analysisService');
-
-    resolverModule.resolveProjectAnalysisTargetDetailed = (async (projectUri) => ({
-      resolution: {
-        status: 'ok',
-        target: {
-          targetPath: '/workspace/project/target/classes',
-          preferredProject: projectUri,
-          targetResolutionRoots: ['/workspace/project/target/classes'],
-          runtimeClasspaths: ['/workspace/project/target/classes'],
-          sourcepaths: ['/workspace/project/src/main/java'],
-        },
-      },
-      issues: [],
-    })) as typeof resolverModule.resolveProjectAnalysisTargetDetailed;
-    spotbugsClient.runSpotBugsAnalysis = (async () =>
-      backendErrorEnvelope(
-        'ANALYSIS_FAILED',
-        'workspace boom',
-        '/workspace/project/target/classes',
-        12
-      )) as typeof spotbugsClient.runSpotBugsAnalysis;
-
-    const result = await service.analyzeWorkspaceFromProjectsDetailed(
-      { getAnalysisSettings: () => ({ effort: 'default' }) } as any,
-      vscode.Uri.file('/workspace') as any,
-      ['file:///workspace/project']
-    );
-
-    assert.strictEqual(result.results.length, 1);
-    assert.strictEqual(result.results[0].errorCode, 'ANALYSIS_FAILED');
-    assert.strictEqual(
-      result.results[0].error,
-      'SpotBugs analysis failed: [ANALYSIS_FAILED] workspace boom'
-    );
-    assert.deepStrictEqual(result.results[0].findings, []);
   });
 
   it('stops workspace analysis when backend returns ANALYSIS_CANCELLED envelopes', async () => {


### PR DESCRIPTION
## Summary

- Separate target execution and protocol mapping from analysis orchestration.
- Add focused tests for execution and service responsibilities.