### PR TITLE
test: add shared analysis protocol fixtures

### DIFF
--- a/.github/workflows/extension-checks.yml
+++ b/.github/workflows/extension-checks.yml
@@ -6,6 +6,7 @@ on:
       - '**'
     paths:
       - 'src/**'
+      - 'test-fixtures/**'
       - 'package.json'
       - 'package-lock.json'
       - 'tsconfig.json'
@@ -17,6 +18,7 @@ on:
   pull_request:
     paths:
       - 'src/**'
+      - 'test-fixtures/**'
       - 'package.json'
       - 'package-lock.json'
       - 'tsconfig.json'

--- a/.github/workflows/javaext-checks.yml
+++ b/.github/workflows/javaext-checks.yml
@@ -6,6 +6,7 @@ on:
       - 'main'
     paths:
       - 'javaext/**'
+      - 'test-fixtures/**'
       - '.github/workflows/javaext-checks.yml'
   pull_request:
     branches:
@@ -16,6 +17,7 @@ on:
       - reopened
     paths:
       - 'javaext/**'
+      - 'test-fixtures/**'
       - '.github/workflows/javaext-checks.yml'
 
 concurrency:

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,6 +1,7 @@
 .vscode/**
 .vscode-test/**
 src/**
+test-fixtures/**
 .gitignore
 .yarnrc
 vsc-extension-quickstart.md

--- a/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/command/AnalysisProtocolFixture.java
+++ b/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/command/AnalysisProtocolFixture.java
@@ -1,0 +1,49 @@
+package com.spotbugs.vscode.runner.internal.command;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+public final class AnalysisProtocolFixture {
+
+    private static final String FIXTURE_ROOT = "test-fixtures/analysis-protocol";
+
+    private AnalysisProtocolFixture() {
+    }
+
+    static String read(String name) throws IOException {
+        return new String(Files.readAllBytes(findFixture(name).toPath()), StandardCharsets.UTF_8);
+    }
+
+    static JsonObject readJsonObject(String name) throws IOException {
+        return JsonParser.parseString(read(name)).getAsJsonObject();
+    }
+
+    static String resolveRepositoryPath(String repoRelativePath) {
+        return new File(findRepositoryRoot(), repoRelativePath).getAbsolutePath();
+    }
+
+    private static File findFixture(String name) {
+        File fixture = new File(new File(findRepositoryRoot(), FIXTURE_ROOT), name);
+        if (fixture.isFile()) {
+            return fixture;
+        }
+        throw new IllegalStateException("Analysis protocol fixture not found: " + name);
+    }
+
+    private static File findRepositoryRoot() {
+        File dir = new File(System.getProperty("user.dir")).getAbsoluteFile();
+        while (dir != null) {
+            File fixtureRoot = new File(dir, FIXTURE_ROOT);
+            if (fixtureRoot.isDirectory()) {
+                return dir;
+            }
+            dir = dir.getParentFile();
+        }
+        throw new IllegalStateException("Analysis protocol fixture root not found: " + FIXTURE_ROOT);
+    }
+}

--- a/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisActionTest.java
+++ b/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisActionTest.java
@@ -20,7 +20,8 @@ import com.spotbugs.vscode.runner.internal.AnalyzerService;
 public class RunAnalysisActionTest {
 
     @Test
-    public void executeWrapsAnalyzerFailuresWithRootCauseAsAnalysisFailedEnvelope() {
+    public void executeWrapsAnalyzerFailuresWithRootCauseAsAnalysisFailedEnvelope() throws Exception {
+        JsonObject expected = AnalysisProtocolFixture.readJsonObject("run-analysis-response-error-with-stats.json");
         RunAnalysisAction action = new RunAnalysisAction(() -> new AnalyzerService() {
             @Override
             public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths) {
@@ -29,12 +30,34 @@ public class RunAnalysisActionTest {
         });
 
         JsonObject response = executeDefault(action);
+        JsonObject expectedError = expected.getAsJsonArray("errors").get(0).getAsJsonObject();
+        JsonObject expectedStats = expected.getAsJsonObject("stats");
+        JsonObject stats = response.getAsJsonObject("stats");
 
-        assertEquals(2, response.get("schemaVersion").getAsInt());
-        assertEquals(0, response.getAsJsonArray("results").size());
-        assertEquals("ANALYSIS_FAILED", firstError(response).get("code").getAsString());
-        assertEquals("inner", firstError(response).get("message").getAsString());
-        assertEquals(0, response.getAsJsonObject("stats").get("findingCount").getAsInt());
+        assertEquals(expected.get("schemaVersion").getAsInt(), response.get("schemaVersion").getAsInt());
+        assertEquals(expected.getAsJsonArray("results").size(), response.getAsJsonArray("results").size());
+        assertEquals(expectedError.get("code").getAsString(), firstError(response).get("code").getAsString());
+        assertEquals(expectedError.get("message").getAsString(), firstError(response).get("message").getAsString());
+        assertEquals(expectedStats.keySet(), stats.keySet());
+        assertEquals(expectedStats.get("target").getAsString(), stats.get("target").getAsString());
+        assertTrue(stats.get("durationMs").getAsLong() >= expectedStats.get("durationMs").getAsLong());
+        assertEquals(expectedStats.get("findingCount").getAsInt(), stats.get("findingCount").getAsInt());
+        assertTrue(stats.get("spotbugsVersion").getAsString().length() > 0);
+        assertEquals(
+                expectedStats.get("targetResolutionRootCount").getAsInt(),
+                stats.get("targetResolutionRootCount").getAsInt()
+        );
+        assertEquals(
+                expectedStats.get("runtimeClasspathCount").getAsInt(),
+                stats.get("runtimeClasspathCount").getAsInt()
+        );
+        assertEquals(
+                expectedStats.get("extraAuxClasspathCount").getAsInt(),
+                stats.get("extraAuxClasspathCount").getAsInt()
+        );
+        assertEquals(expectedStats.get("auxClasspathCount").getAsInt(), stats.get("auxClasspathCount").getAsInt());
+        assertEquals(expectedStats.get("targetCount").getAsInt(), stats.get("targetCount").getAsInt());
+        assertEquals(expectedStats.get("pluginCount").getAsInt(), stats.get("pluginCount").getAsInt());
     }
 
     @Test

--- a/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisRequestParserTest.java
+++ b/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisRequestParserTest.java
@@ -6,10 +6,16 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Test;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import com.spotbugs.vscode.runner.internal.config.ConfigParser;
 import com.spotbugs.vscode.runner.internal.config.ConfigValidator;
 import com.spotbugs.vscode.runner.internal.config.Effort;
@@ -23,15 +29,56 @@ public class RunAnalysisRequestParserTest {
 
     @Test
     public void parseReturnsTargetPathAndValidatedConfig() throws Exception {
+        JsonObject fixture = AnalysisProtocolFixture.readJsonObject("run-analysis-request-full.json");
+        JsonObject payload = fixture.getAsJsonObject("payload");
+        JsonObject parseablePayload = payload.deepCopy();
+        resolveFixturePathList(parseablePayload, "includeFilterPaths");
+        resolveFixturePathList(parseablePayload, "excludeFilterPaths");
+        resolveFixturePathList(parseablePayload, "excludeBaselineBugsPaths");
+        resolveFixturePath(parseablePayload, "excludeFilterPath");
+
         RunAnalysisRequest request = parser.parse(context(
-                "/workspace/build/classes",
-                "{\"effort\":\"max\",\"runtimeClasspaths\":[\"/workspace/lib.jar\"]}"
+                fixture.get("targetPath").getAsString(),
+                parseablePayload.toString()
         ));
 
         assertEquals("/workspace/build/classes", request.getTargetPath());
         assertNotNull(request.getConfig());
         assertEquals(Effort.MAX, request.getConfig().getEffort());
-        assertEquals(1, request.getConfig().getRuntimeClasspaths().size());
+        assertEquals(
+                Arrays.asList("/workspace/build/classes", "/workspace/build/generated"),
+                request.getConfig().getTargetResolutionRoots()
+        );
+        assertEquals(
+                Arrays.asList("/workspace/build/classes", "/workspace/lib/dependency.jar"),
+                request.getConfig().getRuntimeClasspaths()
+        );
+        assertEquals(Collections.singletonList("."), request.getConfig().getExtraAuxClasspaths());
+        assertEquals(
+                Arrays.asList("/workspace/src/main/java", "/workspace/generated/sources"),
+                request.getConfig().getSourcepaths()
+        );
+        assertEquals(Integer.valueOf(5), request.getConfig().getPriorityThreshold());
+        assertEquals(
+                resolvedFixturePathList(payload, "includeFilterPaths"),
+                request.getConfig().getIncludeFilterPaths()
+        );
+        assertEquals(
+                resolvedFixturePathList(payload, "excludeFilterPaths"),
+                request.getConfig().getExcludeFilterPaths()
+        );
+        assertEquals(
+                resolvedFixturePathList(payload, "excludeBaselineBugsPaths"),
+                request.getConfig().getExcludeBaselineBugsPaths()
+        );
+        assertEquals(
+                AnalysisProtocolFixture.resolveRepositoryPath(payload.get("excludeFilterPath").getAsString()),
+                request.getConfig().getExcludeFilterPath()
+        );
+        assertEquals(
+                Arrays.asList("/workspace/plugin-a.jar", "/workspace/plugin-b.jar"),
+                request.getConfig().getPlugins()
+        );
     }
 
     @Test
@@ -105,6 +152,31 @@ public class RunAnalysisRequestParserTest {
 
     private static String jsonString(String value) {
         return value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
+    private static void resolveFixturePathList(JsonObject payload, String fieldName) {
+        JsonArray source = payload.getAsJsonArray(fieldName);
+        JsonArray resolved = new JsonArray();
+        for (int index = 0; index < source.size(); index++) {
+            resolved.add(AnalysisProtocolFixture.resolveRepositoryPath(source.get(index).getAsString()));
+        }
+        payload.add(fieldName, resolved);
+    }
+
+    private static void resolveFixturePath(JsonObject payload, String fieldName) {
+        payload.addProperty(
+                fieldName,
+                AnalysisProtocolFixture.resolveRepositoryPath(payload.get(fieldName).getAsString())
+        );
+    }
+
+    private static List<String> resolvedFixturePathList(JsonObject payload, String fieldName) {
+        JsonArray source = payload.getAsJsonArray(fieldName);
+        List<String> resolved = new ArrayList<>();
+        for (int index = 0; index < source.size(); index++) {
+            resolved.add(AnalysisProtocolFixture.resolveRepositoryPath(source.get(index).getAsString()));
+        }
+        return resolved;
     }
 
     private interface ThrowingRunnable {

--- a/src/test/L0.analysisRequestBuilder.test.ts
+++ b/src/test/L0.analysisRequestBuilder.test.ts
@@ -1,6 +1,8 @@
 import * as assert from 'assert';
 import { buildAnalysisRequestPayload } from '../lsp/analysisRequestBuilder';
+import type { AnalysisRequest } from '../model/analysisProtocol';
 import type { AnalysisSettings } from '../core/config';
+import { readAnalysisProtocolFixtureJson } from './helpers/analysisProtocolFixtures';
 
 function makeSettings(overrides: Partial<AnalysisSettings> = {}): AnalysisSettings {
   return {
@@ -10,6 +12,38 @@ function makeSettings(overrides: Partial<AnalysisSettings> = {}): AnalysisSettin
 }
 
 describe('analysisRequestBuilder', () => {
+  it('builds the shared run-analysis request payload fixture', () => {
+    const fixture = readAnalysisProtocolFixtureJson<AnalysisRequest>(
+      'run-analysis-request-full.json'
+    );
+    const includeFilterPaths = ['test-fixtures/analysis-protocol/include-filter.xml'];
+    const excludeFilterPaths = ['test-fixtures/analysis-protocol/exclude-filter.xml'];
+    const excludeBaselineBugsPaths = ['test-fixtures/analysis-protocol/baseline-bugs.xml'];
+    const excludeFilterPath = 'test-fixtures/analysis-protocol/legacy-exclude-filter.xml';
+
+    const payload = buildAnalysisRequestPayload(
+      makeSettings({
+        effort: 'max',
+        extraAuxClasspaths: ['.'],
+        includeFilterPaths,
+        excludeFilterPaths,
+        excludeBaselineBugsPaths,
+        excludeFilterPath,
+        plugins: ['/workspace/plugin-a.jar', '/workspace/plugin-b.jar'],
+        priorityThreshold: 5,
+      }),
+      {
+        targetResolutionRoots: ['/workspace/build/classes', '/workspace/build/generated'],
+        runtimeClasspaths: ['/workspace/build/classes', '/workspace/lib/dependency.jar'],
+        extraAuxClasspaths: ['.'],
+        sourcepaths: ['/workspace/src/main/java', '/workspace/generated/sources'],
+      }
+    );
+
+    assert.strictEqual(fixture.targetPath, '/workspace/build/classes');
+    assert.deepStrictEqual(payload, fixture.payload);
+  });
+
   it('includes include/exclude/excludeBaseline filter paths in payload', () => {
     const include = ['/tmp/spotbugs/include.xml'];
     const exclude = ['/tmp/spotbugs/exclude.xml'];

--- a/src/test/L0.spotbugsParser.test.ts
+++ b/src/test/L0.spotbugsParser.test.ts
@@ -1,5 +1,7 @@
 import * as assert from 'assert';
 import { parseAnalysisResponse } from '../lsp/spotbugsParser';
+import type { AnalysisResponse } from '../model/analysisProtocol';
+import { readAnalysisProtocolFixtureJson } from './helpers/analysisProtocolFixtures';
 
 describe('spotbugsParser', () => {
   it('returns invalid-json error for malformed payloads', () => {
@@ -68,33 +70,17 @@ describe('spotbugsParser', () => {
   });
 
   it('parses terminal analysis failure envelopes with stats', () => {
-    const result = parseAnalysisResponse(
-      JSON.stringify({
-        schemaVersion: 2,
-        results: [],
-        errors: [
-          {
-            code: 'ANALYSIS_FAILED',
-            message: 'boom',
-          },
-        ],
-        stats: {
-          target: '/workspace/build/classes',
-          durationMs: 9,
-          spotbugsVersion: '4.8.3',
-        },
-      })
+    const fixture = readAnalysisProtocolFixtureJson<AnalysisResponse>(
+      'run-analysis-response-error-with-stats.json'
     );
+    const result = parseAnalysisResponse(JSON.stringify(fixture));
 
     assert.strictEqual(result.ok, true);
     if (result.ok) {
-      assert.strictEqual(result.value.schemaVersion, 2);
-      assert.deepStrictEqual(result.value.bugs, []);
-      assert.strictEqual(result.value.errors?.[0]?.code, 'ANALYSIS_FAILED');
-      assert.strictEqual(result.value.errors?.[0]?.message, 'boom');
-      assert.strictEqual(result.value.stats?.target, '/workspace/build/classes');
-      assert.strictEqual(result.value.stats?.durationMs, 9);
-      assert.strictEqual(result.value.stats?.spotbugsVersion, '4.8.3');
+      assert.strictEqual(result.value.schemaVersion, fixture.schemaVersion);
+      assert.deepStrictEqual(result.value.bugs, fixture.results);
+      assert.deepStrictEqual(result.value.errors, fixture.errors);
+      assert.deepStrictEqual(result.value.stats, fixture.stats);
     }
   });
 

--- a/src/test/helpers/analysisProtocolFixtures.ts
+++ b/src/test/helpers/analysisProtocolFixtures.ts
@@ -1,0 +1,41 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const FIXTURE_ROOT_SEGMENTS = ['test-fixtures', 'analysis-protocol'];
+
+export function readAnalysisProtocolFixture(name: string): string {
+  return fs.readFileSync(path.join(findFixtureRoot(), name), 'utf8');
+}
+
+export function readAnalysisProtocolFixtureJson<T>(name: string): T {
+  return JSON.parse(readAnalysisProtocolFixture(name)) as T;
+}
+
+function findFixtureRoot(): string {
+  const visited = new Set<string>();
+  for (const startDir of [__dirname, process.cwd()]) {
+    const fixtureRoot = findFixtureRootFrom(startDir, visited);
+    if (fixtureRoot) {
+      return fixtureRoot;
+    }
+  }
+  throw new Error(`Analysis protocol fixture root not found: ${FIXTURE_ROOT_SEGMENTS.join('/')}`);
+}
+
+function findFixtureRootFrom(startDir: string, visited: Set<string>): string | undefined {
+  let dir = path.resolve(startDir);
+  while (!visited.has(dir)) {
+    visited.add(dir);
+    const candidate = path.join(dir, ...FIXTURE_ROOT_SEGMENTS);
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isDirectory()) {
+      return candidate;
+    }
+
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+  return undefined;
+}

--- a/test-fixtures/analysis-protocol/baseline-bugs.xml
+++ b/test-fixtures/analysis-protocol/baseline-bugs.xml
@@ -1,0 +1,1 @@
+<BugCollection/>

--- a/test-fixtures/analysis-protocol/exclude-filter.xml
+++ b/test-fixtures/analysis-protocol/exclude-filter.xml
@@ -1,0 +1,1 @@
+<FindBugsFilter/>

--- a/test-fixtures/analysis-protocol/include-filter.xml
+++ b/test-fixtures/analysis-protocol/include-filter.xml
@@ -1,0 +1,1 @@
+<FindBugsFilter/>

--- a/test-fixtures/analysis-protocol/legacy-exclude-filter.xml
+++ b/test-fixtures/analysis-protocol/legacy-exclude-filter.xml
@@ -1,0 +1,1 @@
+<FindBugsFilter/>

--- a/test-fixtures/analysis-protocol/run-analysis-request-full.json
+++ b/test-fixtures/analysis-protocol/run-analysis-request-full.json
@@ -1,0 +1,37 @@
+{
+  "targetPath": "/workspace/build/classes",
+  "payload": {
+    "schemaVersion": 2,
+    "effort": "max",
+    "targetResolutionRoots": [
+      "/workspace/build/classes",
+      "/workspace/build/generated"
+    ],
+    "runtimeClasspaths": [
+      "/workspace/build/classes",
+      "/workspace/lib/dependency.jar"
+    ],
+    "extraAuxClasspaths": [
+      "."
+    ],
+    "sourcepaths": [
+      "/workspace/src/main/java",
+      "/workspace/generated/sources"
+    ],
+    "priorityThreshold": 5,
+    "includeFilterPaths": [
+      "test-fixtures/analysis-protocol/include-filter.xml"
+    ],
+    "excludeFilterPaths": [
+      "test-fixtures/analysis-protocol/exclude-filter.xml"
+    ],
+    "excludeBaselineBugsPaths": [
+      "test-fixtures/analysis-protocol/baseline-bugs.xml"
+    ],
+    "excludeFilterPath": "test-fixtures/analysis-protocol/legacy-exclude-filter.xml",
+    "plugins": [
+      "/workspace/plugin-a.jar",
+      "/workspace/plugin-b.jar"
+    ]
+  }
+}

--- a/test-fixtures/analysis-protocol/run-analysis-response-error-with-stats.json
+++ b/test-fixtures/analysis-protocol/run-analysis-response-error-with-stats.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 2,
+  "results": [],
+  "errors": [
+    {
+      "code": "ANALYSIS_FAILED",
+      "message": "inner"
+    }
+  ],
+  "stats": {
+    "target": "/workspace/build/classes",
+    "durationMs": 0,
+    "findingCount": 0,
+    "spotbugsVersion": "fixture",
+    "targetResolutionRootCount": 0,
+    "runtimeClasspathCount": 0,
+    "extraAuxClasspathCount": 0,
+    "auxClasspathCount": 0,
+    "targetCount": 0,
+    "pluginCount": 0
+  }
+}


### PR DESCRIPTION
## Summary

- Add shared analysis protocol fixtures for TypeScript and Java tests.
- Validate request and response compatibility in both runtimes.