### PR TITLE
refactor(front): normalize analysis response parsing

### DIFF
--- a/src/lsp/spotbugsParser.ts
+++ b/src/lsp/spotbugsParser.ts
@@ -1,4 +1,4 @@
-import { AnalysisError, AnalysisResponse, AnalysisStats } from '../model/analysisProtocol';
+import { AnalysisError, AnalysisStats } from '../model/analysisProtocol';
 import { Bug } from '../model/bug';
 
 export type ParseErrorKind = 'invalid-json' | 'analysis-error';
@@ -48,37 +48,39 @@ export function parseAnalysisResponse(raw: string): ParseResult {
   }
 
   if (Array.isArray(parsed)) {
-    return { ok: true, value: { bugs: parsed as Bug[] } };
+    return isBugArray(parsed) ? { ok: true, value: { bugs: parsed } } : invalidResponse();
   }
 
   if (parsed && typeof parsed === 'object') {
-    const envelope = parsed as AnalysisResponse<Bug>;
+    const envelope = parsed as Record<string, unknown>;
     const hasResults = Object.prototype.hasOwnProperty.call(envelope, 'results');
     const hasErrors = Object.prototype.hasOwnProperty.call(envelope, 'errors');
     if (!hasResults && !hasErrors) {
       return invalidResponse();
     }
-    if (hasResults && !Array.isArray(envelope.results)) {
+    if (hasResults && !isBugArray(envelope.results)) {
       return invalidResponse();
     }
     if (hasErrors && !Array.isArray(envelope.errors)) {
       return invalidResponse();
     }
 
-    const errors = hasErrors ? envelope.errors : undefined;
+    const errors = hasErrors ? normalizeAnalysisErrors(envelope.errors) : undefined;
     if (!hasResults && Array.isArray(errors) && errors.length === 0) {
       return invalidResponse();
     }
 
-    const bugs = hasResults ? envelope.results ?? [] : [];
-    const stats = envelope.stats;
+    const bugs = hasResults ? (envelope.results as Bug[]) : [];
+    const stats = normalizeAnalysisStats(envelope.stats);
+    const schemaVersion =
+      typeof envelope.schemaVersion === 'number' ? envelope.schemaVersion : undefined;
     return {
       ok: true,
       value: {
         bugs,
         errors,
         stats,
-        schemaVersion: envelope.schemaVersion,
+        schemaVersion,
       },
     };
   }
@@ -94,4 +96,77 @@ function invalidResponse(): ParseResult {
       message: INVALID_RESPONSE_MESSAGE,
     },
   };
+}
+
+function isBugArray(value: unknown): value is Bug[] {
+  return Array.isArray(value) && value.every(isRecord);
+}
+
+function normalizeAnalysisErrors(value: unknown): AnalysisError[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const errors: AnalysisError[] = [];
+  for (const item of value) {
+    if (!isRecord(item)) {
+      continue;
+    }
+
+    const error: AnalysisError = {};
+    if (typeof item.code === 'string') {
+      error.code = item.code;
+    }
+    if (typeof item.message === 'string') {
+      error.message = item.message;
+    }
+    if (error.code || error.message) {
+      errors.push(error);
+    }
+  }
+  return errors;
+}
+
+function normalizeAnalysisStats(value: unknown): AnalysisStats | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const stats: AnalysisStats = {};
+  copyStringField(value, stats, 'target');
+  copyNumberField(value, stats, 'durationMs');
+  copyNumberField(value, stats, 'findingCount');
+  copyStringField(value, stats, 'spotbugsVersion');
+  copyNumberField(value, stats, 'targetResolutionRootCount');
+  copyNumberField(value, stats, 'runtimeClasspathCount');
+  copyNumberField(value, stats, 'extraAuxClasspathCount');
+  copyNumberField(value, stats, 'auxClasspathCount');
+  copyNumberField(value, stats, 'targetCount');
+  copyNumberField(value, stats, 'pluginCount');
+
+  return Object.keys(stats).length > 0 ? stats : undefined;
+}
+
+function copyStringField<T extends keyof AnalysisStats>(
+  source: Record<string, unknown>,
+  target: AnalysisStats,
+  key: T
+): void {
+  if (typeof source[key] === 'string') {
+    target[key] = source[key] as AnalysisStats[T];
+  }
+}
+
+function copyNumberField<T extends keyof AnalysisStats>(
+  source: Record<string, unknown>,
+  target: AnalysisStats,
+  key: T
+): void {
+  if (typeof source[key] === 'number') {
+    target[key] = source[key] as AnalysisStats[T];
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
 }

--- a/src/test/L0.spotbugsParser.test.ts
+++ b/src/test/L0.spotbugsParser.test.ts
@@ -30,11 +30,25 @@ describe('spotbugsParser', () => {
     }
   });
 
+  it('rejects array responses with non-object entries', () => {
+    const samples = [JSON.stringify([null]), JSON.stringify(['NP']), JSON.stringify([[]])];
+
+    for (const sample of samples) {
+      const result = parseAnalysisResponse(sample);
+      assert.strictEqual(result.ok, false, sample);
+      if (!result.ok) {
+        assert.strictEqual(result.error.kind, 'invalid-json');
+        assert.strictEqual(result.error.message, 'Invalid response payload.');
+      }
+    }
+  });
+
   it('rejects unsupported JSON protocol shapes', () => {
     const samples = [
       JSON.stringify({}),
       JSON.stringify({ stats: { durationMs: 1 } }),
       JSON.stringify({ errors: [] }),
+      JSON.stringify({ errors: [null, 'bad', {}] }),
       JSON.stringify(null),
       JSON.stringify('boom'),
     ];
@@ -66,6 +80,111 @@ describe('spotbugsParser', () => {
       assert.strictEqual(result.value.errors?.[0]?.code, 'X');
       assert.strictEqual(result.value.errors?.[0]?.message, 'warn');
       assert.strictEqual(result.value.stats?.target, '/tmp/Foo');
+    }
+  });
+
+  it('rejects envelope result arrays with non-object entries', () => {
+    const samples = [
+      JSON.stringify({ schemaVersion: 2, results: [null] }),
+      JSON.stringify({ schemaVersion: 2, results: ['NP'] }),
+      JSON.stringify({ schemaVersion: 2, results: [[]] }),
+    ];
+
+    for (const sample of samples) {
+      const result = parseAnalysisResponse(sample);
+      assert.strictEqual(result.ok, false, sample);
+      if (!result.ok) {
+        assert.strictEqual(result.error.kind, 'invalid-json');
+        assert.strictEqual(result.error.message, 'Invalid response payload.');
+      }
+    }
+  });
+
+  it('normalizes envelope errors to string code and message fields', () => {
+    const result = parseAnalysisResponse(
+      JSON.stringify({
+        schemaVersion: 2,
+        results: [],
+        errors: [
+          null,
+          'bad',
+          { code: 7, message: 'message only' },
+          { code: 'CODE_ONLY', message: 9 },
+          { code: 'VALID', message: 'valid message', extra: 'ignored' },
+          {},
+        ],
+      })
+    );
+
+    assert.strictEqual(result.ok, true);
+    if (result.ok) {
+      assert.deepStrictEqual(result.value.errors, [
+        { message: 'message only' },
+        { code: 'CODE_ONLY' },
+        { code: 'VALID', message: 'valid message' },
+      ]);
+    }
+  });
+
+  it('normalizes envelope stats and schemaVersion without failing usable results', () => {
+    const result = parseAnalysisResponse(
+      JSON.stringify({
+        schemaVersion: '2',
+        results: [{ type: 'UR' }],
+        stats: {
+          target: '/tmp/Foo',
+          durationMs: '12',
+          findingCount: 1,
+          spotbugsVersion: '4.9.8',
+          targetResolutionRootCount: 2,
+          runtimeClasspathCount: false,
+          extraAuxClasspathCount: 3,
+          auxClasspathCount: 4,
+          targetCount: null,
+          pluginCount: 5,
+          ignored: 'value',
+        },
+      })
+    );
+
+    assert.strictEqual(result.ok, true);
+    if (result.ok) {
+      assert.strictEqual(result.value.schemaVersion, undefined);
+      assert.deepStrictEqual(result.value.stats, {
+        target: '/tmp/Foo',
+        findingCount: 1,
+        spotbugsVersion: '4.9.8',
+        targetResolutionRootCount: 2,
+        extraAuxClasspathCount: 3,
+        auxClasspathCount: 4,
+        pluginCount: 5,
+      });
+    }
+  });
+
+  it('ignores malformed stats values without rejecting the envelope', () => {
+    const samples = [
+      JSON.stringify({
+        schemaVersion: 2,
+        results: [],
+        errors: [{ code: 'ANALYSIS_FAILED', message: 'boom' }],
+        stats: 'bad',
+      }),
+      JSON.stringify({
+        schemaVersion: 2,
+        results: [],
+        errors: [{ code: 'ANALYSIS_FAILED', message: 'boom' }],
+        stats: { ignored: 'value', durationMs: '12' },
+      }),
+    ];
+
+    for (const sample of samples) {
+      const result = parseAnalysisResponse(sample);
+      assert.strictEqual(result.ok, true, sample);
+      if (result.ok) {
+        assert.strictEqual(result.value.stats, undefined);
+        assert.strictEqual(result.value.errors?.[0]?.code, 'ANALYSIS_FAILED');
+      }
     }
   });
 


### PR DESCRIPTION
## Summary

- Normalize SpotBugs analysis response parsing in one path.
- Preserve legacy payload and structured error handling.