### PR TITLE
fix: publish folder analysis diagnostics for child files

### DIFF
--- a/src/model/diagnosticScope.ts
+++ b/src/model/diagnosticScope.ts
@@ -1,0 +1,6 @@
+import type { Uri } from 'vscode';
+
+export type DiagnosticUpdateScope =
+  | { kind: 'file'; uri: Uri }
+  | { kind: 'folder'; uri: Uri }
+  | { kind: 'returned-files'; uri: Uri };

--- a/src/orchestration/analysisRunSession.ts
+++ b/src/orchestration/analysisRunSession.ts
@@ -3,6 +3,7 @@ import type { Config } from '../core/config';
 import type { AnalysisResolutionIssue } from '../lsp/javaLsOutcome';
 import type { Notifier } from '../core/notifier';
 import type { AnalysisNotice } from '../model/analysisOutcome';
+import type { DiagnosticUpdateScope } from '../model/diagnosticScope';
 import type { Finding } from '../model/finding';
 import type {
   AnalysisExecutionResult,
@@ -50,7 +51,7 @@ export interface WorkspaceAnalysisSessionTree {
 }
 
 export interface AnalysisSessionDiagnostics {
-  updateForFile(targetUri: Uri, findings: Finding[]): void;
+  replaceForScope(scope: DiagnosticUpdateScope, findings: Finding[]): void;
   replaceAll(findings: Finding[]): void;
 }
 
@@ -112,7 +113,10 @@ export async function runFileAnalysisSession(
       args.tree.showAnalysisFailure(outcome.failure.message, outcome.failure.code);
     } else {
       args.tree.showResults(findings);
-      args.diagnostics.updateForFile(args.uri, findings);
+      args.diagnostics.replaceForScope(
+        result.context.diagnosticScope ?? { kind: 'file', uri: args.uri },
+        findings
+      );
     }
 
     emitNotices(

--- a/src/services/analysisService.ts
+++ b/src/services/analysisService.ts
@@ -3,6 +3,7 @@ import { Logger } from '../core/logger';
 import { Config } from '../core/config';
 import type { AnalysisResolutionIssue } from '../lsp/javaLsOutcome';
 import { AnalysisOutcome } from '../model/analysisOutcome';
+import type { DiagnosticUpdateScope } from '../model/diagnosticScope';
 import { ProjectRef } from '../workspace/classpathService';
 import type { ProjectResult } from './projectResult';
 import { projectResultFromOutcome } from './projectResult';
@@ -32,6 +33,7 @@ export interface WorkspaceResult {
 
 export interface AnalysisExecutionContext {
   resolutionIssues: AnalysisResolutionIssue[];
+  diagnosticScope?: DiagnosticUpdateScope;
 }
 
 export interface AnalysisExecutionResult {
@@ -70,6 +72,7 @@ export async function analyzeFileDetailed(
         context,
       };
     }
+    context.diagnosticScope = result.resolution.target.diagnosticScope;
 
     try {
       return {

--- a/src/services/diagnosticsManager.ts
+++ b/src/services/diagnosticsManager.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import {
   Diagnostic,
   DiagnosticCollection,
@@ -8,6 +9,7 @@ import {
   Uri,
   workspace,
 } from 'vscode';
+import type { DiagnosticUpdateScope } from '../model/diagnosticScope';
 import { Finding } from '../model/finding';
 import { Severity } from '../model/severity';
 import { formatFindingSummary, rankToSeverity } from '../formatters/findingFormatting';
@@ -24,9 +26,16 @@ type FindingRange = {
   finding: Finding;
 };
 
+type FindingBucket = {
+  uri: Uri;
+  entries: FindingRange[];
+  diagnostics: Diagnostic[];
+};
+
 export class SpotBugsDiagnosticsManager {
   private readonly collection: DiagnosticCollection;
   private readonly findingsByFile = new Map<string, FindingRange[]>();
+  private readonly filesByReturnedScope = new Map<string, Set<string>>();
 
   constructor() {
     this.collection = languages.createDiagnosticCollection('spotbugs');
@@ -35,32 +44,43 @@ export class SpotBugsDiagnosticsManager {
   dispose(): void {
     this.collection.dispose();
     this.findingsByFile.clear();
+    this.filesByReturnedScope.clear();
   }
 
   clearAll(): void {
     this.collection.clear();
     this.findingsByFile.clear();
+    this.filesByReturnedScope.clear();
   }
 
   replaceAll(findings: Finding[]): void {
     this.clearAll();
-    const grouped = new Map<string, { uri: Uri; entries: FindingRange[]; diagnostics: Diagnostic[] }>();
-    for (const finding of findings) {
-      const fileUri = this.resolveFileUri(finding);
-      if (!fileUri) continue;
-      const key = fileUri.toString();
-      const entry = grouped.get(key) ?? { uri: fileUri, entries: [], diagnostics: [] };
-      this.appendFinding(entry, finding);
-      grouped.set(key, entry);
+    this.publishGrouped(this.groupFindings(findings));
+  }
+
+  replaceForScope(scope: DiagnosticUpdateScope, findings: Finding[]): void {
+    if (scope.kind === 'file') {
+      this.updateForFile(scope.uri, findings);
+      return;
     }
 
-    for (const [key, { uri, diagnostics, entries }] of grouped) {
-      this.collection.set(uri, diagnostics);
-      this.findingsByFile.set(key, entries);
+    if (scope.kind === 'folder') {
+      this.clearFolderScope(scope.uri);
+      this.publishGrouped(
+        this.groupFindings(findings, (fileUri) => isUriInsideOrEqual(scope.uri, fileUri))
+      );
+      return;
     }
+
+    this.clearReturnedScopesInside(scope.uri);
+    const scopeKey = getScopeKey(scope);
+    const publishedFiles = new Set<string>();
+    this.publishGrouped(this.groupFindings(findings), publishedFiles);
+    this.claimReturnedOwnership(scopeKey, publishedFiles);
   }
 
   updateForFile(targetUri: Uri, findings: Finding[]): void {
+    this.revokeReturnedOwnership(targetUri.toString());
     const filePath = targetUri.fsPath;
     const filtered = findings.filter((finding) => {
       const uri = this.resolveFileUri(finding);
@@ -96,7 +116,7 @@ export class SpotBugsDiagnosticsManager {
   }
 
   private appendFinding(
-    bucket: { uri: Uri; entries: FindingRange[]; diagnostics: Diagnostic[] },
+    bucket: FindingBucket,
     finding: Finding
   ): void {
     const range = this.createRange(finding);
@@ -137,6 +157,135 @@ export class SpotBugsDiagnosticsManager {
   private resolveFileUri(finding: Finding): Uri | undefined {
     return getBestEffortFileUri(finding);
   }
+
+  private clearFolderScope(folderUri: Uri): void {
+    const keysToDelete = Array.from(this.findingsByFile.keys()).filter((key) =>
+      isUriInsideOrEqual(folderUri, Uri.parse(key))
+    );
+    for (const key of keysToDelete) {
+      this.deletePublishedFile(key);
+    }
+  }
+
+  private clearReturnedScope(scopeKey: string): void {
+    const files = this.filesByReturnedScope.get(scopeKey);
+    if (!files) {
+      return;
+    }
+    for (const key of Array.from(files)) {
+      this.deletePublishedFile(key);
+    }
+    this.filesByReturnedScope.delete(scopeKey);
+  }
+
+  private clearReturnedScopesInside(scopeUri: Uri): void {
+    const scopeKeysToDelete = Array.from(this.filesByReturnedScope.keys()).filter(
+      (scopeKey) => {
+        const candidateUri = getReturnedScopeUri(scopeKey);
+        return candidateUri ? isUriInsideOrEqual(scopeUri, candidateUri) : false;
+      }
+    );
+    for (const scopeKey of scopeKeysToDelete) {
+      this.clearReturnedScope(scopeKey);
+    }
+  }
+
+  private deletePublishedFile(key: string): void {
+    this.collection.delete(Uri.parse(key));
+    this.findingsByFile.delete(key);
+    this.revokeReturnedOwnership(key);
+  }
+
+  private revokeReturnedOwnership(key: string): void {
+    for (const [scopeKey, files] of Array.from(this.filesByReturnedScope)) {
+      files.delete(key);
+      if (files.size === 0) {
+        this.filesByReturnedScope.delete(scopeKey);
+      }
+    }
+  }
+
+  private claimReturnedOwnership(scopeKey: string, files: Set<string>): void {
+    if (files.size === 0) {
+      this.filesByReturnedScope.delete(scopeKey);
+      return;
+    }
+    for (const key of files) {
+      this.revokeReturnedOwnership(key);
+    }
+    this.filesByReturnedScope.set(scopeKey, files);
+  }
+
+  private groupFindings(
+    findings: Finding[],
+    includeFile: (uri: Uri) => boolean = () => true
+  ): Map<string, FindingBucket> {
+    const grouped = new Map<string, FindingBucket>();
+
+    for (const finding of findings) {
+      const fileUri = this.resolveFileUri(finding);
+      if (!fileUri || !includeFile(fileUri)) {
+        continue;
+      }
+      const key = fileUri.toString();
+      const entry = grouped.get(key) ?? {
+        uri: fileUri,
+        entries: [],
+        diagnostics: [],
+      };
+      this.appendFinding(entry, finding);
+      grouped.set(key, entry);
+    }
+
+    return grouped;
+  }
+
+  private publishGrouped(
+    grouped: Map<string, FindingBucket>,
+    publishedFiles?: Set<string>
+  ): void {
+    for (const [key, { uri, diagnostics, entries }] of grouped) {
+      this.collection.set(uri, diagnostics);
+      this.findingsByFile.set(key, entries);
+      publishedFiles?.add(key);
+    }
+  }
+}
+
+function getScopeKey(
+  scope: Extract<DiagnosticUpdateScope, { kind: 'returned-files' }>
+): string {
+  return `${RETURNED_SCOPE_KEY_PREFIX}${scope.uri.toString()}`;
+}
+
+const RETURNED_SCOPE_KEY_PREFIX = 'returned-files:';
+
+function getReturnedScopeUri(scopeKey: string): Uri | undefined {
+  if (!scopeKey.startsWith(RETURNED_SCOPE_KEY_PREFIX)) {
+    return undefined;
+  }
+  return Uri.parse(scopeKey.slice(RETURNED_SCOPE_KEY_PREFIX.length));
+}
+
+function isUriInsideOrEqual(folderUri: Uri, candidateUri: Uri): boolean {
+  if (folderUri.scheme !== 'file' || candidateUri.scheme !== 'file') {
+    const folder = folderUri.toString();
+    const candidate = candidateUri.toString();
+    return candidate === folder || candidate.startsWith(`${folder}/`);
+  }
+
+  return isPathInsideOrEqual(folderUri.fsPath, candidateUri.fsPath);
+}
+
+function isPathInsideOrEqual(parentPath: string, candidatePath: string): boolean {
+  const relative = path.relative(path.resolve(parentPath), path.resolve(candidatePath));
+  return (
+    relative === '' ||
+    (relative.length > 0 &&
+      relative !== '..' &&
+      !relative.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relative))
+  );
 }
 
 function toDiagnosticSeverity(severity: Severity): DiagnosticSeverity {

--- a/src/test/L0.analysisRunSession.test.ts
+++ b/src/test/L0.analysisRunSession.test.ts
@@ -110,8 +110,8 @@ describe('analysisRunSession file analysis', () => {
           calls.push(`failure:${code ?? ''}:${message}`),
       },
       diagnostics: {
-        updateForFile: (targetUri: Uri, findings: Finding[]) =>
-          calls.push(`diagnostics:${targetUri.fsPath}:${findings.length}`),
+        replaceForScope: (scope, findings: Finding[]) =>
+          calls.push(`diagnostics:${scope.kind}:${scope.uri.fsPath}:${findings.length}`),
         replaceAll: () => calls.push('replaceAll'),
       },
       notifier: {
@@ -129,10 +129,58 @@ describe('analysisRunSession file analysis', () => {
     assert.deepStrictEqual(calls, [
       'loading',
       'results:1',
-      'diagnostics:/workspace/src/Foo.java:1',
+      'diagnostics:file:/workspace/src/Foo.java:1',
       'log:File analysis finished: elapsedMs=125, file=/workspace/src/Foo.java, findings=1',
     ]);
     assert.deepStrictEqual(infos, []);
+  });
+
+  it('uses diagnostic scope from detailed file analysis context', async () => {
+    const vscode = installVscodeMock();
+    const folderUri = vscode.Uri.file('/workspace/src') as unknown as Uri;
+    const finding = createFinding('/workspace/src/Foo.java');
+    const calls: string[] = [];
+    const deps = createBaseDependencies(vscode);
+
+    deps.analyzeFileDetailed = async () => ({
+      outcome: {
+        findings: [finding],
+        targetPath: folderUri.fsPath,
+      },
+      context: {
+        resolutionIssues: [],
+        diagnosticScope: { kind: 'folder', uri: folderUri },
+      },
+    });
+
+    await runFileAnalysisSession({
+      config: { getAnalysisSettings: () => ({}) } as any,
+      tree: {
+        showLoading: () => calls.push('loading'),
+        showResults: (findings: Finding[]) => calls.push(`results:${findings.length}`),
+        showAnalysisFailure: (message: string, code?: string) =>
+          calls.push(`failure:${code ?? ''}:${message}`),
+      },
+      diagnostics: {
+        replaceForScope: (scope, findings: Finding[]) =>
+          calls.push(`diagnostics:${scope.kind}:${scope.uri.fsPath}:${findings.length}`),
+        replaceAll: () => calls.push('replaceAll'),
+      },
+      notifier: {
+        info: () => undefined,
+        warn: () => undefined,
+        error: () => undefined,
+      },
+      uri: folderUri,
+      startedAtMs: 1000,
+      dependencies: deps,
+    });
+
+    assert.deepStrictEqual(calls, [
+      'loading',
+      'results:1',
+      'diagnostics:folder:/workspace/src:1',
+    ]);
   });
 
   it('renders file analysis failures without updating diagnostics', async () => {
@@ -171,7 +219,7 @@ describe('analysisRunSession file analysis', () => {
           calls.push(`failure:${code ?? ''}:${message}`),
       },
       diagnostics: {
-        updateForFile: () => calls.push('diagnostics:update'),
+        replaceForScope: () => calls.push('diagnostics:update'),
         replaceAll: () => calls.push('replaceAll'),
       },
       notifier: {
@@ -218,7 +266,7 @@ describe('analysisRunSession file analysis', () => {
           calls.push(`failure:${code ?? ''}:${message}`),
       },
       diagnostics: {
-        updateForFile: () => calls.push('diagnostics:update'),
+        replaceForScope: () => calls.push('diagnostics:update'),
         replaceAll: () => calls.push('replaceAll'),
       },
       notifier: {
@@ -293,7 +341,8 @@ function createWorkspaceHarness(overrides: Partial<AnalysisSessionDependencies> 
         },
       },
       diagnostics: {
-        updateForFile: () => calls.push('diagnostics:updateForFile'),
+        replaceForScope: (scope, findings: Finding[]) =>
+          calls.push(`diagnostics:${scope.kind}:${scope.uri.fsPath}:${findings.length}`),
         replaceAll: (findings: Finding[]) => calls.push(`replaceAll:${findings.length}`),
       },
       notifier: {

--- a/src/test/L1.analysisRunner.test.ts
+++ b/src/test/L1.analysisRunner.test.ts
@@ -17,7 +17,7 @@ function createNoopTree() {
 
 function createNoopDiagnostics() {
   return {
-    updateForFile: () => undefined,
+    replaceForScope: () => undefined,
     replaceAll: () => undefined,
   } as any;
 }
@@ -50,21 +50,11 @@ describe('analysisRunner', () => {
     const loggerModule =
       require('../core/logger') as typeof import('../core/logger');
     const originalRunFileAnalysisSession = session.runFileAnalysisSession;
-    const originalAnalyzeFileDetailed = analysisService.analyzeFileDetailed;
     const delegated: unknown[] = [];
 
     session.runFileAnalysisSession = (async (args: unknown) => {
       delegated.push(args);
     }) as typeof session.runFileAnalysisSession;
-    analysisService.analyzeFileDetailed = (async () => ({
-      outcome: {
-        findings: [],
-        targetPath: '/workspace/src/Foo.java',
-      },
-      context: {
-        resolutionIssues: [],
-      },
-    })) as typeof analysisService.analyzeFileDetailed;
     Date.now = () => 1234;
 
     try {
@@ -138,7 +128,6 @@ describe('analysisRunner', () => {
     } finally {
       Date.now = originalDateNow;
       session.runFileAnalysisSession = originalRunFileAnalysisSession;
-      analysisService.analyzeFileDetailed = originalAnalyzeFileDetailed;
     }
   });
 
@@ -303,8 +292,6 @@ describe('analysisRunner', () => {
     const originalRunWorkspaceAnalysisSession = session.runWorkspaceAnalysisSession;
     const originalBuildWorkspaceAuto = workspaceBuildService.buildWorkspaceAuto;
     const originalGetWorkspaceProjectDiscovery = projectDiscovery.getWorkspaceProjectDiscovery;
-    const originalAnalyzeWorkspaceFromProjectsDetailed =
-      analysisService.analyzeWorkspaceFromProjectsDetailed;
     const delegated: unknown[] = [];
 
     session.runWorkspaceAnalysisSession = (async (args: unknown) => {
@@ -323,17 +310,6 @@ describe('analysisRunner', () => {
       projectUris: ['file:///workspace/project-a'],
       issues: [],
     })) as typeof projectDiscovery.getWorkspaceProjectDiscovery;
-    analysisService.analyzeWorkspaceFromProjectsDetailed = (async () => ({
-      results: [
-        {
-          projectUri: 'file:///workspace/project-a',
-          findings: [],
-        },
-      ],
-      context: {
-        resolutionIssues: [],
-      },
-    })) as typeof analysisService.analyzeWorkspaceFromProjectsDetailed;
 
     try {
       const runner =
@@ -362,18 +338,33 @@ describe('analysisRunner', () => {
         tree: unknown;
         diagnostics: unknown;
         notifier: unknown;
+        dependencies: {
+          analyzeWorkspaceFromProjectsDetailed: unknown;
+          buildWorkspaceAuto: unknown;
+          getWorkspaceProjectDiscovery: unknown;
+        };
       };
       assert.strictEqual(delegatedArgs.config, config);
       assert.strictEqual(delegatedArgs.tree, tree);
       assert.strictEqual(delegatedArgs.diagnostics, diagnostics);
       assert.strictEqual(delegatedArgs.notifier, notifierModule.defaultNotifier);
+      assert.strictEqual(
+        delegatedArgs.dependencies.analyzeWorkspaceFromProjectsDetailed,
+        analysisService.analyzeWorkspaceFromProjectsDetailed
+      );
+      assert.strictEqual(
+        delegatedArgs.dependencies.buildWorkspaceAuto,
+        workspaceBuildService.buildWorkspaceAuto
+      );
+      assert.strictEqual(
+        delegatedArgs.dependencies.getWorkspaceProjectDiscovery,
+        projectDiscovery.getWorkspaceProjectDiscovery
+      );
       assert.deepStrictEqual(progressTokens, [progress, token]);
     } finally {
       session.runWorkspaceAnalysisSession = originalRunWorkspaceAnalysisSession;
       workspaceBuildService.buildWorkspaceAuto = originalBuildWorkspaceAuto;
       projectDiscovery.getWorkspaceProjectDiscovery = originalGetWorkspaceProjectDiscovery;
-      analysisService.analyzeWorkspaceFromProjectsDetailed =
-        originalAnalyzeWorkspaceFromProjectsDetailed;
     }
   });
 });

--- a/src/test/L1.analysisService.test.ts
+++ b/src/test/L1.analysisService.test.ts
@@ -55,6 +55,41 @@ describe('analysisService', () => {
     assert.strictEqual(publicOutcome.failure?.code, 'NO_CLASS_TARGETS');
   });
 
+  it('carries file-analysis diagnostic scope into detailed analysis context', async () => {
+    const vscode = installVscodeMock();
+    const folderUri = vscode.Uri.file('/workspace/src') as any;
+    const resolverModule =
+      require('../workspace/analysisTargetResolver') as typeof import('../workspace/analysisTargetResolver');
+    const spotbugsClient =
+      require('../lsp/spotbugsClient') as typeof import('../lsp/spotbugsClient');
+
+    resolverModule.resolveFileAnalysisTargetDetailed = (async () => ({
+      resolution: {
+        status: 'ok',
+        target: {
+          targetPath: '/workspace/build/classes',
+          preferredProject: folderUri,
+          targetResolutionRoots: ['/workspace/build/classes'],
+          runtimeClasspaths: ['/workspace/build/classes'],
+          sourcepaths: ['/workspace/src'],
+          diagnosticScope: { kind: 'folder', uri: folderUri },
+        },
+      },
+      issues: [],
+    })) as typeof resolverModule.resolveFileAnalysisTargetDetailed;
+    spotbugsClient.runSpotBugsAnalysis = (async () =>
+      undefined) as typeof spotbugsClient.runSpotBugsAnalysis;
+
+    const service = require('../services/analysisService') as typeof import('../services/analysisService');
+    const result = await service.analyzeFileDetailed(
+      { getAnalysisSettings: () => ({ effort: 'default' }) } as any,
+      folderUri
+    );
+
+    assert.strictEqual(result.context.diagnosticScope?.kind, 'folder');
+    assert.strictEqual(result.context.diagnosticScope?.uri.fsPath, folderUri.fsPath);
+  });
+
   it('aggregates per-project resolution issues in analyzeWorkspaceFromProjectsDetailed', async () => {
     const resolverModule =
       require('../workspace/analysisTargetResolver') as typeof import('../workspace/analysisTargetResolver');

--- a/src/test/L1.analysisTargetResolver.test.ts
+++ b/src/test/L1.analysisTargetResolver.test.ts
@@ -144,4 +144,173 @@ describe('analysisTargetResolver', () => {
     assert.strictEqual(result.resolution.status, 'no-class-targets');
     assert.deepStrictEqual(result.issues, []);
   });
+
+  for (const { name, targetPath, expectedKind } of [
+    {
+      name: 'Java source file analysis',
+      targetPath: '/workspace/project/src/main/java/demo/Repro.java',
+      expectedKind: 'file' as const,
+    },
+    {
+      name: 'source folder analysis',
+      targetPath: '/workspace/project/src/main/java',
+      expectedKind: 'folder' as const,
+    },
+    {
+      name: 'selected output root analysis',
+      targetPath: '/workspace/project/target/classes',
+      expectedKind: 'returned-files' as const,
+    },
+    {
+      name: 'selected output subfolder analysis',
+      targetPath: '/workspace/project/target/classes/demo',
+      expectedKind: 'returned-files' as const,
+    },
+    {
+      name: 'output child folders starting with dot-dot characters',
+      targetPath: '/workspace/project/target/classes/..generated',
+      expectedKind: 'returned-files' as const,
+    },
+    {
+      name: 'output-prefix sibling folder',
+      targetPath: '/workspace/project/target/classes-sibling/demo',
+      expectedKind: 'folder' as const,
+    },
+  ]) {
+    it(`classifies ${name} as ${expectedKind} diagnostic scope`, async () => {
+      const vscode = installVscodeMock();
+      const resolver = createResolver(vscode, {
+        outputPath: '/workspace/project/target/classes',
+      });
+
+      await assertResolvedDiagnosticScope(vscode, resolver, targetPath, expectedKind);
+    });
+  }
+
+  it('classifies alternate output root subfolders as returned-files diagnostic scope', async () => {
+    const vscode = installVscodeMock();
+    const resolver = createResolver(vscode, {
+      outputPath: '/workspace/project/target/classes',
+      runtimeClasspaths: ['/workspace/project/deps/library.jar'],
+      targetResolutionRoots: [
+        '/workspace/project/target/classes',
+        '/workspace/project/target/test-classes',
+      ],
+    });
+
+    await assertResolvedDiagnosticScope(
+      vscode,
+      resolver,
+      '/workspace/project/target/test-classes/demo',
+      'returned-files'
+    );
+  });
+
+  it('classifies derived output subfolders as returned-files when classpath output is absent', async () => {
+    const vscode = installVscodeMock();
+    const resolver = createResolver(vscode, {
+      derivedOutputPath: '/workspace/project/build/classes/java/main',
+      expectedDeriveRoots: ['/workspace/project/unmatched-runtime-entry'],
+      runtimeClasspaths: ['/workspace/project/deps/library.jar'],
+      targetResolutionRoots: ['/workspace/project/unmatched-runtime-entry'],
+    });
+
+    await assertResolvedDiagnosticScope(
+      vscode,
+      resolver,
+      '/workspace/project/build/classes/java/main/demo',
+      'returned-files'
+    );
+  });
+
+  it('classifies bytecode and archive analysis as returned-files diagnostic scope', async () => {
+    const vscode = installVscodeMock();
+    const resolver = createResolver(vscode, {});
+
+    for (const targetPath of [
+      '/workspace/project/target/classes/demo/Repro.class',
+      '/workspace/project/build/libs/app.jar',
+      '/workspace/project/build/libs/app.zip',
+    ]) {
+      await assertResolvedDiagnosticScope(vscode, resolver, targetPath, 'returned-files');
+    }
+  });
 });
+
+function createResolver(
+  vscode: ReturnType<typeof installVscodeMock>,
+  options: Parameters<typeof createResolverDeps>[1]
+) {
+  const resolverModule =
+    require('../workspace/analysisTargetResolver') as typeof import('../workspace/analysisTargetResolver');
+  return resolverModule.createTargetResolver(createResolverDeps(vscode, options));
+}
+
+async function assertResolvedDiagnosticScope(
+  vscode: ReturnType<typeof installVscodeMock>,
+  resolver: {
+    resolveFileAnalysisTargetDetailed(uri: unknown): Promise<any>;
+  },
+  targetPath: string,
+  expectedKind: 'file' | 'folder' | 'returned-files'
+): Promise<void> {
+  const uri = vscode.Uri.file(targetPath) as any;
+  const result = await resolver.resolveFileAnalysisTargetDetailed(uri);
+
+  assert.strictEqual(result.resolution.status, 'ok');
+  assert.deepStrictEqual(
+    result.resolution.status === 'ok'
+      ? {
+          kind: result.resolution.target.diagnosticScope?.kind,
+          uri: result.resolution.target.diagnosticScope?.uri.fsPath,
+        }
+      : undefined,
+    { kind: expectedKind, uri: uri.fsPath }
+  );
+}
+
+function createResolverDeps(
+  vscode: ReturnType<typeof installVscodeMock>,
+  options: {
+    outputPath?: string;
+    derivedOutputPath?: string;
+    expectedDeriveRoots?: string[];
+    runtimeClasspaths?: string[];
+    targetResolutionRoots?: string[];
+  }
+) {
+  const targetResolutionRoots =
+    options.targetResolutionRoots ?? (options.outputPath ? [options.outputPath] : []);
+  const runtimeClasspaths = options.runtimeClasspaths ?? targetResolutionRoots;
+  return {
+    getClasspathsOutcome: async () => ({
+      status: 'resolved' as const,
+      classpath: {
+        output: options.outputPath,
+        runtimeClasspaths,
+        targetResolutionRoots,
+        sourcepaths: [],
+      },
+      issues: [],
+    }),
+    deriveOutputFolder: async (roots: string[]) => {
+      if (options.expectedDeriveRoots) {
+        assert.deepStrictEqual(roots, options.expectedDeriveRoots);
+      }
+      return options.derivedOutputPath ?? options.outputPath;
+    },
+    findOutputFolderFromProject: async () => undefined,
+    hasClassTargets: async () => true,
+    isBytecodeTarget: (targetPath: string) =>
+      ['.class', '.jar', '.zip'].includes(path.extname(targetPath).toLowerCase()),
+    primeSourcepathsCache: () => undefined,
+    getWorkspaceFolder: () =>
+      ({
+        name: 'workspace',
+        index: 0,
+        uri: vscode.Uri.file('/workspace') as any,
+      }) as any,
+    dirname: path.dirname,
+    logger: { log: () => undefined } as any,
+  };
+}

--- a/src/test/L1.diagnosticsRuleDocs.vscode.test.ts
+++ b/src/test/L1.diagnosticsRuleDocs.vscode.test.ts
@@ -7,6 +7,7 @@ import { SpotBugsCommands } from '../constants/commands';
 import { Finding } from '../model/finding';
 import { SpotBugsDiagnosticsManager } from '../services/diagnosticsManager';
 import { SpotBugsDiagnosticCodeActionProvider } from '../services/spotbugsDiagnosticCodeActionProvider';
+import { isSpotBugsDiagnostic } from '../services/spotbugsDiagnosticSupport';
 
 const cleanupPaths = new Set<string>();
 const helpUri =
@@ -14,6 +15,13 @@ const helpUri =
 const rewrittenHelpUri =
   'https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#np-always-null';
 const detailHtml = '<p>Local SpotBugs detail.</p>';
+
+type NewerDiagnosticScenario = {
+  rootUri: vscode.Uri;
+  fileUri: vscode.Uri;
+  newerTargetUri: vscode.Uri;
+  newerFinding: Finding;
+};
 
 describe('SpotBugs diagnostic explanations', () => {
   afterEach(async () => {
@@ -29,7 +37,7 @@ describe('SpotBugs diagnostic explanations', () => {
       const document = await openTempJavaDocument();
       manager.replaceAll([createFinding(document.uri, { detailHtml, helpUri })]);
 
-      const diagnostics = vscode.languages.getDiagnostics(document.uri);
+      const diagnostics = spotbugsDiagnostics(document.uri);
       assert.strictEqual(diagnostics.length, 1);
       assert.strictEqual(diagnostics[0].code, 'NP_ALWAYS_NULL');
     } finally {
@@ -42,7 +50,7 @@ describe('SpotBugs diagnostic explanations', () => {
     try {
       const document = await openTempJavaDocument();
       manager.replaceAll([createFinding(document.uri, { detailHtml, helpUri })]);
-      const [diagnostic] = vscode.languages.getDiagnostics(document.uri);
+      const [diagnostic] = spotbugsDiagnostics(document.uri);
       assert.ok(diagnostic);
 
       const provider = new SpotBugsDiagnosticCodeActionProvider(manager);
@@ -83,7 +91,7 @@ describe('SpotBugs diagnostic explanations', () => {
     try {
       const document = await openTempJavaDocument();
       manager.replaceAll([createFinding(document.uri, { helpUri })]);
-      const diagnostics = vscode.languages.getDiagnostics(document.uri);
+      const diagnostics = spotbugsDiagnostics(document.uri);
       assert.strictEqual(diagnostics.length, 1);
 
       const code = diagnostics[0].code;
@@ -116,7 +124,7 @@ describe('SpotBugs diagnostic explanations', () => {
     try {
       const document = await openTempJavaDocument();
       manager.replaceAll([createFinding(document.uri)]);
-      const [diagnostic] = vscode.languages.getDiagnostics(document.uri);
+      const [diagnostic] = spotbugsDiagnostics(document.uri);
       assert.ok(diagnostic);
 
       const provider = new SpotBugsDiagnosticCodeActionProvider(manager);
@@ -140,6 +148,297 @@ describe('SpotBugs diagnostic explanations', () => {
   });
 });
 
+describe('SpotBugs scoped diagnostics', () => {
+  afterEach(async () => {
+    for (const targetPath of cleanupPaths) {
+      await fs.rm(targetPath, { recursive: true, force: true });
+    }
+    cleanupPaths.clear();
+  });
+
+  it('publishes folder analysis diagnostics on child source files', async () => {
+    const manager = new SpotBugsDiagnosticsManager();
+    try {
+      const { rootUri, fileUri } = await createTempJavaFile(
+        'src/main/java/demo/Repro.java'
+      );
+
+      manager.replaceForScope(
+        { kind: 'folder', uri: rootUri },
+        [createFinding(fileUri)]
+      );
+
+      const childDiagnostics = spotbugsDiagnostics(fileUri);
+      assert.strictEqual(childDiagnostics.length, 1);
+      assert.strictEqual(diagnosticCodeValue(childDiagnostics[0]), 'NP_ALWAYS_NULL');
+      assert.strictEqual(spotbugsDiagnostics(rootUri).length, 0);
+
+      const findings = manager.getFindingsAt(fileUri, new vscode.Position(0, 0));
+      assert.strictEqual(findings.length, 1);
+      assert.strictEqual(findings[0].patternId, 'NP_ALWAYS_NULL');
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  it('treats child folder names starting with dot-dot characters as in-folder diagnostics', async () => {
+    const manager = new SpotBugsDiagnosticsManager();
+    try {
+      const { rootUri, fileUri } = await createTempJavaFile(
+        '..generated/Repro.java'
+      );
+
+      manager.replaceForScope(
+        { kind: 'folder', uri: rootUri },
+        [createFinding(fileUri)]
+      );
+
+      const diagnostics = spotbugsDiagnostics(fileUri);
+      assert.strictEqual(diagnostics.length, 1);
+      assert.strictEqual(diagnosticCodeValue(diagnostics[0]), 'NP_ALWAYS_NULL');
+      const findings = manager.getFindingsAt(fileUri, new vscode.Position(0, 0));
+      assert.strictEqual(findings.length, 1);
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  it('clears in-folder diagnostics while preserving prefix-siblings and ignoring out-of-scope findings', async () => {
+    const manager = new SpotBugsDiagnosticsManager();
+    try {
+      const { rootUri, fileUri: inScopeUri } = await createTempJavaFile(
+        'src/main/java/demo/InScope.java'
+      );
+      const siblingRoot = `${rootUri.fsPath}-sibling`;
+      const { fileUri: siblingUri } = await createTempJavaFile(
+        'src/main/java/demo/Outside.java',
+        siblingRoot
+      );
+
+      manager.replaceAll([createFinding(inScopeUri), createFinding(siblingUri)]);
+      assert.strictEqual(spotbugsDiagnostics(inScopeUri).length, 1);
+      assert.strictEqual(spotbugsDiagnostics(siblingUri).length, 1);
+
+      manager.replaceForScope(
+        { kind: 'folder', uri: rootUri },
+        [
+          createFinding(siblingUri, {
+            patternId: 'OUT_OF_SCOPE_FOLDER_SCOPE',
+            type: 'OUT_OF_SCOPE_FOLDER_SCOPE',
+          }),
+        ]
+      );
+
+      assert.strictEqual(spotbugsDiagnostics(inScopeUri).length, 0);
+      const siblingDiagnostics = spotbugsDiagnostics(siblingUri);
+      assert.strictEqual(siblingDiagnostics.length, 1);
+      assert.strictEqual(diagnosticCodeValue(siblingDiagnostics[0]), 'NP_ALWAYS_NULL');
+      assert.deepStrictEqual(
+        manager.getFindingsAt(inScopeUri, new vscode.Position(0, 0)),
+        []
+      );
+      const siblingFindings = manager.getFindingsAt(
+        siblingUri,
+        new vscode.Position(0, 0)
+      );
+      assert.strictEqual(siblingFindings.length, 1);
+      assert.strictEqual(siblingFindings[0].patternId, 'NP_ALWAYS_NULL');
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  it('replaces in-folder diagnostics with diagnostics for currently returned child files', async () => {
+    const manager = new SpotBugsDiagnosticsManager();
+    try {
+      const { rootUri, fileUri: staleUri } = await createTempJavaFile(
+        'src/main/java/demo/Stale.java'
+      );
+      const { fileUri: currentUri } = await createTempJavaFile(
+        'src/main/java/demo/Current.java',
+        rootUri.fsPath
+      );
+      const currentFinding = createFinding(currentUri, {
+        patternId: 'CURRENT_FOLDER_SCOPE',
+        type: 'CURRENT_FOLDER_SCOPE',
+      });
+
+      manager.replaceAll([createFinding(staleUri)]);
+      manager.replaceForScope({ kind: 'folder', uri: rootUri }, [currentFinding]);
+
+      assert.strictEqual(spotbugsDiagnostics(staleUri).length, 0);
+      const currentDiagnostics = spotbugsDiagnostics(currentUri);
+      assert.strictEqual(currentDiagnostics.length, 1);
+      assert.strictEqual(
+        diagnosticCodeValue(currentDiagnostics[0]),
+        'CURRENT_FOLDER_SCOPE'
+      );
+      assert.deepStrictEqual(
+        manager.getFindingsAt(staleUri, new vscode.Position(0, 0)),
+        []
+      );
+      const currentFindings = manager.getFindingsAt(
+        currentUri,
+        new vscode.Position(0, 0)
+      );
+      assert.strictEqual(currentFindings.length, 1);
+      assert.strictEqual(currentFindings[0].patternId, 'CURRENT_FOLDER_SCOPE');
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  it('clears stale returned-files diagnostics on rerun of the same bytecode target', async () => {
+    const manager = new SpotBugsDiagnosticsManager();
+    try {
+      const targetUri = vscode.Uri.file(
+        path.join(os.tmpdir(), 'spotbugs-target', 'classes')
+      );
+      const { rootUri, fileUri: firstUri } = await createTempJavaFile(
+        'src/main/java/demo/First.java'
+      );
+      const { fileUri: secondUri } = await createTempJavaFile(
+        'src/main/java/demo/Second.java',
+        rootUri.fsPath
+      );
+      const oldFirstFinding = createFinding(firstUri, {
+        patternId: 'OLD_RETURNED_FILES',
+        type: 'OLD_RETURNED_FILES',
+      });
+      const newFirstFinding = createFinding(firstUri, {
+        patternId: 'NEW_RETURNED_FILES',
+        type: 'NEW_RETURNED_FILES',
+      });
+
+      manager.replaceForScope(
+        { kind: 'returned-files', uri: targetUri },
+        [oldFirstFinding, createFinding(secondUri)]
+      );
+      manager.replaceForScope(
+        { kind: 'returned-files', uri: targetUri },
+        [newFirstFinding]
+      );
+
+      const diagnostics = spotbugsDiagnostics(firstUri);
+      assert.strictEqual(diagnostics.length, 1);
+      assert.strictEqual(diagnosticCodeValue(diagnostics[0]), 'NEW_RETURNED_FILES');
+      const firstFindings = manager.getFindingsAt(firstUri, new vscode.Position(0, 0));
+      assert.strictEqual(firstFindings.length, 1);
+      assert.strictEqual(firstFindings[0].patternId, 'NEW_RETURNED_FILES');
+      assert.strictEqual(spotbugsDiagnostics(secondUri).length, 0);
+      assert.deepStrictEqual(
+        manager.getFindingsAt(secondUri, new vscode.Position(0, 0)),
+        []
+      );
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  it('clears stale returned-files diagnostics from child targets when a parent target reruns', async () => {
+    const manager = new SpotBugsDiagnosticsManager();
+    try {
+      const parentTargetUri = vscode.Uri.file(
+        path.join(os.tmpdir(), 'spotbugs-target', 'classes')
+      );
+      const childTargetUri = vscode.Uri.file(
+        path.join(os.tmpdir(), 'spotbugs-target', 'classes', 'demo')
+      );
+      const { fileUri } = await createTempJavaFile('src/main/java/demo/Repro.java');
+
+      manager.replaceForScope(
+        { kind: 'returned-files', uri: childTargetUri },
+        [createFinding(fileUri)]
+      );
+      assert.strictEqual(spotbugsDiagnostics(fileUri).length, 1);
+
+      manager.replaceForScope({ kind: 'returned-files', uri: parentTargetUri }, []);
+
+      assert.strictEqual(spotbugsDiagnostics(fileUri).length, 0);
+      assert.deepStrictEqual(
+        manager.getFindingsAt(fileUri, new vscode.Position(0, 0)),
+        []
+      );
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  for (const { name, patternId, publishNewer } of [
+    {
+      name: 'file-scope',
+      patternId: 'NEW_FILE_SCOPE',
+      publishNewer: (
+        manager: SpotBugsDiagnosticsManager,
+        context: NewerDiagnosticScenario
+      ) =>
+        manager.replaceForScope(
+          { kind: 'file', uri: context.fileUri },
+          [context.newerFinding]
+        ),
+    },
+    {
+      name: 'folder-scope',
+      patternId: 'NEW_FOLDER_SCOPE',
+      publishNewer: (
+        manager: SpotBugsDiagnosticsManager,
+        context: NewerDiagnosticScenario
+      ) =>
+        manager.replaceForScope(
+          { kind: 'folder', uri: context.rootUri },
+          [context.newerFinding]
+        ),
+    },
+    {
+      name: 'returned-files',
+      patternId: 'NEW_RETURNED_FILES',
+      publishNewer: (
+        manager: SpotBugsDiagnosticsManager,
+        context: NewerDiagnosticScenario
+      ) =>
+        manager.replaceForScope(
+          { kind: 'returned-files', uri: context.newerTargetUri },
+          [context.newerFinding]
+        ),
+    },
+  ]) {
+    it(`does not let older returned-files clearing remove newer ${name} diagnostics`, async () => {
+      const manager = new SpotBugsDiagnosticsManager();
+      try {
+        const olderTargetUri = vscode.Uri.file(
+          path.join(os.tmpdir(), 'spotbugs-target', 'classes-a')
+        );
+        const newerTargetUri = vscode.Uri.file(
+          path.join(os.tmpdir(), 'spotbugs-target', 'classes-b')
+        );
+        const { rootUri, fileUri } = await createTempJavaFile(
+          'src/main/java/demo/Repro.java'
+        );
+        const newerFinding = createFinding(fileUri, {
+          patternId,
+          type: patternId,
+        });
+
+        manager.replaceForScope(
+          { kind: 'returned-files', uri: olderTargetUri },
+          [
+            createFinding(fileUri, {
+              patternId: 'OLD_RETURNED_FILES',
+              type: 'OLD_RETURNED_FILES',
+            }),
+          ]
+        );
+        publishNewer(manager, { rootUri, fileUri, newerTargetUri, newerFinding });
+        manager.replaceForScope({ kind: 'returned-files', uri: olderTargetUri }, []);
+
+        assertPublishedFinding(manager, fileUri, patternId);
+      } finally {
+        manager.dispose();
+      }
+    });
+  }
+});
+
 async function openTempJavaDocument(): Promise<vscode.TextDocument> {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'spotbugs-diagnostic-docs-'));
   cleanupPath(tempDir);
@@ -147,6 +446,47 @@ async function openTempJavaDocument(): Promise<vscode.TextDocument> {
   const targetFile = path.join(tempDir, 'Example.java');
   await fs.writeFile(targetFile, 'class Example {}\n', 'utf8');
   return vscode.workspace.openTextDocument(vscode.Uri.file(targetFile));
+}
+
+async function createTempJavaFile(
+  relativePath: string,
+  existingRoot?: string
+): Promise<{ rootUri: vscode.Uri; fileUri: vscode.Uri }> {
+  const tempDir =
+    existingRoot ?? (await fs.mkdtemp(path.join(os.tmpdir(), 'spotbugs-scoped-diags-')));
+  cleanupPath(tempDir);
+
+  const targetFile = path.join(tempDir, relativePath);
+  await fs.mkdir(path.dirname(targetFile), { recursive: true });
+  await fs.writeFile(targetFile, 'class Example {}\n', 'utf8');
+  const fileUri = vscode.Uri.file(targetFile);
+  return {
+    rootUri: vscode.Uri.file(tempDir),
+    fileUri,
+  };
+}
+
+function assertPublishedFinding(
+  manager: SpotBugsDiagnosticsManager,
+  uri: vscode.Uri,
+  patternId: string
+): void {
+  const diagnostics = spotbugsDiagnostics(uri);
+  assert.strictEqual(diagnostics.length, 1);
+  assert.strictEqual(diagnosticCodeValue(diagnostics[0]), patternId);
+
+  const findings = manager.getFindingsAt(uri, new vscode.Position(0, 0));
+  assert.strictEqual(findings.length, 1);
+  assert.strictEqual(findings[0].patternId, patternId);
+}
+
+function diagnosticCodeValue(diagnostic: vscode.Diagnostic): unknown {
+  const code = diagnostic.code;
+  return code && typeof code === 'object' && 'value' in code ? code.value : code;
+}
+
+function spotbugsDiagnostics(uri: vscode.Uri): vscode.Diagnostic[] {
+  return vscode.languages.getDiagnostics(uri).filter(isSpotBugsDiagnostic);
 }
 
 function cleanupPath(targetPath: string): void {

--- a/src/workspace/analysisTargetResolver.ts
+++ b/src/workspace/analysisTargetResolver.ts
@@ -1,6 +1,7 @@
 import { Uri, workspace } from 'vscode';
 import * as path from 'path';
 import { Logger } from '../core/logger';
+import type { DiagnosticUpdateScope } from '../model/diagnosticScope';
 import type { AnalysisResolutionIssue } from '../lsp/javaLsOutcome';
 import {
   deriveOutputFolder,
@@ -20,6 +21,7 @@ export interface AnalysisTarget {
   targetResolutionRoots?: string[];
   runtimeClasspaths?: string[];
   sourcepaths?: string[];
+  diagnosticScope?: DiagnosticUpdateScope;
 }
 
 export interface TargetResolutionOk {
@@ -177,6 +179,7 @@ export function createTargetResolver(overrides: Partial<TargetResolverDeps> = {}
     const resolutionIssues = [...issues];
 
     const targetPath = uri.fsPath;
+    let resolvedOutputPath: string | undefined;
     if (!deps.isBytecodeTarget(targetPath)) {
       const workspaceFolder = deps.getWorkspaceFolder(uri);
       const workspacePath = workspaceFolder?.uri.fsPath ?? deps.dirname(targetPath);
@@ -186,6 +189,7 @@ export function createTargetResolver(overrides: Partial<TargetResolverDeps> = {}
         workspacePath,
         workspacePath
       );
+      resolvedOutputPath = outputResolution.outputPath;
       if (
         !outputResolution.outputPath ||
         !(await deps.hasClassTargets(outputResolution.outputPath))
@@ -210,6 +214,11 @@ export function createTargetResolver(overrides: Partial<TargetResolverDeps> = {}
       };
     }
 
+    const classTargetRoots = uniquePaths([
+      resolvedOutputPath,
+      ...(targetResolutionRoots ?? []),
+    ]);
+
     return {
       resolution: {
         status: 'ok',
@@ -219,6 +228,7 @@ export function createTargetResolver(overrides: Partial<TargetResolverDeps> = {}
           targetResolutionRoots,
           runtimeClasspaths,
           sourcepaths,
+          diagnosticScope: createDiagnosticScope(uri, targetPath, classTargetRoots),
         },
       },
       issues: resolutionIssues,
@@ -336,4 +346,52 @@ function createOutputFallbackIssue(): AnalysisResolutionIssue {
     phase: 'output-fallback',
     message: 'Output folder fallback was used because Java build output metadata was unavailable.',
   };
+}
+
+function createDiagnosticScope(
+  uri: Uri,
+  targetPath: string,
+  classTargetRoots: readonly string[] = []
+): DiagnosticUpdateScope {
+  const ext = path.extname(targetPath).toLowerCase();
+  if (ext === '.java') {
+    return { kind: 'file', uri };
+  }
+  if (
+    ext === '.class' ||
+    ext === '.jar' ||
+    ext === '.zip' ||
+    classTargetRoots.some((root) => isPathInsideOrEqual(root, targetPath))
+  ) {
+    return { kind: 'returned-files', uri };
+  }
+  return { kind: 'folder', uri };
+}
+
+function uniquePaths(paths: Array<string | undefined>): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const candidate of paths) {
+    if (!candidate) {
+      continue;
+    }
+    const key = path.resolve(candidate);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    result.push(candidate);
+  }
+  return result;
+}
+
+function isPathInsideOrEqual(parentPath: string, candidatePath: string): boolean {
+  const relative = path.relative(path.resolve(parentPath), path.resolve(candidatePath));
+  return (
+    relative === '' ||
+    (relative.length > 0 &&
+      relative !== '..' &&
+      !relative.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relative))
+  );
 }


### PR DESCRIPTION
## Summary

- Track diagnostic scope for file and folder analysis.
- Publish and replace diagnostics for source files under the selected folder.