### PR TITLE
fix: resolve and validate SpotBugs plugin jar paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Rule documentation actions may open external SpotBugs documentation links. Basic
 - `spotbugs.analysis.effort`: SpotBugs effort level (`min`, `default`, `max`). Default: `default`.
 - `spotbugs.analysis.priorityThreshold`: Report bugs with rank less than or equal to this value (1 = most severe, 20 = least). Default: `9`.
 - `spotbugs.analysis.extraAuxClasspaths`: Additional SpotBugs aux classpath entries appended after Java LS runtime classpath entries. Supports absolute and workspace-relative jar/directory paths.
+- `spotbugs.plugins.paths`: SpotBugs plugin jar paths loaded before analysis. Supports absolute and workspace-relative `.jar` paths.
 
 Source target resolution stays separate from aux classpath configuration. SpotBugs uses Java LS runtime classpaths plus any `extraAuxClasspaths` entries for aux analysis, and falls back to the runner's system classpath only when neither source provides any entries.
 
@@ -67,11 +68,3 @@ Source target resolution stays separate from aux classpath configuration. SpotBu
 - `spotbugs.filters.includePaths`: SpotBugs XML include filter paths (`-include`). Supports absolute and workspace-relative paths.
 - `spotbugs.filters.excludePaths`: SpotBugs XML exclude filter paths (`-exclude`). Supports absolute and workspace-relative paths.
 - `spotbugs.filters.excludeBaselineBugsPaths`: SpotBugs XML baseline bug collection paths (`-excludeBugs`). Supports absolute and workspace-relative paths.
-
-If any configured filter file is invalid, analysis stops immediately and an error is shown with a code.
-
-- `CFG_FILTER_NOT_FOUND`
-- `CFG_FILTER_NOT_FILE`
-- `CFG_FILTER_UNREADABLE`
-- `CFG_FILTER_XML_INVALID`
-- `CFG_BASELINE_XML_INVALID`

--- a/package.json
+++ b/package.json
@@ -121,11 +121,11 @@
             "type": "array",
             "items": {
               "type": "string",
-              "pattern": "^.*\\.jar$"
+              "pattern": "^.*\\.[jJ][aA][rR]$"
             },
             "default": [],
             "uniqueItems": true,
-            "markdownDescription": "SpotBugs plugin jar paths. Supports absolute paths and workspace-relative paths.",
+            "markdownDescription": "SpotBugs plugin jar paths loaded before analysis. Supports absolute paths and workspace-relative `.jar` paths. Invalid entries stop analysis with a configuration error.",
             "scope": "window"
           }
         }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -178,8 +178,9 @@ export class Config {
     if (excludeBaselineBugsPaths) {
       settings.excludeBaselineBugsPaths = excludeBaselineBugsPaths;
     }
-    if (Array.isArray(this.plugins) && this.plugins.length > 0) {
-      settings.plugins = this.plugins.slice();
+    const plugins = this.resolvePathsToAbsolute(this.plugins, resource);
+    if (plugins) {
+      settings.plugins = plugins;
     }
     return settings;
   }

--- a/src/services/analysisExecution.ts
+++ b/src/services/analysisExecution.ts
@@ -34,6 +34,7 @@ type LoggerLike = Pick<typeof Logger, 'log' | 'error'>;
 export interface AnalysisExecutorDeps {
   validateFilterFilesPreflight: typeof filterFileValidation.validateFilterFilesPreflight;
   validateExtraAuxClasspathPreflight: typeof filterFileValidation.validateExtraAuxClasspathPreflight;
+  validatePluginJarsPreflight: typeof filterFileValidation.validatePluginJarsPreflight;
   buildAnalysisRequestPayload: typeof analysisRequestBuilder.buildAnalysisRequestPayload;
   runSpotBugsAnalysis: typeof spotbugsClient.runSpotBugsAnalysis;
   parseAnalysisResponse: typeof spotbugsParser.parseAnalysisResponse;
@@ -48,6 +49,8 @@ function createDefaultDeps(): AnalysisExecutorDeps {
       filterFileValidation.validateFilterFilesPreflight,
     validateExtraAuxClasspathPreflight:
       filterFileValidation.validateExtraAuxClasspathPreflight,
+    validatePluginJarsPreflight:
+      filterFileValidation.validatePluginJarsPreflight,
     buildAnalysisRequestPayload:
       analysisRequestBuilder.buildAnalysisRequestPayload,
     runSpotBugsAnalysis: spotbugsClient.runSpotBugsAnalysis,
@@ -114,6 +117,23 @@ export function createAnalysisExecutor(overrides: Partial<AnalysisExecutorDeps> 
           kind: 'analysis-error',
           level: 'error',
           code: preflightAuxClasspathError.code,
+          message: `SpotBugs analysis failed: ${combined}`,
+        },
+      };
+    }
+
+    const preflightPluginError = await deps.validatePluginJarsPreflight(settings);
+    if (preflightPluginError) {
+      const combined = formatAnalysisErrors([preflightPluginError]);
+      deps.logger.error(`SpotBugs plugin configuration error: ${combined}`);
+      return {
+        findings: [],
+        errors: [preflightPluginError],
+        targetPath,
+        failure: {
+          kind: 'analysis-error',
+          level: 'error',
+          code: preflightPluginError.code,
           message: `SpotBugs analysis failed: ${combined}`,
         },
       };

--- a/src/services/filterFileValidation.ts
+++ b/src/services/filterFileValidation.ts
@@ -11,6 +11,10 @@ const CODE_FILTER_UNREADABLE = 'CFG_FILTER_UNREADABLE';
 const CODE_AUX_CLASSPATH_NOT_FOUND = 'CFG_AUX_CLASSPATH_NOT_FOUND';
 const CODE_AUX_CLASSPATH_INVALID_ENTRY = 'CFG_AUX_CLASSPATH_INVALID_ENTRY';
 const CODE_AUX_CLASSPATH_UNREADABLE = 'CFG_AUX_CLASSPATH_UNREADABLE';
+const CODE_PLUGIN_NOT_FOUND = 'CFG_PLUGIN_NOT_FOUND';
+const CODE_PLUGIN_NOT_FILE = 'CFG_PLUGIN_NOT_FILE';
+const CODE_PLUGIN_NOT_JAR = 'CFG_PLUGIN_NOT_JAR';
+const CODE_PLUGIN_UNREADABLE = 'CFG_PLUGIN_UNREADABLE';
 
 export async function validateFilterFilesPreflight(
   settings: AnalysisSettings
@@ -70,6 +74,56 @@ export async function validateExtraAuxClasspathPreflight(
   return undefined;
 }
 
+export async function validatePluginJarsPreflight(
+  settings: AnalysisSettings
+): Promise<AnalysisError | undefined> {
+  const paths = settings.plugins;
+  if (!Array.isArray(paths) || paths.length === 0) {
+    return undefined;
+  }
+
+  for (const rawPath of paths) {
+    const absolutePath = toAbsolutePath(rawPath);
+    let stat: fs.Stats | undefined;
+    try {
+      stat = await safeStat(absolutePath);
+    } catch (error) {
+      return {
+        code: CODE_PLUGIN_UNREADABLE,
+        message: `SpotBugs plugin jar is not readable: ${absolutePath} (${rootCauseMessage(error)})`,
+      };
+    }
+    if (!stat) {
+      return {
+        code: CODE_PLUGIN_NOT_FOUND,
+        message: `SpotBugs plugin jar not found: ${absolutePath}`,
+      };
+    }
+    if (!stat.isFile()) {
+      return {
+        code: CODE_PLUGIN_NOT_FILE,
+        message: `SpotBugs plugin path is not a regular file: ${absolutePath}`,
+      };
+    }
+    if (!isJarPath(absolutePath)) {
+      return {
+        code: CODE_PLUGIN_NOT_JAR,
+        message: `SpotBugs plugin path must be a .jar file: ${absolutePath}`,
+      };
+    }
+    try {
+      await assertReadableFile(absolutePath);
+    } catch (error) {
+      return {
+        code: CODE_PLUGIN_UNREADABLE,
+        message: `SpotBugs plugin jar is not readable: ${absolutePath} (${rootCauseMessage(error)})`,
+      };
+    }
+  }
+
+  return undefined;
+}
+
 async function validateFilterGroup(
   kind: FilterKind,
   paths: string[] | undefined
@@ -117,11 +171,16 @@ async function safeStat(absolutePath: string): Promise<fs.Stats | undefined> {
     return await fs.promises.stat(absolutePath);
   } catch (error) {
     const errno = error as NodeJS.ErrnoException;
-    if (errno && errno.code === 'ENOENT') {
+    if (errno && (errno.code === 'ENOENT' || errno.code === 'ENOTDIR')) {
       return undefined;
     }
     throw error;
   }
+}
+
+async function assertReadableFile(filePath: string): Promise<void> {
+  const handle = await fs.promises.open(filePath, 'r');
+  await handle.close();
 }
 
 function toAbsolutePath(rawPath: string): string {
@@ -135,6 +194,10 @@ function toAbsolutePath(rawPath: string): string {
 function isArchivePath(filePath: string): boolean {
   const ext = path.extname(filePath).toLowerCase();
   return ext === '.jar' || ext === '.zip';
+}
+
+function isJarPath(filePath: string): boolean {
+  return path.extname(filePath).toLowerCase() === '.jar';
 }
 
 function rootCauseMessage(error: unknown): string {

--- a/src/test/L0.analysisExecution.test.ts
+++ b/src/test/L0.analysisExecution.test.ts
@@ -49,6 +49,7 @@ function makeDeps(overrides: Partial<AnalysisExecutorDeps> = {}): AnalysisExecut
   return {
     validateFilterFilesPreflight: async () => undefined,
     validateExtraAuxClasspathPreflight: async () => undefined,
+    validatePluginJarsPreflight: async () => undefined,
     buildAnalysisRequestPayload: (settings, options) => ({
       schemaVersion: 2,
       effort: settings.effort,
@@ -156,6 +157,55 @@ describe('analysisExecution', () => {
     assert.strictEqual(
       outcome.failure?.message,
       'SpotBugs analysis failed: [CFG_AUX_CLASSPATH_NOT_FOUND] Extra aux classpath not found'
+    );
+  });
+
+  it('short-circuits plugin jar preflight failures before backend execution', async () => {
+    const { createAnalysisExecutor } = loadAnalysisExecution();
+    const callOrder: string[] = [];
+    const backendCalls: unknown[] = [];
+    const executor = createAnalysisExecutor(
+      makeDeps({
+        validateFilterFilesPreflight: async () => {
+          callOrder.push('filter');
+          return undefined;
+        },
+        validateExtraAuxClasspathPreflight: async () => {
+          callOrder.push('aux');
+          return undefined;
+        },
+        validatePluginJarsPreflight: async () => {
+          callOrder.push('plugin');
+          return {
+            code: 'CFG_PLUGIN_NOT_FOUND',
+            message: 'SpotBugs plugin jar not found',
+          };
+        },
+        buildAnalysisRequestPayload: () => {
+          throw new Error('buildAnalysisRequestPayload should not run');
+        },
+        runSpotBugsAnalysis: async (request) => {
+          backendCalls.push(request);
+          return JSON.stringify({ schemaVersion: 2, results: [] });
+        },
+      })
+    );
+
+    const outcome = await executor.run(
+      makeConfig({ effort: 'default', plugins: ['/workspace/missing-plugin.jar'] }),
+      makeTarget(installVscodeMock())
+    );
+
+    assert.deepStrictEqual(callOrder, ['filter', 'aux', 'plugin']);
+    assert.deepStrictEqual(backendCalls, []);
+    assert.deepStrictEqual(outcome.findings, []);
+    assert.strictEqual(outcome.targetPath, '/workspace/build/classes');
+    assert.strictEqual(outcome.errors?.[0]?.code, 'CFG_PLUGIN_NOT_FOUND');
+    assert.strictEqual(outcome.failure?.kind, 'analysis-error');
+    assert.strictEqual(outcome.failure?.code, 'CFG_PLUGIN_NOT_FOUND');
+    assert.strictEqual(
+      outcome.failure?.message,
+      'SpotBugs analysis failed: [CFG_PLUGIN_NOT_FOUND] SpotBugs plugin jar not found'
     );
   });
 

--- a/src/test/L0.filterFileValidation.test.ts
+++ b/src/test/L0.filterFileValidation.test.ts
@@ -6,6 +6,7 @@ import type { AnalysisSettings } from '../core/config';
 import {
   validateExtraAuxClasspathPreflight,
   validateFilterFilesPreflight,
+  validatePluginJarsPreflight,
 } from '../services/filterFileValidation';
 
 function makeSettings(overrides: Partial<AnalysisSettings> = {}): AnalysisSettings {
@@ -128,6 +129,105 @@ describe('filterFileValidation', () => {
 
       const error = await validateExtraAuxClasspathPreflight(
         makeSettings({ extraAuxClasspaths: [jarPath, classesDir] })
+      );
+
+      assert.strictEqual(error, undefined);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('returns CFG_PLUGIN_NOT_FOUND when a plugin jar is missing', async () => {
+    const missingPath = path.join(
+      os.tmpdir(),
+      `spotbugs-missing-${process.pid}-${Date.now()}-plugin.jar`
+    );
+    const error = await validatePluginJarsPreflight(
+      makeSettings({ plugins: [missingPath] })
+    );
+
+    assert.ok(error);
+    assert.strictEqual(error?.code, 'CFG_PLUGIN_NOT_FOUND');
+    assert.ok((error?.message ?? '').includes('SpotBugs plugin jar not found'));
+  });
+
+  it('returns CFG_PLUGIN_NOT_FILE when a plugin path points to a directory', async () => {
+    const dir = await makeTempDir();
+    try {
+      const error = await validatePluginJarsPreflight(
+        makeSettings({ plugins: [dir] })
+      );
+
+      assert.ok(error);
+      assert.strictEqual(error?.code, 'CFG_PLUGIN_NOT_FILE');
+      assert.ok(
+        (error?.message ?? '').includes(
+          'SpotBugs plugin path is not a regular file'
+        )
+      );
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('returns CFG_PLUGIN_NOT_JAR when a plugin path is not a jar file', async () => {
+    const dir = await makeTempDir();
+    try {
+      const pluginPath = path.join(dir, 'findsecbugs.txt');
+      await writeFile(pluginPath, 'plain text');
+
+      const error = await validatePluginJarsPreflight(
+        makeSettings({ plugins: [pluginPath] })
+      );
+
+      assert.ok(error);
+      assert.strictEqual(error?.code, 'CFG_PLUGIN_NOT_JAR');
+      assert.ok(
+        (error?.message ?? '').includes(
+          'SpotBugs plugin path must be a .jar file'
+        )
+      );
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('returns CFG_PLUGIN_UNREADABLE when a plugin jar cannot be opened for reading', async () => {
+    const dir = await makeTempDir();
+    const originalOpen = fs.promises.open;
+    try {
+      const pluginPath = path.join(dir, 'unreadable.jar');
+      await writeFile(pluginPath, '');
+      fs.promises.open = (async (filePath, flags, mode) => {
+        if (filePath === pluginPath) {
+          throw new Error('permission denied');
+        }
+        return originalOpen.call(fs.promises, filePath, flags, mode);
+      }) as typeof fs.promises.open;
+
+      const error = await validatePluginJarsPreflight(
+        makeSettings({ plugins: [pluginPath] })
+      );
+
+      assert.ok(error);
+      assert.strictEqual(error?.code, 'CFG_PLUGIN_UNREADABLE');
+      assert.ok(
+        (error?.message ?? '').includes('SpotBugs plugin jar is not readable')
+      );
+    } finally {
+      fs.promises.open = originalOpen;
+      await cleanup(dir);
+    }
+  });
+
+  it('passes when configured plugin jars are readable files', async () => {
+    const dir = await makeTempDir();
+    try {
+      const pluginPath = path.join(dir, 'findsecbugs.JAR');
+      await writeFile(pluginPath, '');
+
+      const error = await validatePluginJarsPreflight(
+        makeSettings({ plugins: [pluginPath] })
       );
 
       assert.strictEqual(error, undefined);

--- a/src/test/L1.config.test.ts
+++ b/src/test/L1.config.test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert';
+import * as path from 'path';
 import { installVscodeMock, resetVscodeMock } from './helpers/mockVscode';
 
 installVscodeMock();
@@ -28,5 +29,40 @@ describe('Config', () => {
     const config = new configModule.Config({} as never);
 
     assert.strictEqual(config.revealSourceOnSelection, false);
+  });
+
+  it('resolves plugin paths against the resource workspace folder', async () => {
+    const vscode = installVscodeMock();
+    const workspaceA = vscode.Uri.file('/workspace-a');
+    const workspaceB = vscode.Uri.file('/workspace-b');
+    resetVscodeMock({
+      workspace: {
+        workspaceFolders: [
+          { name: 'workspace-a', uri: workspaceA },
+          { name: 'workspace-b', uri: workspaceB },
+        ],
+        getConfiguration: () => ({
+          get: (key: string) =>
+            key === 'plugins.paths'
+              ? ['plugins/findsecbugs.jar', '/opt/spotbugs/custom.jar']
+              : undefined,
+        }),
+        getWorkspaceFolder: (uri: typeof workspaceA) =>
+          uri.fsPath.startsWith(workspaceB.fsPath)
+            ? { name: 'workspace-b', uri: workspaceB }
+            : undefined,
+      },
+    } as never);
+    const configModule = await import('../core/config');
+    const config = new configModule.Config({} as never);
+
+    const settings = config.getAnalysisSettings(
+      vscode.Uri.file('/workspace-b/src/main/java/App.java') as never
+    );
+
+    assert.deepStrictEqual(settings.plugins, [
+      path.resolve('/workspace-b', 'plugins/findsecbugs.jar'),
+      '/opt/spotbugs/custom.jar',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- Resolve workspace-relative SpotBugs plugin JAR paths.
- Validate plugin files before starting analysis.