### PR TITLE
Fix SARIF workspace-relative artifact URIs

### DIFF
--- a/src/services/sarifArtifactLocation.ts
+++ b/src/services/sarifArtifactLocation.ts
@@ -10,17 +10,20 @@ export function getSarifArtifactUri(
   finding: Finding,
   options: SarifArtifactUriOptions = {}
 ): string | undefined {
-  const sourcePath = toPortablePath(finding.location.realSourcePath);
-  if (sourcePath) {
-    return sourcePath;
-  }
-
   const fullPath = finding.location.fullPath;
   if (fullPath && path.isAbsolute(fullPath)) {
     const workspaceRelative = toWorkspaceRelativePath(fullPath, options.workspaceRootPath);
     if (workspaceRelative) {
       return workspaceRelative;
     }
+  }
+
+  const sourcePath = toPortablePath(finding.location.realSourcePath);
+  if (sourcePath) {
+    return sourcePath;
+  }
+
+  if (fullPath && path.isAbsolute(fullPath)) {
     return pathToFileURL(fullPath).toString();
   }
 
@@ -53,7 +56,8 @@ function toWorkspaceRelativePath(
   const relativePath = path.relative(workspaceRootPath, targetPath);
   if (
     !relativePath ||
-    relativePath.startsWith('..') ||
+    relativePath === '..' ||
+    relativePath.startsWith(`..${path.sep}`) ||
     path.isAbsolute(relativePath)
   ) {
     return undefined;

--- a/src/test/L0.sarifExporter.test.ts
+++ b/src/test/L0.sarifExporter.test.ts
@@ -91,6 +91,59 @@ describe('buildSarifLog', () => {
     });
   });
 
+  it('prefers workspace-relative fullPath over package-relative realSourcePath', () => {
+    const finding = makeFinding({
+      type: 'NP_NULL_ON_SOME_PATH',
+      shortDescription: 'Null pointer dereference',
+      location: {
+        fullPath: '/__WORKSPACE_ROOT__/src/main/java/com/acme/Foo.java',
+        realSourcePath: 'com/acme/Foo.java',
+        sourceFile: 'Foo.java',
+        startLine: 12,
+      },
+    });
+
+    const actual = buildSarifLog([finding], {
+      workspaceRootPath: placeholderWorkspaceRoot,
+    });
+
+    assert.strictEqual(getFirstArtifactUri(actual), 'src/main/java/com/acme/Foo.java');
+  });
+
+  it('keeps workspace-relative fullPath when a child path starts with dots', () => {
+    const finding = makeFinding({
+      location: {
+        fullPath: '/__WORKSPACE_ROOT__/..generated/com/acme/Foo.java',
+        realSourcePath: 'com/acme/Foo.java',
+        sourceFile: 'Foo.java',
+        startLine: 12,
+      },
+    });
+
+    const actual = buildSarifLog([finding], {
+      workspaceRootPath: placeholderWorkspaceRoot,
+    });
+
+    assert.strictEqual(getFirstArtifactUri(actual), '..generated/com/acme/Foo.java');
+  });
+
+  it('keeps realSourcePath when fullPath is outside the workspace root', () => {
+    const finding = makeFinding({
+      location: {
+        fullPath: '/external/src/main/java/com/acme/Foo.java',
+        realSourcePath: 'com/acme/Foo.java',
+        sourceFile: 'Foo.java',
+        startLine: 12,
+      },
+    });
+
+    const actual = buildSarifLog([finding], {
+      workspaceRootPath: placeholderWorkspaceRoot,
+    });
+
+    assert.strictEqual(getFirstArtifactUri(actual), 'com/acme/Foo.java');
+  });
+
   it('omits regions when the start line is unknown and normalizes workspace paths', () => {
     const finding = makeFinding({
       type: 'UUF_UNUSED_FIELD',
@@ -169,4 +222,8 @@ function makeFinding(overrides: Partial<Finding>): Finding {
     },
     ...overrides,
   };
+}
+
+function getFirstArtifactUri(log: ReturnType<typeof buildSarifLog>): string | undefined {
+  return log.runs[0]?.results[0]?.locations?.[0]?.physicalLocation.artifactLocation.uri;
 }


### PR DESCRIPTION
## Summary

- Prefer workspace-relative artifact URIs for SARIF findings.
- Keep exported source locations portable across machines.