### PR TITLE
fix(runner): align target archive detection

### DIFF
--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/TargetResolver.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/TargetResolver.java
@@ -5,13 +5,14 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 
 /**
- * Resolves input paths (.java/.class/.jar/directories) into concrete analysis targets
- * (.class and .jar files). Uses target-resolution root directories to map sources to outputs.
+ * Resolves input paths (.java/.class/.jar/.zip/directories) into concrete analysis targets
+ * (.class, .jar, and .zip files). Uses target-resolution root directories to map sources to outputs.
  */
 public class TargetResolver {
 
@@ -38,7 +39,7 @@ public class TargetResolver {
                 }
                 continue;
             }
-            if (p.endsWith(".class") || p.endsWith(".jar")) {
+            if (isAnalysisTargetFile(p)) {
                 if (f.exists() && f.isFile()) addIfNew(f.getAbsolutePath(), targets, seen);
                 continue;
             }
@@ -68,7 +69,7 @@ public class TargetResolver {
                 continue;
             }
             String name = c.getName();
-            if (name.endsWith(".class") || name.endsWith(".jar")) {
+            if (isAnalysisTargetFile(name)) {
                 addIfNew(c.getAbsolutePath(), out, seen);
                 continue;
             }
@@ -196,6 +197,14 @@ public class TargetResolver {
     private String stripExtension(String name) {
         int i = name.lastIndexOf('.');
         return (i >= 0) ? name.substring(0, i) : name;
+    }
+
+    private boolean isAnalysisTargetFile(String name) {
+        if (name == null) {
+            return false;
+        }
+        String lower = name.toLowerCase(Locale.ROOT);
+        return lower.endsWith(".class") || lower.endsWith(".jar") || lower.endsWith(".zip");
     }
 
     private void addIfNew(String path, List<String> out, Set<String> seen) {

--- a/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/TargetResolverTest.java
+++ b/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/TargetResolverTest.java
@@ -1,0 +1,59 @@
+package com.spotbugs.vscode.runner.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TargetResolverTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void recursivelyCollectsCaseInsensitiveClassJarAndZipTargets() throws Exception {
+        File root = temporaryFolder.newFolder("targets");
+        File nested = new File(root, "nested");
+        assertTrue(nested.mkdirs());
+
+        File classFile = touch(root, "Foo.CLASS");
+        File jarFile = touch(nested, "app.JAR");
+        File zipFile = touch(root, "lib.ZIP");
+        touch(root, "notes.txt");
+
+        List<String> actual = new TargetResolver().resolveTargets(
+                new String[] { root.getAbsolutePath() },
+                Collections.emptyList()
+        );
+
+        assertEquals(sortedPaths(classFile, jarFile, zipFile), sorted(actual));
+    }
+
+    private File touch(File parent, String name) throws Exception {
+        File file = new File(parent, name);
+        assertTrue(file.createNewFile());
+        return file;
+    }
+
+    private List<String> sortedPaths(File... files) {
+        List<String> paths = new ArrayList<>();
+        for (File file : files) {
+            paths.add(file.getAbsolutePath());
+        }
+        Collections.sort(paths);
+        return paths;
+    }
+
+    private List<String> sorted(List<String> values) {
+        List<String> copy = new ArrayList<>(values);
+        Collections.sort(copy);
+        return copy;
+    }
+}

--- a/src/test/L0.outputResolver.test.ts
+++ b/src/test/L0.outputResolver.test.ts
@@ -41,11 +41,36 @@ describe('outputResolver', () => {
     }
   });
 
+  it('detects archive bytecode targets under a directory', async () => {
+    for (const archiveName of ['app.jar', 'app.zip', 'APP.JAR', 'LIB.ZIP']) {
+      const dir = await makeTempDir();
+      try {
+        await writeFile(path.join(dir, 'libs', archiveName));
+        const has = await hasClassTargets(dir);
+        assert.strictEqual(has, true, archiveName);
+      } finally {
+        await cleanup(dir);
+      }
+    }
+  });
+
   it('finds default output folders with class files', async () => {
     const dir = await makeTempDir();
     try {
       const outputDir = path.join(dir, 'build', 'classes', 'java', 'main');
       await writeFile(path.join(outputDir, 'Foo.class'));
+      const found = await findOutputFolderFromProject(dir);
+      assert.strictEqual(found, outputDir);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('finds default output folders with archive bytecode targets', async () => {
+    const dir = await makeTempDir();
+    try {
+      const outputDir = path.join(dir, 'build', 'classes', 'java', 'main');
+      await writeFile(path.join(outputDir, 'libs', 'app.ZIP'));
       const found = await findOutputFolderFromProject(dir);
       assert.strictEqual(found, outputDir);
     } finally {

--- a/src/workspace/outputResolver.ts
+++ b/src/workspace/outputResolver.ts
@@ -25,7 +25,7 @@ export async function hasClassTargets(targetPath: string): Promise<boolean> {
       return isBytecodeTarget(targetPath);
     }
     if (stat.isDirectory()) {
-      return await containsClassFile(targetPath);
+      return await containsBytecodeTarget(targetPath);
     }
   } catch {
     return false;
@@ -45,7 +45,7 @@ export async function findOutputFolderFromProject(
   return undefined;
 }
 
-async function containsClassFile(root: string): Promise<boolean> {
+async function containsBytecodeTarget(root: string): Promise<boolean> {
   const queue: string[] = [root];
   while (queue.length > 0) {
     const current = queue.pop();
@@ -60,7 +60,7 @@ async function containsClassFile(root: string): Promise<boolean> {
     }
     for (const entry of entries) {
       if (entry.isFile()) {
-        if (entry.name.toLowerCase().endsWith('.class')) {
+        if (isBytecodeTarget(entry.name)) {
           return true;
         }
         continue;
@@ -72,4 +72,3 @@ async function containsClassFile(root: string): Promise<boolean> {
   }
   return false;
 }
-


### PR DESCRIPTION
## Summary

- Treat JAR and ZIP targets consistently in the TypeScript and Java resolvers.
- Detect output folders that contain archive targets only.