### PR TITLE
fix: scope source analysis to mapped output roots

### DIFF
--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/AnalyzerService.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/AnalyzerService.java
@@ -125,9 +125,12 @@ public class AnalyzerService {
         Project project = new Project();
         ClasspathConfigurer cpCfg = new ClasspathConfigurer();
         List<java.io.File> targetResolutionRootDirs = cpCfg.directoriesFrom(this.targetResolutionRoots);
+        List<String> sourcepaths = this.config != null
+                ? this.config.getSourcepaths()
+                : java.util.Collections.emptyList();
         this.lastTargetResolutionRootCount = targetResolutionRootDirs.size();
         TargetResolver resolver = new TargetResolver();
-        List<String> targets = resolver.resolveTargets(filePaths, targetResolutionRootDirs, monitor);
+        List<String> targets = resolver.resolveTargets(filePaths, targetResolutionRootDirs, sourcepaths, monitor);
         this.lastTargetCount = targets.size();
         if (targets.isEmpty()) {
             return null;

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/TargetResolver.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/TargetResolver.java
@@ -2,8 +2,12 @@ package com.spotbugs.vscode.runner.internal;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -21,8 +25,18 @@ public class TargetResolver {
     }
 
     public List<String> resolveTargets(String[] inputs, List<File> targetResolutionRootDirs, IProgressMonitor monitor) throws IOException {
+        return resolveTargets(inputs, targetResolutionRootDirs, null, monitor);
+    }
+
+    public List<String> resolveTargets(
+            String[] inputs,
+            List<File> targetResolutionRootDirs,
+            List<String> sourcepaths,
+            IProgressMonitor monitor
+    ) throws IOException {
         List<String> targets = new ArrayList<>();
         Set<String> seen = new HashSet<>();
+        List<SourceRoot> sourceRoots = normalizeSourceRoots(sourcepaths);
         if (inputs == null) {
             return targets;
         }
@@ -34,8 +48,16 @@ public class TargetResolver {
             File f = new File(p);
             if (f.isDirectory()) {
                 // If a source directory is selected, map it to an output directory first.
-                if (!collectOutputClassesForSourceDirectory(p, targetResolutionRootDirs, targets, seen, monitor)) {
-                    collectTargetsRecursively(f, targetResolutionRootDirs, targets, seen, monitor);
+                SourceDirectoryResolution sourceDirectoryResolution = collectOutputClassesForSourceDirectory(
+                        p,
+                        targetResolutionRootDirs,
+                        sourceRoots,
+                        targets,
+                        seen,
+                        monitor
+                );
+                if (sourceDirectoryResolution == SourceDirectoryResolution.NOT_SOURCE_DIRECTORY) {
+                    collectTargetsRecursively(f, targetResolutionRootDirs, sourceRoots, targets, seen, monitor);
                 }
                 continue;
             }
@@ -43,26 +65,33 @@ public class TargetResolver {
                 if (f.exists() && f.isFile()) addIfNew(f.getAbsolutePath(), targets, seen);
                 continue;
             }
-            if (p.endsWith(".java")) {
-                addTargetsForJavaFile(p, targetResolutionRootDirs, targets, seen, monitor);
+            if (isJavaSourceFile(p)) {
+                addTargetsForJavaFile(p, targetResolutionRootDirs, sourceRoots, targets, seen, monitor);
                 continue;
             }
             // Unknown type: add existing file or scan directory
             if (f.exists()) {
                 if (f.isFile()) addIfNew(f.getAbsolutePath(), targets, seen);
-                else if (f.isDirectory()) collectTargetsRecursively(f, targetResolutionRootDirs, targets, seen, monitor);
+                else if (f.isDirectory()) collectTargetsRecursively(f, targetResolutionRootDirs, sourceRoots, targets, seen, monitor);
             }
         }
         return targets;
     }
 
-    private void collectTargetsRecursively(File dir, List<File> targetResolutionRootDirs, List<String> out, Set<String> seen, IProgressMonitor monitor) throws IOException {
+    private void collectTargetsRecursively(
+            File dir,
+            List<File> targetResolutionRootDirs,
+            List<SourceRoot> sourceRoots,
+            List<String> out,
+            Set<String> seen,
+            IProgressMonitor monitor
+    ) throws IOException {
         File[] children = dir.listFiles();
         if (children == null) return;
         for (File c : children) {
             checkCanceled(monitor);
             if (c.isDirectory()) {
-                collectTargetsRecursively(c, targetResolutionRootDirs, out, seen, monitor);
+                collectTargetsRecursively(c, targetResolutionRootDirs, sourceRoots, out, seen, monitor);
                 continue;
             }
             if (!c.isFile()) {
@@ -73,101 +102,270 @@ public class TargetResolver {
                 addIfNew(c.getAbsolutePath(), out, seen);
                 continue;
             }
-            if (name.endsWith(".java")) {
-                addTargetsForJavaFile(c.getAbsolutePath(), targetResolutionRootDirs, out, seen, monitor);
+            if (isJavaSourceFile(name)) {
+                addTargetsForJavaFile(c.getAbsolutePath(), targetResolutionRootDirs, sourceRoots, out, seen, monitor);
                 continue;
             }
         }
     }
 
-    private boolean collectClassFilesByBasename(File dir, String baseName, List<String> out, Set<String> seen, IProgressMonitor monitor) throws IOException {
+    private SourceDirectoryResolution collectOutputClassesForSourceDirectory(
+            String sourceDir,
+            List<File> targetResolutionRootDirs,
+            List<SourceRoot> sourceRoots,
+            List<String> out,
+            Set<String> seen,
+            IProgressMonitor monitor
+    ) throws IOException {
+        List<SourceDirectoryMatch> sourceDirectoryMatches = deriveRelativeDirectoryMatchesFromSource(sourceDir, sourceRoots, monitor);
+        if (sourceDirectoryMatches.isEmpty()) {
+            return SourceDirectoryResolution.NOT_SOURCE_DIRECTORY;
+        }
+
+        File sourceDirFile = new File(sourceDir);
+        if (!containsJavaSourceRecursively(sourceDirFile, monitor)) {
+            return SourceDirectoryResolution.NOT_SOURCE_DIRECTORY;
+        }
+
+        boolean sourceDirectoryMatched = false;
+        for (SourceDirectoryMatch match : sourceDirectoryMatches) {
+            sourceDirectoryMatched = true;
+            if (targetResolutionRootDirs == null || targetResolutionRootDirs.isEmpty()) {
+                continue;
+            }
+
+            boolean addedForRelative = false;
+            String relDir = normalizePath(match.relativePath);
+            if (relDir.isEmpty()) {
+                int before = out.size();
+                collectMappedClassesForSourceTree(
+                        sourceDirFile,
+                        targetResolutionRootDirs,
+                        sourceRoots,
+                        out,
+                        seen,
+                        monitor
+                );
+                if (out.size() > before) {
+                    addedForRelative = true;
+                }
+            }
+            else {
+                for (File dir : targetResolutionRootDirs) {
+                    checkCanceled(monitor);
+                    if (dir == null) continue;
+                    File candidate = new File(dir, relDir);
+                    if (candidate.exists() && candidate.isDirectory()) {
+                        int before = out.size();
+                        collectClassFilesRecursively(candidate, out, seen, monitor);
+                        if (out.size() > before) {
+                            addedForRelative = true;
+                        }
+                    }
+                }
+            }
+            if (addedForRelative) {
+                return SourceDirectoryResolution.SOURCE_DIRECTORY_WITH_OUTPUTS;
+            }
+        }
+        return sourceDirectoryMatched
+                ? SourceDirectoryResolution.SOURCE_DIRECTORY_NO_OUTPUTS
+                : SourceDirectoryResolution.NOT_SOURCE_DIRECTORY;
+    }
+
+    private boolean containsJavaSourceRecursively(File dir, IProgressMonitor monitor) {
         File[] children = dir.listFiles();
         if (children == null) return false;
         for (File c : children) {
             checkCanceled(monitor);
             if (c.isDirectory()) {
-                if (collectClassFilesByBasename(c, baseName, out, seen, monitor)) {
+                if (containsJavaSourceRecursively(c, monitor)) {
                     return true;
                 }
                 continue;
             }
-            if (c.isFile() && c.getName().equals(baseName + ".class")) {
-                addIfNew(c.getAbsolutePath(), out, seen);
+            if (c.isFile() && isJavaSourceFile(c.getName())) {
                 return true;
             }
         }
         return false;
     }
 
-    private boolean collectOutputClassesForSourceDirectory(
-            String sourceDir,
+    private void collectMappedClassesForSourceTree(
+            File sourceDir,
             List<File> targetResolutionRootDirs,
+            List<SourceRoot> sourceRoots,
             List<String> out,
             Set<String> seen,
             IProgressMonitor monitor
     ) throws IOException {
-        String rel = deriveRelativePathFromSource(sourceDir);
-        if (rel == null) {
-            return false;
-        }
-        if (targetResolutionRootDirs == null || targetResolutionRootDirs.isEmpty()) {
-            return false;
-        }
-
-        boolean added = false;
-        String relDir = normalizePath(rel);
-        for (File dir : targetResolutionRootDirs) {
+        File[] children = sourceDir.listFiles();
+        if (children == null) return;
+        for (File c : children) {
             checkCanceled(monitor);
-            if (dir == null) continue;
-            File candidate = relDir.isEmpty() ? dir : new File(dir, relDir);
-            if (candidate.exists() && candidate.isDirectory()) {
-                int before = out.size();
-                collectTargetsRecursively(candidate, targetResolutionRootDirs, out, seen, monitor);
-                if (out.size() > before) {
-                    added = true;
-                }
+            if (c.isDirectory()) {
+                collectMappedClassesForSourceTree(c, targetResolutionRootDirs, sourceRoots, out, seen, monitor);
+                continue;
+            }
+            if (c.isFile() && isJavaSourceFile(c.getName())) {
+                addTargetsForJavaFile(c.getAbsolutePath(), targetResolutionRootDirs, sourceRoots, out, seen, monitor);
             }
         }
-        return added;
+    }
+
+    private void collectClassFilesRecursively(
+            File dir,
+            List<String> out,
+            Set<String> seen,
+            IProgressMonitor monitor
+    ) {
+        File[] children = dir.listFiles();
+        if (children == null) return;
+        for (File c : children) {
+            checkCanceled(monitor);
+            if (c.isDirectory()) {
+                collectClassFilesRecursively(c, out, seen, monitor);
+                continue;
+            }
+            if (c.isFile() && isClassFile(c.getName())) {
+                addIfNew(c.getAbsolutePath(), out, seen);
+            }
+        }
     }
 
     private boolean addTargetsForJavaFile(
             String javaPath,
             List<File> targetResolutionRootDirs,
+            List<SourceRoot> sourceRoots,
             List<String> out,
             Set<String> seen,
             IProgressMonitor monitor
     ) throws IOException {
         boolean added = false;
-        String rel = deriveRelativePathFromSource(javaPath);
-        if (rel != null && targetResolutionRootDirs != null && !targetResolutionRootDirs.isEmpty()) {
-            String classRel = normalizePath(rel).replace(".java", ".class");
-            for (File dir : targetResolutionRootDirs) {
-                checkCanceled(monitor);
-                if (dir == null) continue;
-                File candidate = new File(dir, classRel);
-                if (candidate.exists() && candidate.isFile()) {
-                    addIfNew(candidate.getAbsolutePath(), out, seen);
-                    added = true;
-                    break;
+        if (targetResolutionRootDirs != null && !targetResolutionRootDirs.isEmpty()) {
+            for (String rel : deriveRelativePathsFromSource(javaPath, sourceRoots, monitor)) {
+                String classRel = toClassRelativePath(rel);
+                if (classRel == null) {
+                    continue;
                 }
-            }
-        }
-
-        if (!added && targetResolutionRootDirs != null && !targetResolutionRootDirs.isEmpty()) {
-            // Fallback: basename scan (may be ambiguous when multiple classes share the same simple name)
-            String baseName = stripExtension(new File(javaPath).getName());
-            for (File dir : targetResolutionRootDirs) {
-                checkCanceled(monitor);
-                if (dir == null) continue;
-                if (collectClassFilesByBasename(dir, baseName, out, seen, monitor)) {
-                    added = true;
+                for (File dir : targetResolutionRootDirs) {
+                    checkCanceled(monitor);
+                    if (dir == null) continue;
+                    if (addClassFamily(dir, classRel, out, seen, monitor)) {
+                        added = true;
+                        break;
+                    }
+                }
+                if (added) {
                     break;
                 }
             }
         }
 
         return added;
+    }
+
+    private boolean addClassFamily(
+            File outputRoot,
+            String classRel,
+            List<String> out,
+            Set<String> seen,
+            IProgressMonitor monitor
+    ) {
+        File anchor = new File(outputRoot, classRel);
+        if (!anchor.exists() || !anchor.isFile()) {
+            return false;
+        }
+
+        File packageDir = anchor.getParentFile();
+        String anchorName = anchor.getName();
+        String baseName = anchorName.substring(0, anchorName.length() - ".class".length());
+        addIfNew(anchor.getAbsolutePath(), out, seen);
+
+        File[] siblings = packageDir != null ? packageDir.listFiles() : null;
+        if (siblings == null) {
+            return true;
+        }
+
+        List<File> nestedClasses = new ArrayList<>();
+        String nestedPrefix = baseName + "$";
+        for (File sibling : siblings) {
+            checkCanceled(monitor);
+            if (!sibling.isFile()) {
+                continue;
+            }
+            String siblingName = sibling.getName();
+            if (siblingName.startsWith(nestedPrefix) && siblingName.endsWith(".class")) {
+                nestedClasses.add(sibling);
+            }
+        }
+        nestedClasses.sort((a, b) -> a.getName().compareTo(b.getName()));
+        for (File nestedClass : nestedClasses) {
+            checkCanceled(monitor);
+            addIfNew(nestedClass.getAbsolutePath(), out, seen);
+        }
+        return true;
+    }
+
+    private List<String> deriveRelativePathsFromSource(
+            String sourcePath,
+            List<SourceRoot> sourceRoots,
+            IProgressMonitor monitor
+    ) {
+        LinkedHashSet<String> candidates = new LinkedHashSet<>();
+        Path source = toNormalizedPath(sourcePath);
+        if (source != null && sourceRoots != null) {
+            for (SourceRoot root : sourceRoots) {
+                checkCanceled(monitor);
+                if (!source.startsWith(root.path)) {
+                    continue;
+                }
+                Path relative = root.path.relativize(source);
+                String rel = normalizeRelativePath(relative.toString());
+                if (!rel.isEmpty()) {
+                    candidates.add(rel);
+                }
+                return new ArrayList<>(candidates);
+            }
+        }
+
+        String markerCandidate = deriveRelativePathFromSource(sourcePath);
+        if (markerCandidate == null) {
+            return new ArrayList<>();
+        }
+        candidates.add(normalizeRelativePath(markerCandidate));
+        return new ArrayList<>(candidates);
+    }
+
+    private List<SourceDirectoryMatch> deriveRelativeDirectoryMatchesFromSource(
+            String sourceDir,
+            List<SourceRoot> sourceRoots,
+            IProgressMonitor monitor
+    ) {
+        List<SourceDirectoryMatch> candidates = new ArrayList<>();
+        Path source = toNormalizedPath(sourceDir);
+        if (source != null && sourceRoots != null) {
+            for (SourceRoot root : sourceRoots) {
+                checkCanceled(monitor);
+                if (!source.startsWith(root.path)) {
+                    continue;
+                }
+                Path relative = root.path.relativize(source);
+                candidates.add(new SourceDirectoryMatch(
+                        normalizeRelativePath(relative.toString())
+                ));
+                return candidates;
+            }
+        }
+
+        String markerCandidate = deriveRelativeDirectoryPathFromSource(sourceDir);
+        if (markerCandidate == null) {
+            return candidates;
+        }
+        candidates.add(new SourceDirectoryMatch(
+                normalizeRelativePath(markerCandidate)
+        ));
+        return candidates;
     }
 
     private String deriveRelativePathFromSource(String sourcePath) {
@@ -182,6 +380,41 @@ public class TargetResolver {
         return null;
     }
 
+    private String deriveRelativeDirectoryPathFromSource(String sourceDir) {
+        String norm = normalizeSourceDirectoryPath(sourceDir);
+        String[] markers = new String[]{"/src/main/java", "/src/test/java", "/src/java", "/src"};
+        for (String marker : markers) {
+            String markerWithChild = marker + "/";
+            int markerWithChildIndex = norm.indexOf(markerWithChild);
+            if (markerWithChildIndex >= 0) {
+                return norm.substring(markerWithChildIndex + markerWithChild.length());
+            }
+            int exactMarkerIndex = norm.indexOf(marker);
+            if (exactMarkerIndex >= 0 && exactMarkerIndex + marker.length() == norm.length()) {
+                return "";
+            }
+        }
+        int javaRootIndex = norm.lastIndexOf("/java/");
+        if (javaRootIndex >= 0 && javaRootIndex + 6 < norm.length()) {
+            return norm.substring(javaRootIndex + 6);
+        }
+        if (norm.endsWith("/java")) {
+            return "";
+        }
+        return null;
+    }
+
+    private String normalizeSourceDirectoryPath(String sourceDir) {
+        String norm = sourceDir.replace('\\', '/');
+        while (norm.endsWith("/.")) {
+            norm = norm.substring(0, norm.length() - 2);
+        }
+        while (norm.endsWith("/") && norm.length() > 1) {
+            norm = norm.substring(0, norm.length() - 1);
+        }
+        return norm;
+    }
+
     private String normalizePath(String value) {
         if (value == null || value.isEmpty()) {
             return "";
@@ -194,9 +427,65 @@ public class TargetResolver {
         return withFsSep;
     }
 
-    private String stripExtension(String name) {
-        int i = name.lastIndexOf('.');
-        return (i >= 0) ? name.substring(0, i) : name;
+    private String normalizeRelativePath(String value) {
+        String normalized = normalizePath(value);
+        if (normalized.isEmpty()) {
+            return "";
+        }
+        try {
+            String relative = Paths.get(normalized).normalize().toString();
+            if (".".equals(relative)) {
+                return "";
+            }
+            return relative.replace(File.separatorChar, '/');
+        } catch (InvalidPathException ex) {
+            return normalized.replace(File.separatorChar, '/');
+        }
+    }
+
+    private String toClassRelativePath(String sourceRelativePath) {
+        String rel = normalizePath(sourceRelativePath);
+        if (!rel.toLowerCase(Locale.ROOT).endsWith(".java")) {
+            return null;
+        }
+        return rel.substring(0, rel.length() - ".java".length()) + ".class";
+    }
+
+    private Path toNormalizedPath(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            return Paths.get(value.trim()).toAbsolutePath().normalize();
+        } catch (InvalidPathException ex) {
+            return null;
+        }
+    }
+
+    private List<SourceRoot> normalizeSourceRoots(List<String> sourcepaths) {
+        List<SourceRoot> roots = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+        if (sourcepaths == null) {
+            return roots;
+        }
+        int index = 0;
+        for (String sourcepath : sourcepaths) {
+            Path root = toNormalizedPath(sourcepath);
+            if (root == null) {
+                index++;
+                continue;
+            }
+            String key = root.toString();
+            if (seen.add(key)) {
+                roots.add(new SourceRoot(root, index));
+            }
+            index++;
+        }
+        roots.sort((a, b) -> {
+            int lengthCompare = Integer.compare(b.path.toString().length(), a.path.toString().length());
+            return lengthCompare != 0 ? lengthCompare : Integer.compare(a.index, b.index);
+        });
+        return roots;
     }
 
     private boolean isAnalysisTargetFile(String name) {
@@ -207,6 +496,14 @@ public class TargetResolver {
         return lower.endsWith(".class") || lower.endsWith(".jar") || lower.endsWith(".zip");
     }
 
+    private boolean isClassFile(String name) {
+        return name != null && name.toLowerCase(Locale.ROOT).endsWith(".class");
+    }
+
+    private boolean isJavaSourceFile(String name) {
+        return name != null && name.toLowerCase(Locale.ROOT).endsWith(".java");
+    }
+
     private void addIfNew(String path, List<String> out, Set<String> seen) {
         if (seen.add(path)) out.add(path);
     }
@@ -215,5 +512,29 @@ public class TargetResolver {
         if (monitor != null && monitor.isCanceled()) {
             throw new java.util.concurrent.CancellationException("Command cancelled");
         }
+    }
+
+    private static final class SourceRoot {
+        private final Path path;
+        private final int index;
+
+        private SourceRoot(Path path, int index) {
+            this.path = path;
+            this.index = index;
+        }
+    }
+
+    private static final class SourceDirectoryMatch {
+        private final String relativePath;
+
+        private SourceDirectoryMatch(String relativePath) {
+            this.relativePath = relativePath;
+        }
+    }
+
+    private enum SourceDirectoryResolution {
+        NOT_SOURCE_DIRECTORY,
+        SOURCE_DIRECTORY_NO_OUTPUTS,
+        SOURCE_DIRECTORY_WITH_OUTPUTS
     }
 }

--- a/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/TargetResolverTest.java
+++ b/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/TargetResolverTest.java
@@ -36,10 +36,286 @@ public class TargetResolverTest {
         assertEquals(sortedPaths(classFile, jarFile, zipFile), sorted(actual));
     }
 
+    @Test
+    public void resolvesJavaFileUsingConfiguredSourcepath() throws Exception {
+        File project = temporaryFolder.newFolder("project");
+        File sourceRoot = mkdirs(project, "generated-sources");
+        File outputRoot = mkdirs(project, "target/classes");
+        File sourceFile = touch(mkdirs(sourceRoot, "demo"), "Repro.java");
+        File outputPackage = mkdirs(outputRoot, "demo");
+        File classFile = touch(outputPackage, "Repro.class");
+        File innerClassFile = touch(outputPackage, "Repro$Inner.class");
+        File anonymousClassFile = touch(outputPackage, "Repro$1.class");
+        touch(outputPackage, "ReproOther.class");
+        touch(outputPackage, "Other.class");
+
+        List<String> actual = new TargetResolver().resolveTargets(
+                new String[] { sourceFile.getAbsolutePath() },
+                Collections.singletonList(outputRoot),
+                Collections.singletonList(sourceRoot.getAbsolutePath()),
+                null
+        );
+
+        assertEquals(sortedPaths(classFile, anonymousClassFile, innerClassFile), sorted(actual));
+    }
+
+    @Test
+    public void prefersLongestConfiguredSourcepathForJavaFile() throws Exception {
+        File project = temporaryFolder.newFolder("project");
+        File broadSourceRoot = mkdirs(project, "generated-sources");
+        File narrowSourceRoot = mkdirs(broadSourceRoot, "demo");
+        File outputRoot = mkdirs(project, "target/classes");
+        File sourceFile = touch(narrowSourceRoot, "Repro.java");
+        File broadClassFile = touch(mkdirs(outputRoot, "demo"), "Repro.class");
+        File narrowClassFile = touch(outputRoot, "Repro.class");
+
+        List<String> actual = new TargetResolver().resolveTargets(
+                new String[] { sourceFile.getAbsolutePath() },
+                Collections.singletonList(outputRoot),
+                listOf(broadSourceRoot.getAbsolutePath(), narrowSourceRoot.getAbsolutePath()),
+                null
+        );
+
+        assertEquals(Collections.singletonList(narrowClassFile.getAbsolutePath()), actual);
+        assertTrue(broadClassFile.exists());
+    }
+
+    @Test
+    public void doesNotFallBackToBroaderSourcepathWhenLongestCandidateHasNoClass() throws Exception {
+        File project = temporaryFolder.newFolder("project");
+        File broadSourceRoot = mkdirs(project, "generated-sources");
+        File narrowSourceRoot = mkdirs(broadSourceRoot, "demo");
+        File outputRoot = mkdirs(project, "target/classes");
+        File sourceFile = touch(narrowSourceRoot, "Repro.java");
+        touch(mkdirs(outputRoot, "demo"), "Repro.class");
+
+        List<String> actual = new TargetResolver().resolveTargets(
+                new String[] { sourceFile.getAbsolutePath() },
+                Collections.singletonList(outputRoot),
+                listOf(broadSourceRoot.getAbsolutePath(), narrowSourceRoot.getAbsolutePath()),
+                null
+        );
+
+        assertEquals(Collections.emptyList(), actual);
+    }
+
+    @Test
+    public void keepsMarkerFallbackWhenSourcepathDoesNotMatchJavaFile() throws Exception {
+        File project = temporaryFolder.newFolder("project");
+        File sourceRoot = mkdirs(project, "src/main/java");
+        File outputRoot = mkdirs(project, "target/classes");
+        File sourceFile = touch(mkdirs(sourceRoot, "demo"), "Repro.java");
+        File classFile = touch(mkdirs(outputRoot, "demo"), "Repro.class");
+
+        List<String> actual = new TargetResolver().resolveTargets(
+                new String[] { sourceFile.getAbsolutePath() },
+                Collections.singletonList(outputRoot),
+                Collections.singletonList(new File(project, "other-source").getAbsolutePath()),
+                null
+        );
+
+        assertEquals(Collections.singletonList(classFile.getAbsolutePath()), actual);
+    }
+
+    @Test
+    public void doesNotResolveJavaFileByBasenameWhenConfiguredSourcepathCandidateFails() throws Exception {
+        File project = temporaryFolder.newFolder("project");
+        File sourceRoot = mkdirs(project, "generated-sources");
+        File outputRoot = mkdirs(project, "target/classes");
+        File sourceFile = touch(mkdirs(sourceRoot, "demo"), "Repro.java");
+        touch(mkdirs(outputRoot, "other"), "Repro.class");
+
+        List<String> actual = new TargetResolver().resolveTargets(
+                new String[] { sourceFile.getAbsolutePath() },
+                Collections.singletonList(outputRoot),
+                Collections.singletonList(sourceRoot.getAbsolutePath()),
+                null
+        );
+
+        assertEquals(Collections.emptyList(), actual);
+    }
+
+    @Test
+    public void resolvesSourceDirectoryUsingConfiguredSourcepath() throws Exception {
+        File project = temporaryFolder.newFolder("project");
+        File sourceRoot = mkdirs(project, "generated-sources");
+        File sourceDir = mkdirs(sourceRoot, "demo");
+        File outputRoot = mkdirs(project, "target/classes");
+        touch(sourceDir, "Repro.java");
+        File classFile = touch(mkdirs(outputRoot, "demo"), "Repro.class");
+
+        List<String> actual = new TargetResolver().resolveTargets(
+                new String[] { sourceDir.getAbsolutePath() },
+                Collections.singletonList(outputRoot),
+                Collections.singletonList(sourceRoot.getAbsolutePath()),
+                null
+        );
+
+        assertEquals(Collections.singletonList(classFile.getAbsolutePath()), actual);
+    }
+
+    @Test
+    public void bytecodeOnlyDirectoryUnderConfiguredSourcepathFallsBackToDirectCollection() throws Exception {
+        File project = temporaryFolder.newFolder("project");
+        File sourceRoot = mkdirs(project, "src/main/java");
+        File selectedDir = mkdirs(sourceRoot, "lib");
+        File outputRoot = mkdirs(project, "target/classes");
+        File classFile = touch(selectedDir, "Library.class");
+        File jarFile = touch(selectedDir, "library.jar");
+        File zipFile = touch(selectedDir, "archive.zip");
+        touch(mkdirs(outputRoot, "other"), "Other.class");
+
+        List<String> actual = new TargetResolver().resolveTargets(
+                new String[] { selectedDir.getAbsolutePath() },
+                Collections.singletonList(outputRoot),
+                Collections.singletonList(sourceRoot.getAbsolutePath()),
+                null
+        );
+
+        assertEquals(sortedPaths(classFile, jarFile, zipFile), sorted(actual));
+    }
+
+    @Test
+    public void sourceDirectoryMappingExcludesArchivesFromMappedOutputPackage() throws Exception {
+        File project = temporaryFolder.newFolder("project");
+        File sourceRoot = mkdirs(project, "generated-sources");
+        File sourceDir = mkdirs(sourceRoot, "demo");
+        File outputRoot = mkdirs(project, "target/classes");
+        File outputPackage = mkdirs(outputRoot, "demo");
+        touch(sourceDir, "Repro.java");
+        File classFile = touch(outputPackage, "Repro.class");
+        touch(outputPackage, "library.jar");
+        touch(outputPackage, "archive.zip");
+
+        List<String> actual = new TargetResolver().resolveTargets(
+                new String[] { sourceDir.getAbsolutePath() },
+                Collections.singletonList(outputRoot),
+                Collections.singletonList(sourceRoot.getAbsolutePath()),
+                null
+        );
+
+        assertEquals(Collections.singletonList(classFile.getAbsolutePath()), actual);
+    }
+
+    @Test
+    public void markerLikeBytecodeOnlyDirectoriesFallBackToDirectCollection() throws Exception {
+        int index = 0;
+        for (String relativeSourceLikePath : listOf(
+                "src/lib",
+                "src/main/java/lib",
+                "src/main/resources/lib",
+                "generated/java"
+        )) {
+            File project = temporaryFolder.newFolder("project-" + index++);
+            File selectedDir = mkdirs(project, relativeSourceLikePath);
+            File outputRoot = mkdirs(project, "target/classes");
+            File classFile = touch(selectedDir, "Library.class");
+            File jarFile = touch(selectedDir, "library.jar");
+            File zipFile = touch(selectedDir, "archive.zip");
+            touch(mkdirs(outputRoot, "other"), "Other.class");
+
+            List<String> actual = new TargetResolver().resolveTargets(
+                    new String[] { selectedDir.getAbsolutePath() },
+                    Collections.singletonList(outputRoot),
+                    Collections.emptyList(),
+                    null
+            );
+
+            assertEquals(sortedPaths(classFile, jarFile, zipFile), sorted(actual));
+        }
+    }
+
+    @Test
+    public void sourcepathRootDirectoryOnlyCollectsMappedClasses() throws Exception {
+        File project = temporaryFolder.newFolder("project");
+        File sourceRoot = mkdirs(project, "generated-sources");
+        File outputRoot = mkdirs(project, "target/classes");
+        File sourcePackage = mkdirs(sourceRoot, "demo");
+        File outputPackage = mkdirs(outputRoot, "demo");
+        File otherOutput = mkdirs(outputRoot, "other");
+        touch(sourcePackage, "Repro.java");
+        File classFile = touch(outputPackage, "Repro.class");
+        File innerClassFile = touch(outputPackage, "Repro$Inner.class");
+        File anonymousClassFile = touch(outputPackage, "Repro$1.class");
+        touch(outputPackage, "ReproOther.class");
+        touch(otherOutput, "Other.class");
+        touch(sourcePackage, "Missing.java");
+        touch(sourcePackage, "library.jar");
+        touch(otherOutput, "Missing.class");
+
+        List<String> actual = new TargetResolver().resolveTargets(
+                new String[] { sourceRoot.getAbsolutePath() },
+                Collections.singletonList(outputRoot),
+                Collections.singletonList(sourceRoot.getAbsolutePath()),
+                null
+        );
+
+        assertEquals(sortedPaths(classFile, anonymousClassFile, innerClassFile), sorted(actual));
+    }
+
+    @Test
+    public void exactJavaSourceRootDirectoryMapsToOutputClasses() throws Exception {
+        File project = temporaryFolder.newFolder("project");
+        File sourceRoot = mkdirs(project, "generated/java");
+        File outputRoot = mkdirs(project, "target/classes");
+        File sourcePackage = mkdirs(sourceRoot, "demo");
+        touch(sourcePackage, "Repro.java");
+        touch(sourcePackage, "library.jar");
+        File classFile = touch(mkdirs(outputRoot, "demo"), "Repro.class");
+
+        List<String> actual = new TargetResolver().resolveTargets(
+                new String[] { sourceRoot.getAbsolutePath() },
+                Collections.singletonList(outputRoot),
+                Collections.emptyList(),
+                null
+        );
+
+        assertEquals(Collections.singletonList(classFile.getAbsolutePath()), sorted(actual));
+    }
+
+    @Test
+    public void markerSourceRootDirectoryVariantsDoNotExpandToEntireOutputRoot() throws Exception {
+        File project = temporaryFolder.newFolder("project");
+        File sourceRoot = mkdirs(project, "src/main/java");
+        File outputRoot = mkdirs(project, "target/classes");
+        File sourcePackage = mkdirs(sourceRoot, "demo");
+        touch(sourcePackage, "Repro.java");
+        touch(sourcePackage, "library.jar");
+        File classFile = touch(mkdirs(outputRoot, "demo"), "Repro.class");
+        touch(mkdirs(outputRoot, "other"), "Other.class");
+
+        for (String sourceRootPath : listOf(
+                sourceRoot.getAbsolutePath(),
+                sourceRoot.getAbsolutePath() + File.separator,
+                sourceRoot.getAbsolutePath() + File.separator + "."
+        )) {
+            List<String> actual = new TargetResolver().resolveTargets(
+                    new String[] { sourceRootPath },
+                    Collections.singletonList(outputRoot),
+                    Collections.emptyList(),
+                    null
+            );
+
+            assertEquals(Collections.singletonList(classFile.getAbsolutePath()), sorted(actual));
+        }
+    }
+
     private File touch(File parent, String name) throws Exception {
         File file = new File(parent, name);
         assertTrue(file.createNewFile());
         return file;
+    }
+
+    private File mkdirs(File parent, String relativePath) {
+        File dir = new File(parent, relativePath);
+        assertTrue(dir.mkdirs());
+        return dir;
+    }
+
+    private List<String> listOf(String... values) {
+        List<String> result = new ArrayList<>();
+        Collections.addAll(result, values);
+        return result;
     }
 
     private List<String> sortedPaths(File... files) {

--- a/src/orchestration/analysisNotices.ts
+++ b/src/orchestration/analysisNotices.ts
@@ -178,7 +178,7 @@ function translateResolutionIssue(
         level: 'info',
         code: issue.code,
         message:
-          'SpotBugs: Java build output metadata was unavailable; output folder fallback was used.',
+          'SpotBugs: Java build output metadata was unavailable or unusable for the selected target; output folder fallback was used.',
       };
     case 'JAVA_LS_NO_RESULT':
       return translateJavaLsLookupFallbackNotice(issue, context);

--- a/src/test/L0.analysisNotices.test.ts
+++ b/src/test/L0.analysisNotices.test.ts
@@ -75,7 +75,7 @@ describe('analysisNotices', () => {
         level: 'info',
         source: 'target-resolution',
         phase: 'output-fallback',
-        message: 'Output folder fallback was used because Java build output metadata was unavailable.',
+        message: 'Output folder fallback was used because Java build output metadata was unavailable or unusable for the selected target.',
       },
     ]);
 
@@ -90,7 +90,7 @@ describe('analysisNotices', () => {
         level: 'info',
         code: 'OUTPUT_FALLBACK_USED',
         message:
-          'SpotBugs: Java build output metadata was unavailable; output folder fallback was used.',
+          'SpotBugs: Java build output metadata was unavailable or unusable for the selected target; output folder fallback was used.',
       },
     ]);
   });
@@ -108,7 +108,7 @@ describe('analysisNotices', () => {
             level: 'info',
             source: 'target-resolution',
             phase: 'output-fallback',
-            message: 'Output folder fallback was used because Java build output metadata was unavailable.',
+            message: 'Output folder fallback was used because Java build output metadata was unavailable or unusable for the selected target.',
           },
         ],
       }
@@ -119,7 +119,7 @@ describe('analysisNotices', () => {
         level: 'info',
         code: 'OUTPUT_FALLBACK_USED',
         message:
-          'SpotBugs: Java build output metadata was unavailable; output folder fallback was used.',
+          'SpotBugs: Java build output metadata was unavailable or unusable for the selected target; output folder fallback was used.',
       },
     ]);
   });
@@ -144,7 +144,7 @@ describe('analysisNotices', () => {
             source: 'target-resolution',
             phase: 'output-fallback',
             message:
-              'Output folder fallback was used because Java build output metadata was unavailable.',
+              'Output folder fallback was used because Java build output metadata was unavailable or unusable for the selected target.',
           },
         ],
       }
@@ -160,7 +160,7 @@ describe('analysisNotices', () => {
         level: 'info',
         code: 'OUTPUT_FALLBACK_USED',
         message:
-          'SpotBugs: Java build output metadata was unavailable; output folder fallback was used.',
+          'SpotBugs: Java build output metadata was unavailable or unusable for the selected target; output folder fallback was used.',
       },
     ]);
   });
@@ -382,7 +382,7 @@ describe('analysisNotices', () => {
             source: 'target-resolution',
             phase: 'output-fallback',
             message:
-              'Output folder fallback was used because Java build output metadata was unavailable.',
+              'Output folder fallback was used because Java build output metadata was unavailable or unusable for the selected target.',
           },
         ],
       }
@@ -398,7 +398,7 @@ describe('analysisNotices', () => {
         level: 'info',
         code: 'OUTPUT_FALLBACK_USED',
         message:
-          'SpotBugs: Java build output metadata was unavailable; output folder fallback was used.',
+          'SpotBugs: Java build output metadata was unavailable or unusable for the selected target; output folder fallback was used.',
       },
     ]);
     assert.ok(
@@ -431,7 +431,7 @@ describe('analysisNotices', () => {
             source: 'target-resolution',
             phase: 'output-fallback',
             message:
-              'Output folder fallback was used because Java build output metadata was unavailable.',
+              'Output folder fallback was used because Java build output metadata was unavailable or unusable for the selected target.',
           },
         ],
       }
@@ -448,7 +448,7 @@ describe('analysisNotices', () => {
         level: 'info',
         code: 'OUTPUT_FALLBACK_USED',
         message:
-          'SpotBugs: Java build output metadata was unavailable; output folder fallback was used.',
+          'SpotBugs: Java build output metadata was unavailable or unusable for the selected target; output folder fallback was used.',
       },
     ]);
   });

--- a/src/test/L0.classpathService.test.ts
+++ b/src/test/L0.classpathService.test.ts
@@ -1,7 +1,17 @@
 import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { installVscodeMock, resetVscodeMock } from './helpers/mockVscode';
 import { deriveTargetResolutionRoots } from '../workspace/classpathLayout';
 
 describe('classpathService', () => {
+  beforeEach(() => {
+    installVscodeMock();
+    resetVscodeMock();
+    delete require.cache[require.resolve('../workspace/classpathService')];
+  });
+
   it('prepends the output folder, filters archives, and dedupes roots', () => {
     const roots = deriveTargetResolutionRoots('/workspace/build/classes', [
       '/workspace/build/classes',
@@ -30,5 +40,215 @@ describe('classpathService', () => {
       'C:\\workspace\\build\\classes',
       'C:\\workspace\\bin',
     ]);
+  });
+
+  it('detects windows workspace prefix siblings case-insensitively', () => {
+    const { isWorkspacePrefixSibling } =
+      require('../workspace/classpathService') as typeof import('../workspace/classpathService');
+
+    assert.strictEqual(
+      isWorkspacePrefixSibling(
+        'C:\\Workspace\\Project',
+        'c:\\workspace\\project-other\\target\\classes'
+      ),
+      true
+    );
+  });
+
+  it('does not treat drive-root workspace children as prefix siblings', () => {
+    const { isWorkspacePrefixSibling } =
+      require('../workspace/classpathService') as typeof import('../workspace/classpathService');
+
+    assert.strictEqual(
+      isWorkspacePrefixSibling('C:\\', 'C:\\workspace\\project\\target\\classes'),
+      false
+    );
+  });
+
+  it('skips outside preferred output candidates before returning inside candidates', async () => {
+    const { deriveOutputFolder } =
+      require('../workspace/classpathService') as typeof import('../workspace/classpathService');
+    const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'spotbugs-cp-'));
+    const workspacePath = path.join(tempRoot, 'project');
+    const siblingOutput = path.join(tempRoot, 'project-other', 'target', 'classes');
+    const workspaceOutput = path.join(workspacePath, 'target', 'classes');
+    await fs.promises.mkdir(siblingOutput, { recursive: true });
+    await fs.promises.mkdir(workspaceOutput, { recursive: true });
+
+    try {
+      const actual = await deriveOutputFolder(
+        [siblingOutput, workspaceOutput],
+        workspacePath,
+        async () => true
+      );
+
+      assert.strictEqual(actual, workspaceOutput);
+    } finally {
+      await fs.promises.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('can scope preferred output candidates to the selected project boundary', async () => {
+    const { deriveOutputFolder } =
+      require('../workspace/classpathService') as typeof import('../workspace/classpathService');
+    const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'spotbugs-cp-'));
+    const workspacePath = path.join(tempRoot, 'workspace');
+    const projectA = path.join(workspacePath, 'project-a');
+    const projectBOutput = path.join(workspacePath, 'project-b', 'target', 'classes');
+    const projectAOutput = path.join(projectA, 'target', 'classes');
+    await fs.promises.mkdir(projectBOutput, { recursive: true });
+    await fs.promises.mkdir(projectAOutput, { recursive: true });
+
+    try {
+      const actual = await deriveOutputFolder(
+        [projectBOutput, projectAOutput],
+        projectA,
+        async () => true,
+        { allowRecognizedOutputOutsideBoundary: false }
+      );
+
+      assert.strictEqual(actual, projectAOutput);
+    } finally {
+      await fs.promises.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('skips external generic classpath roots before returning workspace candidates', async () => {
+    const { deriveOutputFolder } =
+      require('../workspace/classpathService') as typeof import('../workspace/classpathService');
+    const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'spotbugs-cp-'));
+    const workspacePath = path.join(tempRoot, 'workspace', 'project');
+    const externalClasspathRoot = path.join(tempRoot, 'external-deps', 'generated');
+    const workspaceOutput = path.join(workspacePath, 'custom-output');
+    await fs.promises.mkdir(externalClasspathRoot, { recursive: true });
+    await fs.promises.mkdir(workspaceOutput, { recursive: true });
+
+    try {
+      const actual = await deriveOutputFolder(
+        [externalClasspathRoot, workspaceOutput],
+        workspacePath,
+        async () => true
+      );
+
+      assert.strictEqual(actual, workspaceOutput);
+    } finally {
+      await fs.promises.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('skips external descendants under recognized output roots', async () => {
+    const { deriveOutputFolder } =
+      require('../workspace/classpathService') as typeof import('../workspace/classpathService');
+    const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'spotbugs-cp-'));
+    const workspacePath = path.join(tempRoot, 'workspace', 'project');
+    const externalOutputChild = path.join(
+      tempRoot,
+      'external-deps',
+      'target',
+      'classes',
+      'com',
+      'acme'
+    );
+    const externalOutput = path.join(tempRoot, 'external-build', 'target', 'classes');
+    await fs.promises.mkdir(externalOutputChild, { recursive: true });
+    await fs.promises.mkdir(externalOutput, { recursive: true });
+
+    try {
+      const actual = await deriveOutputFolder(
+        [externalOutputChild, externalOutput],
+        workspacePath,
+        async () => true
+      );
+
+      assert.strictEqual(actual, externalOutput);
+    } finally {
+      await fs.promises.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('recognizes mixed-case Windows output suffixes outside the workspace', async () => {
+    const { deriveOutputFolder } =
+      require('../workspace/classpathService') as typeof import('../workspace/classpathService');
+    const windowsOutput = 'C:\\external-build\\TARGET\\CLASSES';
+    const originalStat = fs.promises.stat;
+    fs.promises.stat = (async (targetPath: fs.PathLike) => {
+      if (targetPath === windowsOutput) {
+        return { isDirectory: () => true } as fs.Stats;
+      }
+      throw new Error(`Unexpected stat path: ${String(targetPath)}`);
+    }) as typeof fs.promises.stat;
+
+    try {
+      const actual = await deriveOutputFolder(
+        [windowsOutput],
+        'D:\\workspace\\project',
+        async () => true
+      );
+
+      assert.strictEqual(actual, windowsOutput);
+    } finally {
+      fs.promises.stat = originalStat;
+    }
+  });
+
+  it('orders derived output folders by specificity and source set', async () => {
+    const { deriveOutputFolder } =
+      require('../workspace/classpathService') as typeof import('../workspace/classpathService');
+    const cases = [
+      {
+        roots: ['build/classes', 'build/classes/java/main'],
+        expected: 'build/classes/java/main',
+      },
+      {
+        roots: ['bin', 'bin/main'],
+        expected: 'bin/main',
+      },
+      {
+        roots: ['target/test-classes', 'build/classes/java/main'],
+        expected: 'build/classes/java/main',
+      },
+    ];
+
+    for (const testCase of cases) {
+      const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'spotbugs-cp-'));
+      const workspacePath = path.join(tempRoot, 'project');
+      const roots = testCase.roots.map((root) => path.join(workspacePath, root));
+      await Promise.all(roots.map((root) => fs.promises.mkdir(root, { recursive: true })));
+
+      try {
+        const actual = await deriveOutputFolder(roots, workspacePath, async () => true);
+
+        assert.strictEqual(
+          actual,
+          path.join(workspacePath, testCase.expected),
+          testCase.expected
+        );
+      } finally {
+        await fs.promises.rm(tempRoot, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('skips derived output candidates rejected by the supplied predicate', async () => {
+    const { deriveOutputFolder } =
+      require('../workspace/classpathService') as typeof import('../workspace/classpathService');
+    const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'spotbugs-cp-'));
+    const workspacePath = path.join(tempRoot, 'project');
+    const archiveOnlyOutput = path.join(workspacePath, 'build', 'classes', 'java', 'main');
+    const classOutput = path.join(workspacePath, 'target', 'classes');
+    await fs.promises.mkdir(archiveOnlyOutput, { recursive: true });
+    await fs.promises.mkdir(classOutput, { recursive: true });
+
+    try {
+      const actual = await deriveOutputFolder(
+        [archiveOnlyOutput, classOutput],
+        workspacePath,
+        async (candidate) => candidate === classOutput
+      );
+
+      assert.strictEqual(actual, classOutput);
+    } finally {
+      await fs.promises.rm(tempRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/src/test/L0.outputResolver.test.ts
+++ b/src/test/L0.outputResolver.test.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import {
   findOutputFolderFromProject,
   hasClassTargets,
+  hasLooseClassTargets,
   isBytecodeTarget,
 } from '../workspace/outputResolver';
 
@@ -54,6 +55,30 @@ describe('outputResolver', () => {
     }
   });
 
+  it('detects loose class targets without counting archives', async () => {
+    const classDir = await makeTempDir();
+    const archiveDir = await makeTempDir();
+    const directDir = await makeTempDir();
+    try {
+      await writeFile(path.join(classDir, 'classes', 'Foo.class'));
+      await writeFile(path.join(archiveDir, 'libs', 'app.jar'));
+      const jarPath = path.join(directDir, 'app.jar');
+      const classPath = path.join(directDir, 'Foo.CLASS');
+      await writeFile(jarPath);
+      await writeFile(classPath);
+
+      assert.strictEqual(await hasLooseClassTargets(classDir), true);
+      assert.strictEqual(await hasLooseClassTargets(archiveDir), false);
+      assert.strictEqual(await hasClassTargets(archiveDir), true);
+      assert.strictEqual(await hasLooseClassTargets(jarPath), false);
+      assert.strictEqual(await hasLooseClassTargets(classPath), true);
+    } finally {
+      await cleanup(classDir);
+      await cleanup(archiveDir);
+      await cleanup(directDir);
+    }
+  });
+
   it('finds default output folders with class files', async () => {
     const dir = await makeTempDir();
     try {
@@ -73,6 +98,64 @@ describe('outputResolver', () => {
       await writeFile(path.join(outputDir, 'libs', 'app.ZIP'));
       const found = await findOutputFolderFromProject(dir);
       assert.strictEqual(found, outputDir);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('can find default output folders with a loose-class predicate', async () => {
+    const dir = await makeTempDir();
+    try {
+      const archiveOnlyOutputDir = path.join(dir, 'build', 'classes', 'java', 'main');
+      const classOutputDir = path.join(dir, 'target', 'classes');
+      await writeFile(path.join(archiveOnlyOutputDir, 'libs', 'app.jar'));
+      await writeFile(path.join(classOutputDir, 'demo', 'Foo.class'));
+
+      const found = await findOutputFolderFromProject(dir, hasLooseClassTargets);
+      assert.strictEqual(found, classOutputDir);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('finds standard test output folders with a loose-class predicate', async () => {
+    for (const relativeOutputDir of [
+      path.join('target', 'test-classes'),
+      path.join('build', 'classes', 'java', 'test'),
+      path.join('build', 'classes', 'kotlin', 'test'),
+      path.join('bin', 'test'),
+    ]) {
+      const dir = await makeTempDir();
+      try {
+        const outputDir = path.join(dir, relativeOutputDir);
+        await writeFile(path.join(outputDir, 'demo', 'FooTest.class'));
+
+        const found = await findOutputFolderFromProject(dir, hasLooseClassTargets);
+
+        assert.strictEqual(found, outputDir, relativeOutputDir);
+      } finally {
+        await cleanup(dir);
+      }
+    }
+  });
+
+  it('can rank default output folder candidates without changing the default order', async () => {
+    const dir = await makeTempDir();
+    try {
+      const mainOutputDir = path.join(dir, 'target', 'classes');
+      const testOutputDir = path.join(dir, 'target', 'test-classes');
+      await writeFile(path.join(mainOutputDir, 'demo', 'Foo.class'));
+      await writeFile(path.join(testOutputDir, 'demo', 'Foo.class'));
+
+      assert.strictEqual(
+        await findOutputFolderFromProject(dir, hasLooseClassTargets),
+        mainOutputDir
+      );
+
+      const found = await findOutputFolderFromProject(dir, hasLooseClassTargets, {
+        rankCandidate: ({ targetPath }) => (targetPath === testOutputDir ? 0 : 1),
+      });
+      assert.strictEqual(found, testOutputDir);
     } finally {
       await cleanup(dir);
     }

--- a/src/test/L0.workspaceSummary.test.ts
+++ b/src/test/L0.workspaceSummary.test.ts
@@ -203,14 +203,14 @@ describe('workspaceSummary', () => {
         level: 'info',
         source: 'target-resolution',
         phase: 'output-fallback',
-        message: 'Output folder fallback was used because Java build output metadata was unavailable.',
+        message: 'Output folder fallback was used because Java build output metadata was unavailable or unusable for the selected target.',
       },
       {
         code: 'OUTPUT_FALLBACK_USED',
         level: 'info',
         source: 'target-resolution',
         phase: 'output-fallback',
-        message: 'Output folder fallback was used because Java build output metadata was unavailable.',
+        message: 'Output folder fallback was used because Java build output metadata was unavailable or unusable for the selected target.',
       },
     ]);
 
@@ -223,7 +223,7 @@ describe('workspaceSummary', () => {
         level: 'info',
         code: 'OUTPUT_FALLBACK_USED',
         message:
-          'SpotBugs: Java build output metadata was unavailable; output folder fallback was used.',
+          'SpotBugs: Java build output metadata was unavailable or unusable for the selected target; output folder fallback was used.',
       },
     ]);
   });

--- a/src/test/L1.analysisService.test.ts
+++ b/src/test/L1.analysisService.test.ts
@@ -34,7 +34,7 @@ describe('analysisService', () => {
           level: 'info',
           source: 'target-resolution',
           phase: 'output-fallback',
-          message: 'Output folder fallback was used because Java build output metadata was unavailable.',
+          message: 'Output folder fallback was used because Java build output metadata was unavailable or unusable for the selected target.',
         },
       ],
     })) as typeof resolverModule.resolveFileAnalysisTargetDetailed;

--- a/src/test/L1.analysisTargetResolver.test.ts
+++ b/src/test/L1.analysisTargetResolver.test.ts
@@ -1,4 +1,6 @@
 import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { installVscodeMock, resetVscodeMock } from './helpers/mockVscode';
 
@@ -56,6 +58,12 @@ describe('analysisTargetResolver', () => {
     assert.strictEqual(
       result.resolution.status === 'ok' ? result.resolution.target.targetPath : '',
       '/workspace/project/target/classes'
+    );
+    assert.deepStrictEqual(
+      result.resolution.status === 'ok'
+        ? result.resolution.target.targetResolutionRoots
+        : undefined,
+      ['/workspace/project/target/classes']
     );
     assert.deepStrictEqual(
       result.issues.map((issue) => issue.code),
@@ -235,6 +243,875 @@ describe('analysisTargetResolver', () => {
       await assertResolvedDiagnosticScope(vscode, resolver, targetPath, 'returned-files');
     }
   });
+
+  it('rejects Java source analysis when archive-only output has no mapped class fallback', async () => {
+    const vscode = installVscodeMock();
+    const resolver = createResolver(vscode, {
+      outputPath: '/workspace/project/target/classes',
+      targetResolutionRoots: [],
+      deriveOutputFolder: async () => undefined,
+      findOutputFolderFromProject: async () => undefined,
+      hasClassTargets: async () => false,
+    });
+
+    const result = await resolver.resolveFileAnalysisTargetDetailed(
+      vscode.Uri.file('/workspace/project/src/main/java/demo/Repro.java') as any
+    );
+
+    assert.strictEqual(result.resolution.status, 'no-class-targets');
+  });
+
+  it('keeps archive-only output valid for project analysis', async () => {
+    const vscode = installVscodeMock();
+    const resolver = createResolver(vscode, {
+      outputPath: '/workspace/project/target/classes',
+      hasClassTargets: async () => true,
+    });
+
+    const result = await resolver.resolveProjectAnalysisTargetDetailed(
+      vscode.Uri.file('/workspace/project') as any,
+      vscode.Uri.file('/workspace') as any
+    );
+
+    assert.strictEqual(result.resolution.status, 'ok');
+    assert.strictEqual(
+      result.resolution.status === 'ok' ? result.resolution.target.targetPath : '',
+      '/workspace/project/target/classes'
+    );
+  });
+
+  it('does not fall back from an empty declared project output to a sibling project output', async () => {
+    const vscode = installVscodeMock();
+    const resolver = createResolver(vscode, {
+      outputPath: '/workspace/project-a/target/classes',
+      targetResolutionRoots: ['/workspace/project-b/target/classes'],
+      deriveOutputFolder: async (
+        roots: string[],
+        _classpathsRoot: string,
+        hasTargets?: (targetPath: string) => Promise<boolean>
+      ) => {
+        for (const candidate of roots) {
+          if (!hasTargets || (await hasTargets(candidate))) {
+            return candidate;
+          }
+        }
+        return undefined;
+      },
+      findOutputFolderFromProject: async () => {
+        throw new Error('project fallback should not be used');
+      },
+      hasClassTargets: async (targetPath: string) =>
+        targetPath === '/workspace/project-b/target/classes',
+    });
+
+    const result = await resolver.resolveProjectAnalysisTargetDetailed(
+      vscode.Uri.file('/workspace/project-a') as any,
+      vscode.Uri.file('/workspace') as any
+    );
+
+    assert.strictEqual(result.resolution.status, 'no-class-targets');
+    assert.deepStrictEqual(
+      result.issues.map((issue) => issue.code),
+      []
+    );
+  });
+
+  it('keeps fallback roots scoped to the selected project', async () => {
+    const vscode = installVscodeMock();
+    const projectAOutput = '/workspace/project-a/target/classes';
+    const projectBOutput = '/workspace/project-b/target/classes';
+    const firstMatchingProjectRoot = async (
+      roots: string[],
+      classpathsRoot: string,
+      hasTargets?: (targetPath: string) => Promise<boolean>
+    ) => {
+      assert.strictEqual(classpathsRoot, '/workspace/project-a');
+      assert.deepStrictEqual(roots, [projectAOutput]);
+      for (const candidate of roots) {
+        if (!hasTargets || (await hasTargets(candidate))) {
+          return candidate;
+        }
+      }
+      return undefined;
+    };
+
+    for (const testCase of [
+      {
+        name: 'Java source',
+        options: {
+          outputPath: '/workspace/project-a/build/classes/java/main',
+          hasClassTargets: async (targetPath: string) =>
+            targetPath === `${projectAOutput}/demo/Repro.class`,
+        },
+        resolve: (resolver: any) =>
+          resolver.resolveFileAnalysisTargetDetailed(
+            vscode.Uri.file('/workspace/project-a/src/main/java/demo/Repro.java') as any
+          ),
+      },
+      {
+        name: 'project',
+        options: {
+          hasClassTargets: async (targetPath: string) => targetPath === projectAOutput,
+        },
+        resolve: (resolver: any) =>
+          resolver.resolveProjectAnalysisTargetDetailed(
+            vscode.Uri.file('/workspace/project-a') as any,
+            vscode.Uri.file('/workspace') as any
+          ),
+      },
+    ]) {
+      const resolver = createResolver(vscode, {
+        ...testCase.options,
+        targetResolutionRoots: [projectBOutput, projectAOutput],
+        deriveOutputFolder: firstMatchingProjectRoot,
+        findOutputFolderFromProject: async () => {
+          throw new Error('project fallback should not be used');
+        },
+      });
+      const result = await testCase.resolve(resolver);
+
+      assert.strictEqual(result.resolution.status, 'ok', testCase.name);
+      assert.deepStrictEqual(
+        result.resolution.status === 'ok'
+          ? result.resolution.target.targetResolutionRoots
+          : undefined,
+        [projectAOutput],
+        testCase.name
+      );
+    }
+  });
+
+  it('accepts workspace-level Java LS output paths for project analysis', async () => {
+    const vscode = installVscodeMock();
+    const workspaceOutput = '/workspace/build/classes/java/main';
+    const resolver = createResolver(vscode, {
+      outputPath: workspaceOutput,
+      targetResolutionRoots: [],
+      findOutputFolderFromProject: async () => undefined,
+      hasClassTargets: async (targetPath: string) => targetPath === workspaceOutput,
+    });
+
+    const result = await resolver.resolveProjectAnalysisTargetDetailed(
+      vscode.Uri.file('/workspace/project') as any,
+      vscode.Uri.file('/workspace') as any
+    );
+
+    assert.strictEqual(result.resolution.status, 'ok');
+    assert.strictEqual(
+      result.resolution.status === 'ok'
+        ? result.resolution.target.targetPath
+        : undefined,
+      workspaceOutput
+    );
+  });
+
+  it('returns accepted output path as the Java source target-resolution root', async () => {
+    const vscode = installVscodeMock();
+    const resolver = createResolver(vscode, {
+      outputPath: '/workspace/project/build/classes/java/main',
+      targetResolutionRoots: ['/workspace/project/target/classes'],
+      hasClassTargets: async (targetPath: string) =>
+        targetPath === '/workspace/project/build/classes/java/main/demo/Repro.class',
+    });
+
+    const result = await resolver.resolveFileAnalysisTargetDetailed(
+      vscode.Uri.file('/workspace/project/src/main/java/demo/Repro.java') as any
+    );
+
+    assert.strictEqual(result.resolution.status, 'ok');
+    assert.deepStrictEqual(
+      result.resolution.status === 'ok'
+        ? result.resolution.target.targetResolutionRoots
+        : undefined,
+      ['/workspace/project/build/classes/java/main']
+    );
+  });
+
+  it('keeps Java source final roots scoped to verified selected-project outputs', async () => {
+    const vscode = installVscodeMock();
+    const projectAOutput = '/workspace/project-a/target/classes';
+    const projectBOutput = '/workspace/project-b/target/classes';
+    const firstMatchingRoot = async (
+      roots: string[],
+      _classpathsRoot: string,
+      hasTargets?: (targetPath: string) => Promise<boolean>
+    ) => {
+      for (const candidate of roots) {
+        if (!hasTargets || (await hasTargets(candidate))) {
+          return candidate;
+        }
+      }
+      return undefined;
+    };
+
+    for (const testCase of [
+      {
+        name: 'unusable workspace-level outputPath',
+        targetPath: '/workspace/project-a/src/main/java/demo/Repro.java',
+        options: {
+          outputPath: '/workspace/build/classes/java/main',
+          targetResolutionRoots: [projectBOutput, projectAOutput],
+          deriveOutputFolder: firstMatchingRoot,
+          findOutputFolderFromProject: async () => undefined,
+          hasClassTargets: async (targetPath: string) =>
+            targetPath === `${projectBOutput}/demo/Repro.class`,
+        },
+        expectedStatus: 'no-class-targets' as const,
+      },
+      {
+        name: 'generated java marker without sourcepaths',
+        targetPath: '/workspace/project-a/generated/java/demo/Repro.java',
+        options: {
+          targetResolutionRoots: [projectBOutput, projectAOutput],
+          deriveOutputFolder: firstMatchingRoot,
+          findOutputFolderFromProject: async () => undefined,
+          hasClassTargets: async (targetPath: string) =>
+            targetPath === `${projectBOutput}/demo/Repro.class`,
+        },
+        expectedStatus: 'no-class-targets' as const,
+      },
+    ]) {
+      const resolver = createResolver(vscode, testCase.options);
+      const result = await resolver.resolveFileAnalysisTargetDetailed(
+        vscode.Uri.file(testCase.targetPath) as any
+      );
+
+      assert.strictEqual(result.resolution.status, testCase.expectedStatus, testCase.name);
+    }
+  });
+
+  it('accepts workspace-level Java LS output paths for selected project sources', async () => {
+    const vscode = installVscodeMock();
+    const resolver = createResolver(vscode, {
+      outputPath: '/workspace/build/classes/java/main',
+      targetResolutionRoots: [],
+      findOutputFolderFromProject: async () => undefined,
+      hasClassTargets: async (targetPath: string) =>
+        targetPath === '/workspace/build/classes/java/main/demo/Repro.class',
+    });
+
+    const result = await resolver.resolveFileAnalysisTargetDetailed(
+      vscode.Uri.file('/workspace/project/src/main/java/demo/Repro.java') as any
+    );
+
+    assert.strictEqual(result.resolution.status, 'ok');
+    assert.deepStrictEqual(
+      result.resolution.status === 'ok'
+        ? result.resolution.target.targetResolutionRoots
+        : undefined,
+      ['/workspace/build/classes/java/main']
+    );
+  });
+
+  it('falls back to target-resolution roots when Java source outputPath lacks the mapped class', async () => {
+    const vscode = installVscodeMock();
+    const archiveOutput = '/workspace/project/build/classes/java/main';
+    const looseOutput = '/workspace/project/target/classes';
+    const resolver = createResolver(vscode, {
+      outputPath: archiveOutput,
+      targetResolutionRoots: [archiveOutput, looseOutput],
+      deriveOutputFolder: async (
+        roots: string[],
+        _classpathsRoot: string,
+        hasTargets?: (targetPath: string) => Promise<boolean>
+      ) => {
+        for (const candidate of roots) {
+          if (!hasTargets || (await hasTargets(candidate))) {
+            return candidate;
+          }
+        }
+        return undefined;
+      },
+      findOutputFolderFromProject: async () => {
+        throw new Error('project fallback should not be used');
+      },
+      hasClassTargets: async (targetPath: string) =>
+        targetPath === `${looseOutput}/demo/Repro.class`,
+    });
+
+    const result = await resolver.resolveFileAnalysisTargetDetailed(
+      vscode.Uri.file('/workspace/project/src/main/java/demo/Repro.java') as any
+    );
+
+    assert.strictEqual(result.resolution.status, 'ok');
+    assert.deepStrictEqual(
+      result.resolution.status === 'ok'
+        ? result.resolution.target.targetResolutionRoots
+        : undefined,
+      [looseOutput]
+    );
+    assert.deepStrictEqual(
+      result.issues.map((issue) => issue.code),
+      ['OUTPUT_FALLBACK_USED']
+    );
+  });
+
+  it('ranks fallback output roots by Java source set', async () => {
+    const vscode = installVscodeMock();
+    const mainOutput = '/workspace/project/target/classes';
+    const testOutput = '/workspace/project/target/test-classes';
+
+    for (const testCase of [
+      {
+        sourcePath: '/workspace/project/src/test/java/demo/Foo.java',
+        roots: [mainOutput, testOutput],
+        expectedRoots: [testOutput, mainOutput],
+      },
+      {
+        sourcePath: '/workspace/project/src/main/java/demo/Foo.java',
+        roots: [testOutput, mainOutput],
+        expectedRoots: [mainOutput, testOutput],
+      },
+    ]) {
+      const resolver = createResolver(vscode, {
+        targetResolutionRoots: testCase.roots,
+        deriveOutputFolder: async (
+          roots: string[],
+          _classpathsRoot: string,
+          hasTargets?: (targetPath: string) => Promise<boolean>,
+          options?: OutputFolderSelectionOptions
+        ) => {
+          const rankedRoots = rankRoots(roots, options);
+          for (const candidate of rankedRoots) {
+            if (!hasTargets || (await hasTargets(candidate))) {
+              return candidate;
+            }
+          }
+          return undefined;
+        },
+        findOutputFolderFromProject: async () => {
+          throw new Error('project fallback should not be used');
+        },
+        hasClassTargets: async (targetPath: string) =>
+          targetPath === `${mainOutput}/demo/Foo.class` ||
+          targetPath === `${testOutput}/demo/Foo.class`,
+      });
+
+      const result = await resolver.resolveFileAnalysisTargetDetailed(
+        vscode.Uri.file(testCase.sourcePath) as any
+      );
+
+      assert.strictEqual(result.resolution.status, 'ok', testCase.sourcePath);
+      assert.deepStrictEqual(
+        result.resolution.status === 'ok'
+          ? result.resolution.target.targetResolutionRoots
+          : undefined,
+        testCase.expectedRoots,
+        testCase.sourcePath
+      );
+    }
+  });
+
+  it('orders test output roots before classpath output metadata for test Java source analysis', async () => {
+    const vscode = installVscodeMock();
+    const mainOutput = '/workspace/project/target/classes';
+    const testOutput = '/workspace/project/target/test-classes';
+    const resolver = createResolver(vscode, {
+      outputPath: mainOutput,
+      targetResolutionRoots: [mainOutput, testOutput],
+      deriveOutputFolder: async () => {
+        throw new Error('deriveOutputFolder should not be called');
+      },
+      findOutputFolderFromProject: async () => {
+        throw new Error('project fallback should not be used');
+      },
+      hasClassTargets: async (targetPath: string) =>
+        targetPath === `${mainOutput}/demo/Foo.class` ||
+        targetPath === `${testOutput}/demo/Foo.class`,
+    });
+
+    const result = await resolver.resolveFileAnalysisTargetDetailed(
+      vscode.Uri.file('/workspace/project/src/test/java/demo/Foo.java') as any
+    );
+
+    assert.strictEqual(result.resolution.status, 'ok');
+    assert.deepStrictEqual(
+      result.resolution.status === 'ok'
+        ? result.resolution.target.targetResolutionRoots
+        : undefined,
+      [testOutput, mainOutput]
+    );
+  });
+
+  it('resolves Java source analysis through Java LS sourcepaths before source markers', async () => {
+    const vscode = installVscodeMock();
+    const outputRoot = '/workspace/project/target/classes';
+    const resolver = createResolver(vscode, {
+      outputPath: outputRoot,
+      sourcepaths: ['/workspace/project/generated-sources'],
+      hasClassTargets: async (targetPath: string) =>
+        targetPath === `${outputRoot}/demo/Repro.class`,
+    });
+
+    const result = await resolver.resolveFileAnalysisTargetDetailed(
+      vscode.Uri.file('/workspace/project/generated-sources/demo/Repro.java') as any
+    );
+
+    assert.strictEqual(result.resolution.status, 'ok');
+  });
+
+  it('prefers the longest matching Java LS sourcepath for Java source analysis', async () => {
+    const vscode = installVscodeMock();
+    const outputRoot = '/workspace/project/target/classes';
+    const resolver = createResolver(vscode, {
+      outputPath: outputRoot,
+      sourcepaths: [
+        '/workspace/project/generated-sources',
+        '/workspace/project/generated-sources/demo',
+      ],
+      hasClassTargets: async (targetPath: string) =>
+        targetPath === `${outputRoot}/Repro.class`,
+    });
+
+    const result = await resolver.resolveFileAnalysisTargetDetailed(
+      vscode.Uri.file('/workspace/project/generated-sources/demo/Repro.java') as any
+    );
+
+    assert.strictEqual(result.resolution.status, 'ok');
+  });
+
+  it('does not fall back to a broader Java LS sourcepath when the longest candidate has no class', async () => {
+    const vscode = installVscodeMock();
+    const outputRoot = '/workspace/project/target/classes';
+    const resolver = createResolver(vscode, {
+      outputPath: outputRoot,
+      sourcepaths: [
+        '/workspace/project/generated-sources',
+        '/workspace/project/generated-sources/demo',
+      ],
+      hasClassTargets: async (targetPath: string) =>
+        targetPath === `${outputRoot}/demo/Repro.class`,
+    });
+
+    const result = await resolver.resolveFileAnalysisTargetDetailed(
+      vscode.Uri.file('/workspace/project/generated-sources/demo/Repro.java') as any
+    );
+
+    assert.strictEqual(result.resolution.status, 'no-class-targets');
+  });
+
+  it('does not match Java LS sourcepaths by string prefix alone', async () => {
+    const vscode = installVscodeMock();
+    const outputRoot = '/workspace/project/target/classes';
+    const resolver = createResolver(vscode, {
+      outputPath: outputRoot,
+      sourcepaths: ['/workspace/project/generated'],
+      hasClassTargets: async (targetPath: string) =>
+        targetPath === `${outputRoot}/-sources/demo/Repro.class`,
+    });
+
+    const result = await resolver.resolveFileAnalysisTargetDetailed(
+      vscode.Uri.file('/workspace/project/generated-sources/demo/Repro.java') as any
+    );
+
+    assert.strictEqual(result.resolution.status, 'no-class-targets');
+  });
+
+  it('rejects Java source output roots with only same-basename unmapped class', async () => {
+    const vscode = installVscodeMock();
+    const outputRoot = '/workspace/project/target/classes';
+    const resolver = createResolver(vscode, {
+      targetResolutionRoots: [outputRoot],
+      sourcepaths: ['/workspace/project/generated-sources'],
+      deriveOutputFolder: async (
+        roots: string[],
+        _classpathsRoot: string,
+        hasTargets?: (targetPath: string) => Promise<boolean>
+      ) => {
+        for (const candidate of roots) {
+          if (!hasTargets || (await hasTargets(candidate))) {
+            return candidate;
+          }
+        }
+        return undefined;
+      },
+      findOutputFolderFromProject: async () => undefined,
+      hasClassTargets: async (targetPath: string) =>
+        targetPath === `${outputRoot}/other/Repro.class`,
+    });
+
+    const result = await resolver.resolveFileAnalysisTargetDetailed(
+      vscode.Uri.file('/workspace/project/generated-sources/demo/Repro.java') as any
+    );
+
+    assert.strictEqual(result.resolution.status, 'no-class-targets');
+  });
+
+  it('skips archive-only fallback output candidates for Java source analysis', async () => {
+    const vscode = installVscodeMock();
+    const resolver = createResolver(vscode, {
+      targetResolutionRoots: [],
+      derivedOutputPath: undefined,
+      findOutputFolderFromProject: async (
+        _projectRoot: string,
+        hasTargets?: (targetPath: string) => Promise<boolean>
+      ) => {
+        for (const candidate of [
+          '/workspace/project/build/classes/java/main',
+          '/workspace/project/target/classes',
+        ]) {
+          if (!hasTargets || (await hasTargets(candidate))) {
+            return candidate;
+          }
+        }
+        return undefined;
+      },
+      hasClassTargets: async (targetPath: string) =>
+        targetPath === '/workspace/project/target/classes/demo/Repro.class',
+    });
+
+    const result = await resolver.resolveFileAnalysisTargetDetailed(
+      vscode.Uri.file('/workspace/project/src/main/java/demo/Repro.java') as any
+    );
+
+    assert.strictEqual(result.resolution.status, 'ok');
+    assert.deepStrictEqual(
+      result.resolution.status === 'ok'
+        ? result.resolution.target.targetResolutionRoots
+        : undefined,
+      ['/workspace/project/target/classes']
+    );
+  });
+
+  it('falls back from archive-only output for Java source folder analysis', async () => {
+    const vscode = installVscodeMock();
+    const archiveOutput = '/workspace/project/build/classes/java/main';
+    const looseOutput = '/workspace/project/target/classes';
+
+    for (const selectedFolder of [
+      '/workspace/project/src/main/java/demo',
+      '/workspace/project/generated/java/demo',
+    ]) {
+      const resolver = createResolver(vscode, {
+        outputPath: archiveOutput,
+        targetResolutionRoots: [],
+        findOutputFolderFromProject: async (
+          _projectRoot: string,
+          hasTargets?: (targetPath: string) => Promise<boolean>
+        ) => {
+          for (const candidate of [archiveOutput, looseOutput]) {
+            if (!hasTargets || (await hasTargets(candidate))) {
+              return candidate;
+            }
+          }
+          return undefined;
+        },
+        hasClassTargets: async (targetPath: string) =>
+          targetPath === archiveOutput || targetPath === `${looseOutput}/demo`,
+        containsJavaSources: async () => true,
+      });
+
+      const result = await resolver.resolveFileAnalysisTargetDetailed(
+        vscode.Uri.file(selectedFolder) as any
+      );
+
+      assert.strictEqual(result.resolution.status, 'ok', selectedFolder);
+      assert.deepStrictEqual(
+        result.resolution.status === 'ok'
+          ? result.resolution.target.targetResolutionRoots
+          : undefined,
+        [looseOutput],
+        selectedFolder
+      );
+      assert.deepStrictEqual(
+        result.issues.map((issue) => issue.code),
+        ['OUTPUT_FALLBACK_USED'],
+        selectedFolder
+      );
+    }
+  });
+
+  it('does not treat marker-like archive folders without Java sources as source folders', async () => {
+    const vscode = installVscodeMock();
+    const selectedFolder = '/workspace/project/src/lib';
+    const outputRoot = '/workspace/project/target/classes';
+    const resolver = createResolver(vscode, {
+      outputPath: outputRoot,
+      hasClassTargets: async (targetPath: string) =>
+        targetPath === selectedFolder,
+    });
+
+    const result = await resolver.resolveFileAnalysisTargetDetailed(
+      vscode.Uri.file(selectedFolder) as any
+    );
+
+    assert.strictEqual(result.resolution.status, 'ok');
+    assert.strictEqual(
+      result.resolution.status === 'ok'
+        ? result.resolution.target.targetPath
+        : undefined,
+      selectedFolder
+    );
+  });
+
+  it('does not treat bytecode-only folders under sourcepaths as source folders', async () => {
+    const vscode = installVscodeMock();
+    const selectedFolder = '/workspace/project/src/main/java/lib';
+    const outputRoot = '/workspace/project/target/classes';
+    const resolver = createResolver(vscode, {
+      outputPath: outputRoot,
+      sourcepaths: ['/workspace/project/src/main/java'],
+      hasClassTargets: async (targetPath: string) =>
+        targetPath === selectedFolder,
+      containsJavaSources: async () => false,
+    });
+
+    const result = await resolver.resolveFileAnalysisTargetDetailed(
+      vscode.Uri.file(selectedFolder) as any
+    );
+
+    assert.strictEqual(result.resolution.status, 'ok');
+    assert.strictEqual(
+      result.resolution.status === 'ok'
+        ? result.resolution.target.targetPath
+        : undefined,
+      selectedFolder
+    );
+  });
+
+  it('rejects non-source folders without direct or mapped analysis targets', async () => {
+    const vscode = installVscodeMock();
+    const selectedFolder = '/workspace/project/src/lib';
+    const outputRoot = '/workspace/project/target/classes';
+    const resolver = createResolver(vscode, {
+      outputPath: outputRoot,
+      hasClassTargets: async (targetPath: string) => targetPath === outputRoot,
+      containsJavaSources: async () => false,
+    });
+
+    const result = await resolver.resolveFileAnalysisTargetDetailed(
+      vscode.Uri.file(selectedFolder) as any
+    );
+
+    assert.strictEqual(result.resolution.status, 'no-class-targets');
+  });
+
+  it('falls back from unusable output for non-source folders with mapped Java sources', async () => {
+    const vscode = installVscodeMock();
+    const tempRoot = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), 'spotbugs-folder-source-fallback-')
+    );
+    try {
+      const projectRoot = path.join(tempRoot, 'project');
+      const archiveOutput = path.join(projectRoot, 'build', 'classes', 'java', 'main');
+      const looseOutput = path.join(projectRoot, 'target', 'classes');
+      await fs.promises.mkdir(path.join(projectRoot, 'src', 'main', 'java', 'demo'), {
+        recursive: true,
+      });
+      await fs.promises.writeFile(
+        path.join(projectRoot, 'src', 'main', 'java', 'demo', 'Repro.java'),
+        ''
+      );
+
+      const resolver = createResolver(vscode, {
+        outputPath: archiveOutput,
+        targetResolutionRoots: [archiveOutput, looseOutput],
+        deriveOutputFolder: async (
+          roots: string[],
+          _classpathsRoot: string,
+          hasTargets?: (targetPath: string) => Promise<boolean>
+        ) => {
+          for (const candidate of roots) {
+            if (!hasTargets || (await hasTargets(candidate))) {
+              return candidate;
+            }
+          }
+          return undefined;
+        },
+        findOutputFolderFromProject: async () => undefined,
+        hasClassTargets: async (targetPath: string) =>
+          targetPath === path.join(looseOutput, 'demo', 'Repro.class'),
+      });
+
+      const result = await resolver.resolveFileAnalysisTargetDetailed(
+        vscode.Uri.file(projectRoot) as any
+      );
+
+      assert.strictEqual(result.resolution.status, 'ok');
+      assert.deepStrictEqual(
+        result.resolution.status === 'ok'
+          ? result.resolution.target.targetResolutionRoots
+          : undefined,
+        [looseOutput]
+      );
+    } finally {
+      await fs.promises.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps non-source folder fallback scoped when sourcepaths are nested under the target', async () => {
+    const vscode = installVscodeMock();
+    const workspaceRoot = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), 'spotbugs-nested-sourcepath-scope-')
+    );
+    try {
+      const projectA = path.join(workspaceRoot, 'project-a');
+      const projectB = path.join(workspaceRoot, 'project-b');
+      const sourceRoot = path.join(projectA, 'src', 'main', 'java');
+      const projectAOutput = path.join(projectA, 'target', 'classes');
+      const projectBOutput = path.join(projectB, 'target', 'classes');
+      await fs.promises.mkdir(path.join(sourceRoot, 'demo'), { recursive: true });
+      await fs.promises.writeFile(path.join(sourceRoot, 'demo', 'Repro.java'), '');
+
+      const resolver = createResolver(vscode, {
+        workspacePath: workspaceRoot,
+        outputPath: projectBOutput,
+        targetResolutionRoots: [projectBOutput, projectAOutput],
+        sourcepaths: [sourceRoot],
+        deriveOutputFolder: async (
+          roots: string[],
+          _classpathsRoot: string,
+          hasTargets?: (targetPath: string) => Promise<boolean>
+        ) => {
+          for (const candidate of roots) {
+            if (!hasTargets || (await hasTargets(candidate))) {
+              return candidate;
+            }
+          }
+          return undefined;
+        },
+        findOutputFolderFromProject: async () => undefined,
+        hasClassTargets: async (targetPath: string) =>
+          targetPath === path.join(projectBOutput, 'demo', 'Repro.class'),
+      });
+
+      const result = await resolver.resolveFileAnalysisTargetDetailed(
+        vscode.Uri.file(projectA) as any
+      );
+
+      assert.strictEqual(result.resolution.status, 'no-class-targets');
+    } finally {
+      await fs.promises.rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('requires mapped classes for exact Java source root preflight', async () => {
+    const vscode = installVscodeMock();
+    const tempRoot = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), 'spotbugs-source-root-')
+    );
+    try {
+      const projectRoot = path.join(tempRoot, 'project');
+      const sourceRoot = path.join(projectRoot, 'src', 'main', 'java');
+      const outputRoot = path.join(projectRoot, 'target', 'classes');
+      await fs.promises.mkdir(path.join(sourceRoot, 'demo'), { recursive: true });
+      await fs.promises.mkdir(path.join(outputRoot, 'other'), { recursive: true });
+      await fs.promises.writeFile(path.join(sourceRoot, 'demo', 'Missing.java'), '');
+      await fs.promises.writeFile(path.join(outputRoot, 'other', 'Other.class'), '');
+
+      const resolver = createResolver(vscode, {
+        outputPath: outputRoot,
+        hasClassTargets: async (targetPath: string) =>
+          targetPath === outputRoot ||
+          targetPath === path.join(outputRoot, 'other', 'Other.class'),
+        containsJavaSources: async () => true,
+      });
+
+      for (const selectedPath of [sourceRoot, `${sourceRoot}${path.sep}.`]) {
+        const result = await resolver.resolveFileAnalysisTargetDetailed(
+          vscode.Uri.file(selectedPath) as any
+        );
+
+        assert.strictEqual(
+          result.resolution.status,
+          'no-class-targets',
+          selectedPath
+        );
+      }
+    } finally {
+      await fs.promises.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps generated java sourcepath fallback scoped to the project root', async () => {
+    const vscode = installVscodeMock();
+    const outputRoot = '/workspace/project/target/classes';
+
+    for (const testCase of [
+      {
+        sourcepath: '/workspace/project/generated/java',
+        targetPath: '/workspace/project/generated/java/demo/Repro.java',
+      },
+      {
+        sourcepath: '/workspace/project/target/generated-sources/annotations',
+        targetPath:
+          '/workspace/project/target/generated-sources/annotations/demo/Repro.java',
+      },
+    ]) {
+      const resolver = createResolver(vscode, {
+        targetResolutionRoots: [outputRoot],
+        sourcepaths: [testCase.sourcepath],
+        deriveOutputFolder: async (
+          roots: string[],
+          classpathsRoot: string,
+          hasTargets?: (targetPath: string) => Promise<boolean>
+        ) => {
+          assert.strictEqual(classpathsRoot, '/workspace/project', testCase.sourcepath);
+          assert.deepStrictEqual(roots, [outputRoot], testCase.sourcepath);
+          for (const candidate of roots) {
+            if (!hasTargets || (await hasTargets(candidate))) {
+              return candidate;
+            }
+          }
+          return undefined;
+        },
+        findOutputFolderFromProject: async () => {
+          throw new Error('project fallback should not be used');
+        },
+        hasClassTargets: async (targetPath: string) =>
+          targetPath === `${outputRoot}/demo/Repro.class`,
+      });
+
+      const result = await resolver.resolveFileAnalysisTargetDetailed(
+        vscode.Uri.file(testCase.targetPath) as any
+      );
+
+      assert.strictEqual(result.resolution.status, 'ok', testCase.sourcepath);
+      assert.deepStrictEqual(
+        result.resolution.status === 'ok'
+          ? result.resolution.target.targetResolutionRoots
+          : undefined,
+        [outputRoot],
+        testCase.sourcepath
+      );
+    }
+  });
+
+  it('applies Java source-set ranking to project output folder fallback', async () => {
+    const vscode = installVscodeMock();
+    const mainOutput = '/workspace/project/target/classes';
+    const testOutput = '/workspace/project/target/test-classes';
+    const resolver = createResolver(vscode, {
+      targetResolutionRoots: [],
+      findOutputFolderFromProject: async (
+        _projectRoot: string,
+        hasTargets?: (targetPath: string) => Promise<boolean>,
+        options?: OutputFolderSelectionOptions
+      ) => {
+        for (const candidate of rankRoots([mainOutput, testOutput], options)) {
+          if (!hasTargets || (await hasTargets(candidate))) {
+            return candidate;
+          }
+        }
+        return undefined;
+      },
+      hasClassTargets: async (targetPath: string) =>
+        targetPath === `${mainOutput}/demo/Foo.class` ||
+        targetPath === `${testOutput}/demo/Foo.class`,
+    });
+
+    const result = await resolver.resolveFileAnalysisTargetDetailed(
+      vscode.Uri.file('/workspace/project/src/test/java/demo/Foo.java') as any
+    );
+
+    assert.deepStrictEqual(
+      result.resolution.status === 'ok'
+        ? result.resolution.target.targetResolutionRoots
+        : undefined,
+      [testOutput]
+    );
+  });
+
 });
 
 function createResolver(
@@ -277,11 +1154,28 @@ function createResolverDeps(
     expectedDeriveRoots?: string[];
     runtimeClasspaths?: string[];
     targetResolutionRoots?: string[];
+    deriveOutputFolder?: (
+      roots: string[],
+      classpathsRoot: string,
+      hasTargets?: (targetPath: string) => Promise<boolean>,
+      options?: OutputFolderSelectionOptions
+    ) => Promise<string | undefined>;
+    findOutputFolderFromProject?: (
+      projectRoot: string,
+      hasTargets?: (targetPath: string) => Promise<boolean>,
+      options?: OutputFolderSelectionOptions
+    ) => Promise<string | undefined>;
+    hasClassTargets?: (targetPath: string) => Promise<boolean>;
+    hasLooseClassTargets?: (targetPath: string) => Promise<boolean>;
+    containsJavaSources?: (targetPath: string) => Promise<boolean>;
+    sourcepaths?: string[];
+    workspacePath?: string;
   }
 ) {
   const targetResolutionRoots =
     options.targetResolutionRoots ?? (options.outputPath ? [options.outputPath] : []);
   const runtimeClasspaths = options.runtimeClasspaths ?? targetResolutionRoots;
+  const hasClassTargets = options.hasClassTargets ?? (async () => true);
   return {
     getClasspathsOutcome: async () => ({
       status: 'resolved' as const,
@@ -289,18 +1183,23 @@ function createResolverDeps(
         output: options.outputPath,
         runtimeClasspaths,
         targetResolutionRoots,
-        sourcepaths: [],
+        sourcepaths: options.sourcepaths ?? [],
       },
       issues: [],
     }),
-    deriveOutputFolder: async (roots: string[]) => {
-      if (options.expectedDeriveRoots) {
-        assert.deepStrictEqual(roots, options.expectedDeriveRoots);
-      }
-      return options.derivedOutputPath ?? options.outputPath;
-    },
-    findOutputFolderFromProject: async () => undefined,
-    hasClassTargets: async () => true,
+    deriveOutputFolder:
+      options.deriveOutputFolder ??
+      (async (roots: string[]) => {
+        if (options.expectedDeriveRoots) {
+          assert.deepStrictEqual(roots, options.expectedDeriveRoots);
+        }
+        return options.derivedOutputPath ?? options.outputPath;
+      }),
+    findOutputFolderFromProject:
+      options.findOutputFolderFromProject ?? (async () => undefined),
+    hasClassTargets,
+    hasLooseClassTargets: options.hasLooseClassTargets ?? hasClassTargets,
+    containsJavaSources: options.containsJavaSources ?? (async () => false),
     isBytecodeTarget: (targetPath: string) =>
       ['.class', '.jar', '.zip'].includes(path.extname(targetPath).toLowerCase()),
     primeSourcepathsCache: () => undefined,
@@ -308,9 +1207,27 @@ function createResolverDeps(
       ({
         name: 'workspace',
         index: 0,
-        uri: vscode.Uri.file('/workspace') as any,
+        uri: vscode.Uri.file(options.workspacePath ?? '/workspace') as any,
       }) as any,
     dirname: path.dirname,
     logger: { log: () => undefined } as any,
   };
+}
+
+type OutputFolderSelectionOptions = {
+  rankCandidate?: (candidate: { targetPath: string; index: number }) => number;
+};
+
+function rankRoots(
+  roots: readonly string[],
+  options: OutputFolderSelectionOptions | undefined
+): string[] {
+  return roots
+    .map((targetPath, index) => ({
+      targetPath,
+      index,
+      rank: options?.rankCandidate?.({ targetPath, index }) ?? 0,
+    }))
+    .sort((a, b) => a.rank - b.rank || a.index - b.index)
+    .map((candidate) => candidate.targetPath);
 }

--- a/src/workspace/analysisTargetResolver.ts
+++ b/src/workspace/analysisTargetResolver.ts
@@ -1,10 +1,12 @@
 import { Uri, workspace } from 'vscode';
+import * as fs from 'fs';
 import * as path from 'path';
 import { Logger } from '../core/logger';
 import type { DiagnosticUpdateScope } from '../model/diagnosticScope';
 import type { AnalysisResolutionIssue } from '../lsp/javaLsOutcome';
 import {
   deriveOutputFolder,
+  filterAdmissibleTargetResolutionRoots,
   getClasspathsOutcome,
 } from './classpathService';
 import { primeSourcepathsCache } from './pathResolver';
@@ -12,7 +14,10 @@ import { NO_CLASS_TARGETS_CODE, NO_CLASS_TARGETS_MESSAGE } from './analysisTarge
 import {
   findOutputFolderFromProject,
   hasClassTargets,
+  hasLooseClassTargets,
   isBytecodeTarget,
+  orderOutputFolderCandidates,
+  type OutputFolderSelectionOptions,
 } from './outputResolver';
 
 export interface AnalysisTarget {
@@ -47,7 +52,9 @@ export interface TargetResolverDeps {
   deriveOutputFolder: typeof deriveOutputFolder;
   findOutputFolderFromProject: typeof findOutputFolderFromProject;
   hasClassTargets: typeof hasClassTargets;
+  hasLooseClassTargets: typeof hasLooseClassTargets;
   isBytecodeTarget: typeof isBytecodeTarget;
+  containsJavaSources: typeof containsJavaSources;
   primeSourcepathsCache: typeof primeSourcepathsCache;
   getWorkspaceFolder: typeof workspace.getWorkspaceFolder;
   dirname: typeof path.dirname;
@@ -59,7 +66,9 @@ const defaultDeps: TargetResolverDeps = {
   deriveOutputFolder,
   findOutputFolderFromProject,
   hasClassTargets,
+  hasLooseClassTargets,
   isBytecodeTarget,
+  containsJavaSources,
   primeSourcepathsCache,
   getWorkspaceFolder: workspace.getWorkspaceFolder,
   dirname: path.dirname,
@@ -80,6 +89,11 @@ export function createTargetResolver(overrides: Partial<TargetResolverDeps> = {}
   type OutputResolution = {
     outputPath?: string;
     usedFallback: boolean;
+    targetResolutionRoots: string[];
+  };
+
+  type ResolveOutputPathOptions = OutputFolderSelectionOptions & {
+    allowFallbackFromUnusableOutput?: boolean;
   };
 
   function noClassTargets(logMessage?: string): TargetResolutionFailure {
@@ -145,26 +159,124 @@ export function createTargetResolver(overrides: Partial<TargetResolverDeps> = {}
   async function resolveOutputPath(
     targetResolutionRoots: string[] | undefined,
     outputPath: string | undefined,
-    classpathsRoot: string,
-    projectRoot: string
+    outputPathRoot: string,
+    targetRootsBoundary: string,
+    projectRoot: string,
+    hasTargets: (targetPath: string) => Promise<boolean> = deps.hasClassTargets,
+    options: ResolveOutputPathOptions = {}
   ): Promise<OutputResolution> {
-    let resolved = outputPath;
-    let usedFallback = false;
-
-    if (!resolved && Array.isArray(targetResolutionRoots)) {
-      resolved = await deps.deriveOutputFolder(targetResolutionRoots, classpathsRoot);
-      usedFallback = !!resolved;
+    const scopedTargetResolutionRoots = Array.isArray(targetResolutionRoots)
+      ? filterAdmissibleTargetResolutionRoots(
+          targetResolutionRoots,
+          targetRootsBoundary,
+          options
+        )
+      : [];
+    const usableTargetResolutionRoots = await filterTargetResolutionRootsWithTargets(
+      scopedTargetResolutionRoots,
+      hasTargets
+    );
+    const admissibleOutputPath = outputPath
+      ? filterAdmissibleTargetResolutionRoots([outputPath], outputPathRoot, options)[0]
+      : undefined;
+    if (
+      admissibleOutputPath &&
+      (!options.allowFallbackFromUnusableOutput ||
+        (await hasTargets(admissibleOutputPath)))
+    ) {
+      return {
+        outputPath: admissibleOutputPath,
+        usedFallback: false,
+        targetResolutionRoots: usableTargetResolutionRoots,
+      };
     }
 
-    if (!resolved) {
-      resolved = await deps.findOutputFolderFromProject(projectRoot);
-      usedFallback = !!resolved;
+    let resolved: string | undefined;
+
+    if (usableTargetResolutionRoots.length > 0) {
+      resolved = await deps.deriveOutputFolder(
+        usableTargetResolutionRoots,
+        targetRootsBoundary,
+        hasTargets,
+        options
+      );
+      if (resolved) {
+        return {
+          outputPath: resolved,
+          usedFallback: true,
+          targetResolutionRoots: usableTargetResolutionRoots,
+        };
+      }
+    }
+
+    resolved = await deps.findOutputFolderFromProject(
+      projectRoot,
+      hasTargets,
+      options
+    );
+    if (resolved) {
+      return {
+        outputPath: resolved,
+        usedFallback: true,
+        targetResolutionRoots: [],
+      };
     }
 
     return {
-      outputPath: resolved,
-      usedFallback,
+      outputPath: undefined,
+      usedFallback: false,
+      targetResolutionRoots: usableTargetResolutionRoots,
     };
+  }
+
+  async function filterTargetResolutionRootsWithTargets(
+    targetResolutionRoots: readonly string[],
+    hasTargets: (targetPath: string) => Promise<boolean>
+  ): Promise<string[]> {
+    const result: string[] = [];
+    for (const targetRoot of targetResolutionRoots) {
+      if (await hasTargets(targetRoot)) {
+        result.push(targetRoot);
+      }
+    }
+    return result;
+  }
+
+  function createOutputTargetPredicate(
+    targetPath: string,
+    sourcepaths: readonly string[] | undefined,
+    requiresMappedLooseOutput: boolean,
+    isJavaSourceTarget: boolean,
+    directTargetHasClassTargets: boolean
+  ): (targetPath: string) => Promise<boolean> {
+    if (!requiresMappedLooseOutput) {
+      if (directTargetHasClassTargets) {
+        return deps.hasClassTargets;
+      }
+      return (outputRoot: string) =>
+        hasMappedJavaSourceTreeClassTarget(
+          targetPath,
+          outputRoot,
+          sourcepaths,
+          deps.hasClassTargets
+        );
+    }
+    if (isJavaSourceTarget) {
+      return (outputRoot: string) =>
+        hasJavaSourceClassTarget(
+          targetPath,
+          outputRoot,
+          sourcepaths,
+          deps.hasClassTargets
+        );
+    }
+    return (outputRoot: string) =>
+      hasJavaSourceDirectoryClassTarget(
+        targetPath,
+        outputRoot,
+        sourcepaths,
+        deps.hasLooseClassTargets
+      );
   }
 
   async function resolveFileAnalysisTargetDetailed(
@@ -180,23 +292,66 @@ export function createTargetResolver(overrides: Partial<TargetResolverDeps> = {}
 
     const targetPath = uri.fsPath;
     let resolvedOutputPath: string | undefined;
+    let targetRootCandidates = targetResolutionRoots ?? [];
+    let isJavaSourceDirectoryTarget = false;
     if (!deps.isBytecodeTarget(targetPath)) {
+      const isJavaSourceTarget = isJavaSourceFile(targetPath);
+      isJavaSourceDirectoryTarget = await isJavaSourceDirectoryPath(
+        targetPath,
+        sourcepaths,
+        deps.containsJavaSources
+      );
+      const requiresMappedLooseOutput =
+        isJavaSourceTarget || isJavaSourceDirectoryTarget;
+      const directTargetHasClassTargets =
+        !requiresMappedLooseOutput && (await deps.hasClassTargets(targetPath));
+      const outputHasTargets = createOutputTargetPredicate(
+        targetPath,
+        sourcepaths,
+        requiresMappedLooseOutput,
+        isJavaSourceTarget,
+        directTargetHasClassTargets
+      );
+      const outputSelectionOptions = requiresMappedLooseOutput
+        ? createJavaSourceOutputSelectionOptions(targetPath, sourcepaths)
+        : undefined;
       const workspaceFolder = deps.getWorkspaceFolder(uri);
       const workspacePath = workspaceFolder?.uri.fsPath ?? deps.dirname(targetPath);
+      const targetRootsBoundary = inferAnalysisFallbackRoot(
+        targetPath,
+        sourcepaths,
+        outputPath,
+        workspacePath,
+        requiresMappedLooseOutput
+      );
+      const outputPathRoot = inferOutputPathRoot(
+        targetPath,
+        outputPath,
+        targetRootsBoundary
+      );
       const outputResolution = await resolveOutputPath(
         targetResolutionRoots,
         outputPath,
-        workspacePath,
-        workspacePath
+        outputPathRoot,
+        targetRootsBoundary,
+        targetRootsBoundary,
+        outputHasTargets,
+        {
+          ...outputSelectionOptions,
+          allowFallbackFromUnusableOutput:
+            requiresMappedLooseOutput || !directTargetHasClassTargets,
+          allowRecognizedOutputOutsideBoundary: false,
+        }
       );
       resolvedOutputPath = outputResolution.outputPath;
-      if (
-        !outputResolution.outputPath ||
-        !(await deps.hasClassTargets(outputResolution.outputPath))
-      ) {
+      targetRootCandidates = outputResolution.targetResolutionRoots;
+      const outputResolutionHasTargets =
+        !!outputResolution.outputPath &&
+        (await outputHasTargets(outputResolution.outputPath));
+      if (!directTargetHasClassTargets && !outputResolutionHasTargets) {
         return {
           resolution: noClassTargets(
-          `Skipping SpotBugs analysis for ${targetPath}: no compiled classes found.`
+            `Skipping SpotBugs analysis for ${targetPath}: no compiled classes found.`
           ),
           issues: resolutionIssues,
         };
@@ -214,10 +369,12 @@ export function createTargetResolver(overrides: Partial<TargetResolverDeps> = {}
       };
     }
 
-    const classTargetRoots = uniquePaths([
-      resolvedOutputPath,
-      ...(targetResolutionRoots ?? []),
-    ]);
+    const classTargetRoots = orderClassTargetRootsForTarget(
+      targetPath,
+      sourcepaths,
+      uniquePaths([resolvedOutputPath, ...targetRootCandidates]),
+      isJavaSourceDirectoryTarget
+    );
 
     return {
       resolution: {
@@ -225,7 +382,8 @@ export function createTargetResolver(overrides: Partial<TargetResolverDeps> = {}
         target: {
           targetPath,
           preferredProject: uri,
-          targetResolutionRoots,
+          targetResolutionRoots:
+            classTargetRoots.length > 0 ? classTargetRoots : targetResolutionRoots,
           runtimeClasspaths,
           sourcepaths,
           diagnosticScope: createDiagnosticScope(uri, targetPath, classTargetRoots),
@@ -248,11 +406,26 @@ export function createTargetResolver(overrides: Partial<TargetResolverDeps> = {}
     const resolutionIssues = [...issues];
     const projectRoot =
       projectUri.scheme === 'file' ? projectUri.fsPath : workspaceFolder.fsPath;
+    const targetRootsBoundary = inferAnalysisFallbackRoot(
+      projectRoot,
+      sourcepaths,
+      outputPath,
+      projectRoot,
+      false
+    );
+    const outputPathRoot = inferOutputPathRoot(
+      projectRoot,
+      outputPath,
+      targetRootsBoundary
+    );
     const outputResolution = await resolveOutputPath(
       targetResolutionRoots,
       outputPath,
-      workspaceFolder.fsPath,
-      projectRoot
+      outputPathRoot,
+      targetRootsBoundary,
+      projectRoot,
+      deps.hasClassTargets,
+      { allowRecognizedOutputOutsideBoundary: false }
     );
     if (!outputResolution.outputPath) {
       return {
@@ -275,6 +448,10 @@ export function createTargetResolver(overrides: Partial<TargetResolverDeps> = {}
     if (outputResolution.usedFallback) {
       resolutionIssues.push(createOutputFallbackIssue());
     }
+    const classTargetRoots = uniquePaths([
+      outputResolution.outputPath,
+      ...outputResolution.targetResolutionRoots,
+    ]);
 
     return {
       resolution: {
@@ -282,7 +459,7 @@ export function createTargetResolver(overrides: Partial<TargetResolverDeps> = {}
         target: {
           targetPath: outputResolution.outputPath,
           preferredProject: projectUri,
-          targetResolutionRoots,
+          targetResolutionRoots: classTargetRoots,
           runtimeClasspaths,
           sourcepaths,
         },
@@ -338,13 +515,205 @@ export async function resolveProjectAnalysisTarget(
   return defaultResolver.resolveProjectAnalysisTarget(projectUri, workspaceFolder);
 }
 
+const OUTPUT_PROJECT_ROOT_SUFFIXES = [
+  '/build/classes/java/main',
+  '/build/classes/kotlin/main',
+  '/build/classes/java/test',
+  '/build/classes/kotlin/test',
+  '/target/test-classes',
+  '/target/classes',
+  '/bin/main',
+  '/bin/test',
+  '/out/production',
+  '/build/classes',
+  '/classes',
+  '/bin',
+  '/out',
+];
+
+function inferAnalysisFallbackRoot(
+  targetPath: string,
+  sourcepaths: readonly string[] | undefined,
+  outputPath: string | undefined,
+  workspacePath: string,
+  useSourceMarkers: boolean
+): string {
+  if (useSourceMarkers) {
+    const markerRoot = inferProjectRootFromSourceMarker(targetPath);
+    if (markerRoot) {
+      return markerRoot;
+    }
+  }
+
+  const sourcepathRoot = inferProjectRootFromSourcepaths(targetPath, sourcepaths);
+  if (sourcepathRoot) {
+    return sourcepathRoot;
+  }
+
+  const outputProjectRoot = outputPath
+    ? inferProjectRootFromOutputPath(outputPath)
+    : undefined;
+  if (
+    outputProjectRoot &&
+    isPathInsideOrEqual(outputProjectRoot, targetPath) &&
+    !isPathInsideOrEqual(outputProjectRoot, workspacePath)
+  ) {
+    return outputProjectRoot;
+  }
+
+  return workspacePath;
+}
+
+function inferOutputPathRoot(
+  targetPath: string,
+  outputPath: string | undefined,
+  targetRootsBoundary: string
+): string {
+  const outputProjectRoot = outputPath
+    ? inferProjectRootFromOutputPath(outputPath)
+    : undefined;
+  if (outputProjectRoot && isPathInsideOrEqual(outputProjectRoot, targetPath)) {
+    return outputProjectRoot;
+  }
+  return targetRootsBoundary;
+}
+
+function inferProjectRootFromOutputPath(outputPath: string): string | undefined {
+  const normalized = normalizeForSourceSet(outputPath);
+  for (const suffix of OUTPUT_PROJECT_ROOT_SUFFIXES) {
+    if (normalized.endsWith(suffix)) {
+      const root = normalized.slice(0, normalized.length - suffix.length);
+      if (root) {
+        return root;
+      }
+    }
+  }
+  return undefined;
+}
+
+function inferProjectRootFromSourceMarker(sourcePath: string): string | undefined {
+  const normalized = normalizeForSourceSet(sourcePath);
+  const markers = ['/src/main/java', '/src/test/java', '/src/java', '/src'];
+  for (const marker of markers) {
+    const markerWithChild = `${marker}/`;
+    const markerIndex = normalized.indexOf(markerWithChild);
+    if (markerIndex >= 0) {
+      return normalized.substring(0, markerIndex);
+    }
+    if (normalized.endsWith(marker)) {
+      return normalized.substring(0, normalized.length - marker.length);
+    }
+  }
+
+  const generatedSourceRoot = inferProjectRootFromGeneratedSourcepath(normalized);
+  if (generatedSourceRoot) {
+    return generatedSourceRoot;
+  }
+
+  const javaRootIndex = normalized.lastIndexOf('/java/');
+  if (javaRootIndex >= 0) {
+    return normalized.substring(0, javaRootIndex);
+  }
+  if (normalized.endsWith('/java')) {
+    return normalized.substring(0, normalized.length - '/java'.length);
+  }
+
+  return undefined;
+}
+
+function inferProjectRootFromSourcepaths(
+  targetPath: string,
+  sourcepaths: readonly string[] | undefined
+): string | undefined {
+  const sourcepathCandidates = sortSourcepathCandidates(
+    normalizeSourcepathCandidates(sourcepaths).filter((candidate) =>
+      isPathInsideOrEqual(candidate.root, targetPath)
+    )
+  );
+  const sourcepathRoot = sourcepathCandidates[0]?.root;
+  if (sourcepathRoot) {
+    return inferProjectRootFromSourcepathRoot(sourcepathRoot);
+  }
+
+  const nestedSourcepathCandidates = sortSourcepathCandidates(
+    normalizeSourcepathCandidates(sourcepaths).filter((candidate) =>
+      isPathInsideOrEqual(targetPath, candidate.root)
+    )
+  );
+  for (const candidate of nestedSourcepathCandidates) {
+    const projectRoot = inferProjectRootFromSourcepathRoot(candidate.root);
+    if (projectRoot && path.resolve(projectRoot) === path.resolve(targetPath)) {
+      return projectRoot;
+    }
+  }
+
+  return undefined;
+}
+
+function sortSourcepathCandidates<T extends { root: string; index: number }>(
+  candidates: readonly T[]
+): T[] {
+  return [...candidates].sort(
+    (a, b) =>
+      path.resolve(b.root).length - path.resolve(a.root).length ||
+      a.index - b.index
+  );
+}
+
+function inferProjectRootFromSourcepathRoot(sourcepathRoot: string): string | undefined {
+  const markerRoot = inferProjectRootFromSourceMarker(sourcepathRoot);
+  if (markerRoot) {
+    return markerRoot;
+  }
+
+  const generatedSourceRoot = inferProjectRootFromGeneratedSourcepath(sourcepathRoot);
+  if (generatedSourceRoot) {
+    return generatedSourceRoot;
+  }
+
+  const parent = path.dirname(sourcepathRoot);
+  return parent && parent !== sourcepathRoot ? parent : undefined;
+}
+
+function inferProjectRootFromGeneratedSourcepath(
+  sourcepathRoot: string
+): string | undefined {
+  const normalized = normalizeForSourceSet(sourcepathRoot);
+  const markers = [
+    '/target/generated-sources',
+    '/target/generated-test-sources',
+    '/build/generated/sources',
+    '/build/generated/source',
+    '/generated-sources',
+    '/generated-test-sources',
+    '/generated/main/java',
+    '/generated/test/java',
+    '/generated/java',
+  ];
+  for (const marker of markers) {
+    const markerIndex = normalized.indexOf(marker);
+    if (markerIndex < 0) {
+      continue;
+    }
+    const markerEnd = markerIndex + marker.length;
+    if (markerEnd !== normalized.length && normalized.charAt(markerEnd) !== '/') {
+      continue;
+    }
+    const root = normalized.substring(0, markerIndex);
+    if (root) {
+      return root;
+    }
+  }
+  return undefined;
+}
+
 function createOutputFallbackIssue(): AnalysisResolutionIssue {
   return {
     code: 'OUTPUT_FALLBACK_USED',
     level: 'info',
     source: 'target-resolution',
     phase: 'output-fallback',
-    message: 'Output folder fallback was used because Java build output metadata was unavailable.',
+    message: 'Output folder fallback was used because Java build output metadata was unavailable or unusable for the selected target.',
   };
 }
 
@@ -366,6 +735,444 @@ function createDiagnosticScope(
     return { kind: 'returned-files', uri };
   }
   return { kind: 'folder', uri };
+}
+
+async function hasJavaSourceClassTarget(
+  sourcePath: string,
+  outputRoot: string,
+  sourcepaths: readonly string[] | undefined,
+  hasClassTarget: (targetPath: string) => Promise<boolean>
+): Promise<boolean> {
+  for (const classPath of resolveJavaSourceClassPaths(sourcePath, outputRoot, sourcepaths)) {
+    if (await hasClassTarget(classPath)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function hasJavaSourceDirectoryClassTarget(
+  sourceDir: string,
+  outputRoot: string,
+  sourcepaths: readonly string[] | undefined,
+  hasLooseClassTarget: (targetPath: string) => Promise<boolean>
+): Promise<boolean> {
+  for (const relativeDir of deriveRelativeJavaSourceDirectoryPaths(
+    sourceDir,
+    sourcepaths
+  )) {
+    if (!relativeDir) {
+      if (
+        await hasMappedJavaSourceTreeClassTarget(
+          sourceDir,
+          outputRoot,
+          sourcepaths,
+          hasLooseClassTarget
+        )
+      ) {
+        return true;
+      }
+      continue;
+    }
+    const outputDir = path.join(
+      outputRoot,
+      ...relativeDir.split(/[\\/]+/).filter(Boolean)
+    );
+    if (await hasLooseClassTarget(outputDir)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function hasMappedJavaSourceTreeClassTarget(
+  sourceDir: string,
+  outputRoot: string,
+  sourcepaths: readonly string[] | undefined,
+  hasLooseClassTarget: (targetPath: string) => Promise<boolean>
+): Promise<boolean> {
+  const queue: string[] = [sourceDir];
+  while (queue.length > 0) {
+    const current = queue.pop();
+    if (!current) {
+      continue;
+    }
+    let entries: fs.Dirent[];
+    try {
+      entries = await fs.promises.readdir(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const entryPath = path.join(current, entry.name);
+      if (entry.isFile()) {
+        if (
+          isJavaSourceFile(entryPath) &&
+          (await hasJavaSourceClassTarget(
+            entryPath,
+            outputRoot,
+            sourcepaths,
+            hasLooseClassTarget
+          ))
+        ) {
+          return true;
+        }
+        continue;
+      }
+      if (entry.isDirectory()) {
+        queue.push(entryPath);
+      }
+    }
+  }
+  return false;
+}
+
+function isJavaSourceFile(targetPath: string): boolean {
+  return path.extname(targetPath).toLowerCase() === '.java';
+}
+
+async function containsJavaSources(targetPath: string): Promise<boolean> {
+  try {
+    const stat = await fs.promises.stat(targetPath);
+    if (stat.isFile()) {
+      return isJavaSourceFile(targetPath);
+    }
+    if (!stat.isDirectory()) {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+
+  const queue: string[] = [targetPath];
+  while (queue.length > 0) {
+    const current = queue.pop();
+    if (!current) {
+      continue;
+    }
+    let entries: fs.Dirent[];
+    try {
+      entries = await fs.promises.readdir(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const entryPath = path.join(current, entry.name);
+      if (entry.isFile()) {
+        if (isJavaSourceFile(entryPath)) {
+          return true;
+        }
+        continue;
+      }
+      if (entry.isDirectory()) {
+        queue.push(entryPath);
+      }
+    }
+  }
+  return false;
+}
+
+async function isJavaSourceDirectoryPath(
+  targetPath: string,
+  sourcepaths: readonly string[] | undefined,
+  containsJavaSources: (targetPath: string) => Promise<boolean>
+): Promise<boolean> {
+  return (
+    deriveRelativeJavaSourceDirectoryPaths(targetPath, sourcepaths).length > 0 &&
+    (await containsJavaSources(targetPath))
+  );
+}
+
+type JavaSourceSet = 'main' | 'test' | 'unknown';
+
+function createJavaSourceOutputSelectionOptions(
+  sourcePath: string,
+  sourcepaths: readonly string[] | undefined
+): OutputFolderSelectionOptions {
+  const sourceSet = inferJavaSourceSet(sourcePath, sourcepaths);
+  if (sourceSet === 'unknown') {
+    return {};
+  }
+
+  return {
+    rankCandidate: ({ targetPath }) =>
+      rankOutputFolderForSourceSet(targetPath, sourceSet),
+  };
+}
+
+function orderClassTargetRootsForTarget(
+  targetPath: string,
+  sourcepaths: readonly string[] | undefined,
+  classTargetRoots: readonly string[],
+  isJavaSourceDirectoryTarget = false
+): string[] {
+  if (
+    (!isJavaSourceFile(targetPath) &&
+      !isJavaSourceDirectoryTarget) ||
+    classTargetRoots.length < 2
+  ) {
+    return [...classTargetRoots];
+  }
+  const options = createJavaSourceOutputSelectionOptions(targetPath, sourcepaths);
+  return orderOutputFolderCandidates(
+    classTargetRoots.map((root, index) => ({ targetPath: root, index })),
+    options
+  ).map((candidate) => candidate.targetPath);
+}
+
+function inferJavaSourceSet(
+  sourcePath: string,
+  sourcepaths: readonly string[] | undefined
+): JavaSourceSet {
+  const sourcepathCandidates = sortSourcepathCandidates(
+    normalizeSourcepathCandidates(sourcepaths).filter((candidate) =>
+      isPathInsideOrEqual(candidate.root, sourcePath)
+    )
+  );
+
+  for (const candidate of sourcepathCandidates) {
+    const sourceSet = classifyJavaSourcePath(candidate.root);
+    if (sourceSet !== 'unknown') {
+      return sourceSet;
+    }
+  }
+
+  return classifyJavaSourcePath(sourcePath);
+}
+
+function rankOutputFolderForSourceSet(
+  targetPath: string,
+  sourceSet: Exclude<JavaSourceSet, 'unknown'>
+): number {
+  const outputSet = classifyJavaOutputPath(targetPath);
+  if (outputSet === sourceSet) {
+    return 0;
+  }
+  if (outputSet === 'unknown') {
+    return 1;
+  }
+  return 2;
+}
+
+function classifyJavaSourcePath(sourcePath: string): JavaSourceSet {
+  const normalized = normalizeForSourceSet(sourcePath);
+  if (
+    normalized.includes('/src/test/java/') ||
+    normalized.endsWith('/src/test/java') ||
+    normalized.includes('/src/test/') ||
+    normalized.endsWith('/src/test')
+  ) {
+    return 'test';
+  }
+  if (
+    normalized.includes('/src/main/java/') ||
+    normalized.endsWith('/src/main/java') ||
+    normalized.includes('/src/main/') ||
+    normalized.endsWith('/src/main')
+  ) {
+    return 'main';
+  }
+  return 'unknown';
+}
+
+function classifyJavaOutputPath(outputPath: string): JavaSourceSet {
+  const normalized = normalizeForSourceSet(outputPath);
+  if (
+    normalized.endsWith('/target/test-classes') ||
+    normalized.includes('/target/test-classes/') ||
+    normalized.endsWith('/build/classes/java/test') ||
+    normalized.includes('/build/classes/java/test/') ||
+    normalized.endsWith('/build/classes/kotlin/test') ||
+    normalized.includes('/build/classes/kotlin/test/') ||
+    normalized.endsWith('/bin/test') ||
+    normalized.includes('/bin/test/')
+  ) {
+    return 'test';
+  }
+  if (
+    normalized.endsWith('/target/classes') ||
+    normalized.includes('/target/classes/') ||
+    normalized.endsWith('/build/classes/java/main') ||
+    normalized.includes('/build/classes/java/main/') ||
+    normalized.endsWith('/build/classes/kotlin/main') ||
+    normalized.includes('/build/classes/kotlin/main/') ||
+    normalized.endsWith('/bin/main') ||
+    normalized.includes('/bin/main/') ||
+    normalized.endsWith('/out/production') ||
+    normalized.includes('/out/production/')
+  ) {
+    return 'main';
+  }
+  return 'unknown';
+}
+
+function normalizeForSourceSet(value: string): string {
+  let normalized = value.replace(/\\/g, '/').replace(/\/+$/, '');
+  while (normalized.endsWith('/.')) {
+    normalized = normalized.slice(0, -2).replace(/\/+$/, '');
+  }
+  return normalized;
+}
+
+function resolveJavaSourceClassPaths(
+  sourcePath: string,
+  outputRoot: string,
+  sourcepaths: readonly string[] | undefined
+): string[] {
+  return deriveRelativeJavaSourcePaths(sourcePath, sourcepaths).map(
+    (relativeSourcePath) => {
+      const extension = path.extname(relativeSourcePath);
+      const relativeClassPath = `${relativeSourcePath.slice(0, -extension.length)}.class`;
+      return path.join(outputRoot, ...relativeClassPath.split(/[\\/]+/).filter(Boolean));
+    }
+  );
+}
+
+function deriveRelativeJavaSourcePaths(
+  sourcePath: string,
+  sourcepaths: readonly string[] | undefined
+): string[] {
+  const candidates: string[] = [];
+  const sourcepathCandidates = sortSourcepathCandidates(
+    normalizeSourcepathCandidates(sourcepaths).filter((candidate) =>
+      isPathInsideOrEqual(candidate.root, sourcePath)
+    )
+  );
+
+  for (const candidate of sourcepathCandidates) {
+    const relative = path.relative(path.resolve(candidate.root), path.resolve(sourcePath));
+    if (relative && path.extname(relative).toLowerCase() === '.java') {
+      return uniqueRelativeJavaSourcePaths([relative]);
+    }
+    return [];
+  }
+
+  const markerCandidate = deriveMarkerRelativeJavaSourcePath(sourcePath);
+  if (markerCandidate) {
+    candidates.push(markerCandidate);
+  }
+
+  return uniqueRelativeJavaSourcePaths(candidates);
+}
+
+function deriveRelativeJavaSourceDirectoryPaths(
+  sourceDir: string,
+  sourcepaths: readonly string[] | undefined
+): string[] {
+  const sourcepathCandidates = sortSourcepathCandidates(
+    normalizeSourcepathCandidates(sourcepaths).filter((candidate) =>
+      isPathInsideOrEqual(candidate.root, sourceDir)
+    )
+  );
+
+  for (const candidate of sourcepathCandidates) {
+    return uniqueRelativeJavaSourceDirectoryPaths([
+      path.relative(path.resolve(candidate.root), path.resolve(sourceDir)),
+    ]);
+  }
+
+  const markerCandidate = deriveMarkerRelativeJavaSourceDirectoryPath(sourceDir);
+  return markerCandidate === undefined
+    ? []
+    : uniqueRelativeJavaSourceDirectoryPaths([markerCandidate]);
+}
+
+function normalizeSourcepathCandidates(
+  sourcepaths: readonly string[] | undefined
+): Array<{ root: string; index: number }> {
+  const result: Array<{ root: string; index: number }> = [];
+  const seen = new Set<string>();
+  for (const [index, sourcepath] of (sourcepaths ?? []).entries()) {
+    const trimmed = sourcepath.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const root = path.resolve(trimmed);
+    if (seen.has(root)) {
+      continue;
+    }
+    seen.add(root);
+    result.push({ root, index });
+  }
+  return result;
+}
+
+function uniqueRelativeJavaSourceDirectoryPaths(candidates: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const candidate of candidates) {
+    const key = normalizeForSourceSet(candidate);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    result.push(candidate);
+  }
+  return result;
+}
+
+function uniqueRelativeJavaSourcePaths(candidates: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const candidate of candidates) {
+    if (path.extname(candidate).toLowerCase() !== '.java') {
+      continue;
+    }
+    const key = candidate.replace(/\\/g, '/');
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    result.push(candidate);
+  }
+  return result;
+}
+
+function deriveMarkerRelativeJavaSourcePath(sourcePath: string): string | undefined {
+  const normalized = sourcePath.replace(/\\/g, '/');
+  const markers = ['/src/main/java/', '/src/test/java/', '/src/java/', '/src/'];
+  for (const marker of markers) {
+    const index = normalized.indexOf(marker);
+    if (index >= 0) {
+      return normalized.substring(index + marker.length);
+    }
+  }
+
+  const javaRootIndex = normalized.lastIndexOf('/java/');
+  if (javaRootIndex >= 0 && javaRootIndex + '/java/'.length < normalized.length) {
+    return normalized.substring(javaRootIndex + '/java/'.length);
+  }
+  return undefined;
+}
+
+function deriveMarkerRelativeJavaSourceDirectoryPath(
+  sourceDir: string
+): string | undefined {
+  const normalized = normalizeForSourceSet(sourceDir);
+  const markers = ['/src/main/java', '/src/test/java', '/src/java', '/src'];
+  for (const marker of markers) {
+    const markerWithChild = `${marker}/`;
+    const markerIndex = normalized.indexOf(markerWithChild);
+    if (markerIndex >= 0) {
+      return normalized.substring(markerIndex + markerWithChild.length);
+    }
+    const exactMarkerIndex = normalized.indexOf(marker);
+    if (
+      exactMarkerIndex >= 0 &&
+      exactMarkerIndex + marker.length === normalized.length
+    ) {
+      return '';
+    }
+  }
+
+  const javaRootIndex = normalized.lastIndexOf('/java/');
+  if (javaRootIndex >= 0 && javaRootIndex + '/java/'.length < normalized.length) {
+    return normalized.substring(javaRootIndex + '/java/'.length);
+  }
+  if (normalized.endsWith('/java')) {
+    return '';
+  }
+  return undefined;
 }
 
 function uniquePaths(paths: Array<string | undefined>): string[] {

--- a/src/workspace/classpathService.ts
+++ b/src/workspace/classpathService.ts
@@ -8,6 +8,10 @@ import {
   runClasspathAttemptsOutcome,
 } from './classpathCommandRunner';
 import type { ClasspathResult } from './classpathTypes';
+import {
+  orderOutputFolderCandidates,
+  type OutputFolderSelectionOptions,
+} from './outputResolver';
 
 export interface ClasspathLookupOptions {
   verbose?: boolean;
@@ -15,16 +19,23 @@ export interface ClasspathLookupOptions {
 }
 
 const PREFERRED_OUTPUT_SUFFIXES = [
-  `${path.sep}target${path.sep}classes`,
-  `${path.sep}build${path.sep}classes${path.sep}java${path.sep}main`,
-  `${path.sep}build${path.sep}classes`,
-  `${path.sep}bin`,
-  `${path.sep}out${path.sep}production`,
-  `${path.sep}out`,
-  `${path.sep}classes`,
+  '/target/classes',
+  '/build/classes/java/main',
+  '/build/classes/kotlin/main',
+  '/bin/main',
+  '/out/production',
+  '/target/test-classes',
+  '/build/classes/java/test',
+  '/build/classes/kotlin/test',
+  '/bin/test',
+  '/build/classes',
+  '/bin',
+  '/out',
+  '/classes',
 ];
 
 export type ProjectRef = string | Uri | undefined;
+export type OutputFolderPredicate = (targetPath: string) => Promise<boolean>;
 
 export async function getClasspathsOutcome(
   project?: ProjectRef,
@@ -44,31 +55,167 @@ export async function getClasspaths(
 
 export async function deriveOutputFolder(
   targetResolutionRoots: string[],
-  workspacePath: string
+  workspacePath: string,
+  hasTargets?: OutputFolderPredicate,
+  options: OutputFolderSelectionOptions = {}
 ): Promise<string | undefined> {
-  const candidates: string[] = [];
-  for (const cp of targetResolutionRoots) {
-    for (const suf of PREFERRED_OUTPUT_SUFFIXES) {
-      if (cp.includes(suf)) {
-        candidates.push(cp);
-        break;
-      }
-    }
-  }
-  for (const cp of targetResolutionRoots) {
-    if (!candidates.includes(cp) && cp.startsWith(workspacePath)) {
-      candidates.push(cp);
-    }
-  }
-  for (const c of candidates) {
+  const candidateRoots = filterAdmissibleTargetResolutionRoots(
+    targetResolutionRoots,
+    workspacePath,
+    options
+  );
+  const rankedCandidates = orderOutputFolderCandidates(
+    candidateRoots.map((targetPath, rootIndex) => ({
+      targetPath,
+      index: getOutputFolderBaseRank(targetPath) * candidateRoots.length + rootIndex,
+    })),
+    options
+  );
+  for (const c of rankedCandidates) {
     try {
-      const st = await fs.promises.stat(c);
-      if (st.isDirectory()) {
-        return c;
+      const st = await fs.promises.stat(c.targetPath);
+      if (
+        st.isDirectory() &&
+        (!hasTargets || (await hasTargets(c.targetPath)))
+      ) {
+        return c.targetPath;
       }
     } catch {
       // ignore
     }
   }
   return undefined;
+}
+
+export function filterAdmissibleTargetResolutionRoots(
+  targetResolutionRoots: readonly string[],
+  workspacePath: string,
+  options: OutputFolderSelectionOptions = {}
+): string[] {
+  const allowRecognizedOutputOutsideBoundary =
+    options.allowRecognizedOutputOutsideBoundary ?? true;
+  return uniqueCandidateRoots(
+    targetResolutionRoots.filter((cp) =>
+      isAdmissibleOutputCandidate(
+        workspacePath,
+        cp,
+        allowRecognizedOutputOutsideBoundary
+      )
+    )
+  );
+}
+
+function isAdmissibleOutputCandidate(
+  workspacePath: string,
+  candidatePath: string,
+  allowRecognizedOutputOutsideBoundary: boolean
+): boolean {
+  if (isWorkspacePrefixSibling(workspacePath, candidatePath)) {
+    return false;
+  }
+  if (isPathInsideOrEqual(workspacePath, candidatePath)) {
+    return true;
+  }
+  return (
+    allowRecognizedOutputOutsideBoundary && isRecognizedOutputRoot(candidatePath)
+  );
+}
+
+function uniqueCandidateRoots(candidateRoots: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const candidate of candidateRoots) {
+    const pathFlavor = selectPathFlavor(candidate);
+    const key = normalizeForPathComparison(candidate, pathFlavor);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    result.push(candidate);
+  }
+  return result;
+}
+
+function isRecognizedOutputRoot(targetPath: string): boolean {
+  const normalized = normalizeForOutputSuffix(targetPath);
+  return PREFERRED_OUTPUT_SUFFIXES.some((suffix) => normalized.endsWith(suffix));
+}
+
+function getOutputFolderBaseRank(targetPath: string): number {
+  const normalized = normalizeForOutputSuffix(targetPath);
+  const rank = PREFERRED_OUTPUT_SUFFIXES.findIndex(
+    (suffix) => normalized.endsWith(suffix) || normalized.includes(`${suffix}/`)
+  );
+  return rank >= 0 ? rank : PREFERRED_OUTPUT_SUFFIXES.length;
+}
+
+function isPathInsideOrEqual(parentPath: string, candidatePath: string): boolean {
+  const pathFlavor = selectPathFlavor(parentPath, candidatePath);
+  const relative = pathFlavor.relative(
+    pathFlavor.resolve(parentPath),
+    pathFlavor.resolve(candidatePath)
+  );
+  return (
+    relative === '' ||
+    (relative.length > 0 &&
+      relative !== '..' &&
+      !relative.startsWith(`..${pathFlavor.sep}`) &&
+      !pathFlavor.isAbsolute(relative))
+  );
+}
+
+export function isWorkspacePrefixSibling(
+  workspacePath: string,
+  candidatePath: string
+): boolean {
+  const pathFlavor = selectPathFlavor(workspacePath, candidatePath);
+  const resolvedWorkspace = normalizeForPathComparison(workspacePath, pathFlavor);
+  const resolvedCandidate = normalizeForPathComparison(candidatePath, pathFlavor);
+  return (
+    !isPathInsideOrEqual(resolvedWorkspace, resolvedCandidate) &&
+    resolvedCandidate.startsWith(resolvedWorkspace)
+  );
+}
+
+type PathFlavor = Pick<
+  typeof path,
+  'isAbsolute' | 'parse' | 'relative' | 'resolve' | 'sep'
+>;
+
+function selectPathFlavor(...values: string[]): PathFlavor {
+  return values.some(isWindowsPathString) ? path.win32 : path;
+}
+
+function isWindowsPathString(value: string): boolean {
+  return (
+    /^[a-zA-Z]:[\\/]/.test(value) ||
+    value.startsWith('\\\\') ||
+    value.startsWith('//')
+  );
+}
+
+function normalizeForPathComparison(
+  value: string,
+  pathFlavor: PathFlavor
+): string {
+  const resolved = stripTrailingSeparators(pathFlavor.resolve(value), pathFlavor);
+  return pathFlavor.sep === '\\' ? resolved.toLowerCase() : resolved;
+}
+
+function stripTrailingSeparators(value: string, pathFlavor: PathFlavor): string {
+  const root = pathFlavor.parse(value).root;
+  let end = value.length;
+  while (end > root.length && /[\\/]/.test(value.charAt(end - 1))) {
+    end--;
+  }
+  return value.slice(0, end);
+}
+
+function normalizeForOutputSuffix(value: string): string {
+  const normalized = normalizeSeparators(value);
+  return isWindowsPathString(value) ? normalized.toLowerCase() : normalized;
+}
+
+function normalizeSeparators(value: string): string {
+  return value.replace(/\\/g, '/').replace(/\/+$/, '');
 }

--- a/src/workspace/outputResolver.ts
+++ b/src/workspace/outputResolver.ts
@@ -4,28 +4,60 @@ import * as path from 'path';
 const DEFAULT_OUTPUT_DIRS = [
   path.join('build', 'classes', 'java', 'main'),
   path.join('build', 'classes', 'kotlin', 'main'),
-  path.join('build', 'classes'),
   path.join('target', 'classes'),
   path.join('bin', 'main'),
-  'bin',
   path.join('out', 'production'),
+  path.join('build', 'classes', 'java', 'test'),
+  path.join('build', 'classes', 'kotlin', 'test'),
+  path.join('target', 'test-classes'),
+  path.join('bin', 'test'),
+  path.join('build', 'classes'),
+  'bin',
   'out',
   'classes',
 ];
+
+export type OutputTargetPredicate = (targetPath: string) => Promise<boolean>;
+
+export interface OutputFolderCandidate {
+  targetPath: string;
+  relativePath?: string;
+  index: number;
+}
+
+export interface OutputFolderSelectionOptions {
+  rankCandidate?: (candidate: OutputFolderCandidate) => number;
+  allowRecognizedOutputOutsideBoundary?: boolean;
+}
 
 export function isBytecodeTarget(targetPath: string): boolean {
   const ext = path.extname(targetPath).toLowerCase();
   return ext === '.class' || ext === '.jar' || ext === '.zip';
 }
 
+function isLooseClassTarget(targetPath: string): boolean {
+  return path.extname(targetPath).toLowerCase() === '.class';
+}
+
 export async function hasClassTargets(targetPath: string): Promise<boolean> {
+  return hasTargets(targetPath, isBytecodeTarget);
+}
+
+export async function hasLooseClassTargets(targetPath: string): Promise<boolean> {
+  return hasTargets(targetPath, isLooseClassTarget);
+}
+
+async function hasTargets(
+  targetPath: string,
+  isTargetFile: (targetPath: string) => boolean
+): Promise<boolean> {
   try {
     const stat = await fs.promises.stat(targetPath);
     if (stat.isFile()) {
-      return isBytecodeTarget(targetPath);
+      return isTargetFile(targetPath);
     }
     if (stat.isDirectory()) {
-      return await containsBytecodeTarget(targetPath);
+      return await containsTarget(targetPath, isTargetFile);
     }
   } catch {
     return false;
@@ -34,18 +66,41 @@ export async function hasClassTargets(targetPath: string): Promise<boolean> {
 }
 
 export async function findOutputFolderFromProject(
-  projectRoot: string
+  projectRoot: string,
+  hasTargets: OutputTargetPredicate = hasClassTargets,
+  options: OutputFolderSelectionOptions = {}
 ): Promise<string | undefined> {
-  for (const rel of DEFAULT_OUTPUT_DIRS) {
-    const candidate = path.join(projectRoot, rel);
-    if (await hasClassTargets(candidate)) {
-      return candidate;
+  const candidates = orderOutputFolderCandidates(
+    DEFAULT_OUTPUT_DIRS.map((relativePath, index) => ({
+      targetPath: path.join(projectRoot, relativePath),
+      relativePath,
+      index,
+    })),
+    options
+  );
+  for (const candidate of candidates) {
+    if (await hasTargets(candidate.targetPath)) {
+      return candidate.targetPath;
     }
   }
   return undefined;
 }
 
-async function containsBytecodeTarget(root: string): Promise<boolean> {
+export function orderOutputFolderCandidates<T extends OutputFolderCandidate>(
+  candidates: readonly T[],
+  options: OutputFolderSelectionOptions = {}
+): T[] {
+  return [...candidates].sort((a, b) => {
+    const aRank = options.rankCandidate?.(a) ?? 0;
+    const bRank = options.rankCandidate?.(b) ?? 0;
+    return aRank - bRank || a.index - b.index;
+  });
+}
+
+async function containsTarget(
+  root: string,
+  isTargetFile: (targetPath: string) => boolean
+): Promise<boolean> {
   const queue: string[] = [root];
   while (queue.length > 0) {
     const current = queue.pop();
@@ -60,7 +115,7 @@ async function containsBytecodeTarget(root: string): Promise<boolean> {
     }
     for (const entry of entries) {
       if (entry.isFile()) {
-        if (isBytecodeTarget(entry.name)) {
+        if (isTargetFile(entry.name)) {
           return true;
         }
         continue;


### PR DESCRIPTION
## Summary
- Keep Java source and source-folder analysis scoped to mapped output roots.
- Align TypeScript target resolution and the Java runner around sourcepath-aware loose class mapping.
- Preserve archive/direct bytecode handling while reducing duplicate resolver tests.

## Test Plan
- [x] npm run compile && npm run test:l1:unit
- [x] npm run test:unit
- [x] npm run lint
- [x] git diff --check