### PR TITLE
fix(runner): load configured SpotBugs plugins

### DIFF
--- a/javaext/com.spotbugs.runner/pom.xml
+++ b/javaext/com.spotbugs.runner/pom.xml
@@ -80,6 +80,32 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.6.1</version>
+                <executions>
+                    <execution>
+                        <id>copy-findsecbugs-test-plugin</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.h3xstream.findsecbugs</groupId>
+                                    <artifactId>findsecbugs-plugin</artifactId>
+                                    <version>1.11.0</version>
+                                    <type>jar</type>
+                                    <outputDirectory>${project.build.directory}/test-plugins</outputDirectory>
+                                    <destFileName>findsecbugs-plugin-1.11.0.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SpotBugsExecutor.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SpotBugsExecutor.java
@@ -4,12 +4,15 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLClassLoader;
+import java.lang.reflect.Field;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import com.spotbugs.vscode.runner.api.BugInfo;
 
@@ -17,11 +20,16 @@ import edu.umd.cs.findbugs.BugCollectionBugReporter;
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.DetectorFactoryCollection;
 import edu.umd.cs.findbugs.FindBugs2;
+import edu.umd.cs.findbugs.Plugin;
+import edu.umd.cs.findbugs.PluginException;
+import edu.umd.cs.findbugs.PluginLoader;
 import edu.umd.cs.findbugs.Project;
 import edu.umd.cs.findbugs.config.UserPreferences;
 import edu.umd.cs.findbugs.sarif.SarifBugReporter;
 
 public class SpotBugsExecutor {
+
+    private static final Object SPOTBUGS_GLOBAL_LOCK = new Object();
 
     private final FindBugs2 findBugs;
     private final Project project;
@@ -42,17 +50,25 @@ public class SpotBugsExecutor {
     }
 
     public List<BugInfo> executeBugs() throws IOException, InterruptedException {
-        execute(defaultBugReporter);
-        return collectBugs(defaultBugReporter);
+        synchronized (SPOTBUGS_GLOBAL_LOCK) {
+            try (LoadedPlugins ignored = LoadedPlugins.load(pluginJars, project)) {
+                execute(defaultBugReporter);
+                return collectBugs(defaultBugReporter);
+            }
+        }
     }
 
     public String executeNativeSarif() throws IOException, InterruptedException {
-        StringWriter writer = new StringWriter();
-        SarifBugReporter reporter = new SarifBugReporter(project);
-        reporter.setPriorityThreshold(this.reporterPriorityThreshold != null ? this.reporterPriorityThreshold.intValue() : 1);
-        reporter.setWriter(new PrintWriter(writer));
-        execute(reporter);
-        return writer.toString();
+        synchronized (SPOTBUGS_GLOBAL_LOCK) {
+            try (LoadedPlugins ignored = LoadedPlugins.load(pluginJars, project)) {
+                StringWriter writer = new StringWriter();
+                SarifBugReporter reporter = new SarifBugReporter(project);
+                reporter.setPriorityThreshold(this.reporterPriorityThreshold != null ? this.reporterPriorityThreshold.intValue() : 1);
+                reporter.setWriter(new PrintWriter(writer));
+                execute(reporter);
+                return writer.toString();
+            }
+        }
     }
 
     private void execute(BugCollectionBugReporter reporter) throws IOException, InterruptedException {
@@ -63,39 +79,34 @@ public class SpotBugsExecutor {
             // Re-apply current preferences so filter wrappers bind to the current bug reporter chain.
             findBugs.setUserPreferences(currentPreferences);
         }
-        ClassLoader prev = Thread.currentThread().getContextClassLoader();
-        URLClassLoader pluginLoader = null;
-        try {
-            DetectorFactoryCollection dfc;
-            if (pluginJars != null && !pluginJars.isEmpty()) {
-                URL[] urls = pluginJarsToUrls(pluginJars);
-                // If no valid URLs, fall back to default discovery
-                if (urls.length > 0) {
-                    pluginLoader = new URLClassLoader(urls, prev);
-                    Thread.currentThread().setContextClassLoader(pluginLoader);
-                }
-            }
-            dfc = DetectorFactoryCollection.instance();
-            findBugs.setDetectorFactoryCollection(dfc);
-            findBugs.execute();
-        } finally {
-            // restore TCCL
-            Thread.currentThread().setContextClassLoader(prev);
-            if (pluginLoader != null) try { pluginLoader.close(); } catch (IOException ignored) {}
-        }
+        DetectorFactoryCollection dfc = DetectorFactoryCollection.instance();
+        findBugs.setDetectorFactoryCollection(dfc);
+        findBugs.execute();
     }
 
-    private static URL[] pluginJarsToUrls(List<String> jars) {
-        List<URL> urls = new ArrayList<>();
-        for (String p : jars) {
-            if (p == null) continue;
-            File f = new File(p);
-            if (!f.exists() || !f.isFile()) continue;
-            try {
-                urls.add(f.toURI().toURL());
-            } catch (MalformedURLException ignored) {}
+    private static List<File> pluginJarFiles(List<String> jars) throws IOException {
+        List<File> files = new ArrayList<>();
+        Set<String> seen = new LinkedHashSet<>();
+        if (jars == null || jars.isEmpty()) {
+            return files;
         }
-        return urls.toArray(new URL[0]);
+        for (String p : jars) {
+            if (p == null) {
+                continue;
+            }
+            String path = p.trim();
+            if (path.isEmpty()) {
+                continue;
+            }
+            File f = new File(path).getCanonicalFile();
+            if (!f.isFile()) {
+                throw new IOException("SpotBugs plugin jar does not exist or is not a file: " + path);
+            }
+            if (seen.add(f.toURI().toString())) {
+                files.add(f);
+            }
+        }
+        return files;
     }
 
     private List<BugInfo> collectBugs(BugCollectionBugReporter reporter) {
@@ -105,5 +116,160 @@ public class SpotBugsExecutor {
             bugList.add(new BugInfo(bug));
         }
         return bugList;
+    }
+
+    private static final class LoadedPlugins implements AutoCloseable {
+
+        private final List<Plugin> loadedPlugins = new ArrayList<>();
+
+        private static LoadedPlugins load(List<String> pluginJars, Project project) throws IOException {
+            LoadedPlugins loaded = new LoadedPlugins();
+            try {
+                for (File pluginJar : pluginJarFiles(pluginJars)) {
+                    loaded.load(pluginJar, project);
+                }
+                return loaded;
+            } catch (IOException | RuntimeException e) {
+                loaded.close(e);
+                throw e;
+            }
+        }
+
+        private void load(File pluginJar, Project project) throws IOException {
+            SpotBugsPluginState stateBeforeLoad = SpotBugsPluginState.snapshot();
+            Plugin existing = stateBeforeLoad.pluginByUri(pluginJar.toURI());
+            if (existing != null) {
+                if (project != null) {
+                    project.setPluginStatusTrinary(existing.getPluginId(), Boolean.TRUE);
+                }
+                return;
+            }
+
+            try {
+                Plugin plugin = Plugin.loadCustomPlugin(pluginJar, project);
+                if (plugin != null) {
+                    loadedPlugins.add(plugin);
+                }
+            } catch (PluginException e) {
+                IOException failure = new IOException("Failed to load SpotBugs plugin jar " + pluginJar.getPath(), e);
+                cleanupAfterFailedLoad(stateBeforeLoad, failure);
+                throw failure;
+            } catch (RuntimeException e) {
+                cleanupAfterFailedLoad(stateBeforeLoad, e);
+                throw e;
+            }
+        }
+
+        @Override
+        public void close() {
+            close(null);
+        }
+
+        private void close(Throwable failure) {
+            boolean resetDetectorFactories = !loadedPlugins.isEmpty();
+            RuntimeException closeFailure = null;
+            try {
+                for (int i = loadedPlugins.size() - 1; i >= 0; i--) {
+                    Plugin plugin = loadedPlugins.get(i);
+                    try {
+                        Plugin.removeCustomPlugin(plugin);
+                    } catch (RuntimeException e) {
+                        if (failure != null) {
+                            failure.addSuppressed(e);
+                        } else if (closeFailure == null) {
+                            closeFailure = e;
+                        } else {
+                            closeFailure.addSuppressed(e);
+                        }
+                    } finally {
+                        closePlugin(plugin, failure != null ? failure : closeFailure);
+                    }
+                }
+            } finally {
+                if (resetDetectorFactories) {
+                    DetectorFactoryCollection.resetInstance(null);
+                }
+            }
+            if (failure == null && closeFailure != null) {
+                throw closeFailure;
+            }
+        }
+
+        private static void cleanupAfterFailedLoad(SpotBugsPluginState stateBeforeLoad, Throwable failure) {
+            for (Map.Entry<URI, Plugin> entry : Plugin.getAllPluginsMap().entrySet()) {
+                if (!stateBeforeLoad.hasPluginUri(entry.getKey())) {
+                    Plugin plugin = entry.getValue();
+                    try {
+                        Plugin.removeCustomPlugin(plugin);
+                    } catch (RuntimeException e) {
+                        failure.addSuppressed(e);
+                    } finally {
+                        closePlugin(plugin, failure);
+                    }
+                }
+            }
+            stateBeforeLoad.restoreLoadedPluginIds(failure);
+            DetectorFactoryCollection.resetInstance(null);
+        }
+
+        private static void closePlugin(Plugin plugin, Throwable failure) {
+            try {
+                plugin.close();
+            } catch (IOException e) {
+                if (failure != null) {
+                    failure.addSuppressed(e);
+                }
+            }
+        }
+    }
+
+    private static final class SpotBugsPluginState {
+
+        private final Map<URI, Plugin> pluginsByUri;
+        private final Set<String> loadedPluginIds;
+
+        private SpotBugsPluginState(Map<URI, Plugin> pluginsByUri, Set<String> loadedPluginIds) {
+            this.pluginsByUri = pluginsByUri;
+            this.loadedPluginIds = loadedPluginIds;
+        }
+
+        private static SpotBugsPluginState snapshot() throws IOException {
+            return new SpotBugsPluginState(Plugin.getAllPluginsMap(), copyLoadedPluginIds());
+        }
+
+        private Plugin pluginByUri(URI uri) {
+            return pluginsByUri.get(uri);
+        }
+
+        private boolean hasPluginUri(URI uri) {
+            return pluginsByUri.containsKey(uri);
+        }
+
+        private void restoreLoadedPluginIds(Throwable failure) {
+            try {
+                loadedPluginIds().retainAll(loadedPluginIds);
+            } catch (ReflectiveOperationException | RuntimeException e) {
+                failure.addSuppressed(e);
+            }
+        }
+
+        private static Set<String> copyLoadedPluginIds() throws IOException {
+            try {
+                return new HashSet<>(loadedPluginIds());
+            } catch (ReflectiveOperationException | RuntimeException e) {
+                throw new IOException("Unable to inspect SpotBugs plugin id registry", e);
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        private static Set<String> loadedPluginIds() throws ReflectiveOperationException {
+            Field field = PluginLoader.class.getDeclaredField("loadedPluginIds");
+            field.setAccessible(true);
+            Object value = field.get(null);
+            if (!(value instanceof Set)) {
+                throw new IllegalStateException("SpotBugs plugin id registry is not a Set");
+            }
+            return (Set<String>) value;
+        }
     }
 }

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/config/PreferencesApplier.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/config/PreferencesApplier.java
@@ -28,7 +28,7 @@ public class PreferencesApplier {
         prefs.setExcludeBugsFiles(toEnabledPathMap(cfg.getExcludeBaselineBugsPaths()));
 
         // rank threshold is handled via BugReporter in SpotBugsExecutor
-        // plugins are loaded via a temporary context ClassLoader in SpotBugsExecutor
+        // plugins are loaded explicitly by SpotBugsExecutor for the current analysis project
     }
 
     private static String toEffortString(Effort e) {

--- a/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/SpotBugsExecutorPluginLoadingTest.java
+++ b/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/SpotBugsExecutorPluginLoadingTest.java
@@ -1,0 +1,204 @@
+package com.spotbugs.vscode.runner.internal;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import edu.umd.cs.findbugs.DetectorFactoryCollection;
+import edu.umd.cs.findbugs.FindBugs2;
+import edu.umd.cs.findbugs.Plugin;
+import edu.umd.cs.findbugs.Project;
+
+public class SpotBugsExecutorPluginLoadingTest {
+
+    private static final String FINDSECBUGS_PLUGIN_ID = "com.h3xstream.findsecbugs";
+    private static final String FINDSECBUGS_DETECTOR = "com.h3xstream.findsecbugs.PredictableRandomDetector";
+    private static final String FINDSECBUGS_BUG_PATTERN = "PREDICTABLE_RANDOM";
+
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
+
+    @Before
+    public void resetSpotBugsStateBefore() {
+        resetSpotBugsState();
+    }
+
+    @After
+    public void resetSpotBugsStateAfter() {
+        resetSpotBugsState();
+    }
+
+    @Test
+    public void executeRegistersConfiguredPluginDetectorsBeforeRunningSpotBugs() throws Exception {
+        CapturingFindBugs findBugs = new CapturingFindBugs(
+                FINDSECBUGS_PLUGIN_ID,
+                FINDSECBUGS_DETECTOR,
+                FINDSECBUGS_BUG_PATTERN
+        );
+        Project project = new Project();
+        SpotBugsExecutor executor = new SpotBugsExecutor(
+                findBugs,
+                project,
+                3,
+                Collections.singletonList(findSecBugsPluginJar().getAbsolutePath())
+        );
+
+        executor.executeBugs();
+
+        assertTrue(findBugs.wasExecuted());
+        assertNull(
+                "FindSecBugs plugin should not leak after analysis completes",
+                Plugin.getByPluginId(FINDSECBUGS_PLUGIN_ID)
+        );
+    }
+
+    @Test
+    public void failedPluginLoadDoesNotBlockLaterPluginWithSameId() throws Exception {
+        String pluginId = "com.spotbugs.vscode.test.partial." + System.nanoTime();
+        File invalidPlugin = createPluginJar(pluginId, "invalid-plugin.jar", true);
+        File validPlugin = createPluginJar(pluginId, "valid-plugin.jar", false);
+
+        try {
+            new SpotBugsExecutor(
+                    new CapturingFindBugs(pluginId),
+                    new Project(),
+                    3,
+                    Collections.singletonList(invalidPlugin.getAbsolutePath())
+            ).executeBugs();
+            fail("Expected invalid plugin jar to fail analysis");
+        } catch (IOException expected) {
+            assertNull("Failed plugin should not be globally registered", Plugin.getByPluginId(pluginId));
+        }
+
+        CapturingFindBugs retryFindBugs = new CapturingFindBugs(pluginId);
+        new SpotBugsExecutor(
+                retryFindBugs,
+                new Project(),
+                3,
+                Collections.singletonList(validPlugin.getAbsolutePath())
+        ).executeBugs();
+
+        assertTrue(retryFindBugs.wasExecuted());
+        assertNull("Retried plugin should not leak after analysis completes", Plugin.getByPluginId(pluginId));
+    }
+
+    private static File findSecBugsPluginJar() {
+        File jar = new File(System.getProperty(
+                "findsecbugs.plugin.jar",
+                "target/test-plugins/findsecbugs-plugin-1.11.0.jar"
+        ));
+        assertTrue("FindSecBugs test plugin jar should exist: " + jar.getAbsolutePath(), jar.isFile());
+        return jar;
+    }
+
+    private static void resetSpotBugsState() {
+        Plugin existing = Plugin.getByPluginId(FINDSECBUGS_PLUGIN_ID);
+        if (existing != null) {
+            Plugin.removeCustomPlugin(existing);
+            try {
+                existing.close();
+            } catch (IOException ignored) {
+            }
+        }
+        DetectorFactoryCollection.resetInstance(null);
+    }
+
+    private File createPluginJar(String pluginId, String fileName, boolean includeMissingDetector) throws IOException {
+        File jar = temp.newFile(fileName);
+        try (JarOutputStream out = new JarOutputStream(new FileOutputStream(jar))) {
+            writeJarEntry(out, "findbugs.xml", findbugsXml(pluginId, includeMissingDetector));
+            writeJarEntry(out, "messages.xml", messagesXml());
+        }
+        return jar;
+    }
+
+    private static void writeJarEntry(JarOutputStream out, String name, String content) throws IOException {
+        out.putNextEntry(new JarEntry(name));
+        out.write(content.getBytes(StandardCharsets.UTF_8));
+        out.closeEntry();
+    }
+
+    private static String findbugsXml(String pluginId, boolean includeMissingDetector) {
+        String detector = includeMissingDetector
+                ? "<Detector class=\"com.spotbugs.vscode.test.MissingDetector\" reports=\"TEST_MISSING\"/>"
+                : "";
+        return "<FindbugsPlugin pluginid=\"" + pluginId + "\" provider=\"SpotBugs Runner Test\" defaultenabled=\"true\">"
+                + detector
+                + "</FindbugsPlugin>";
+    }
+
+    private static String messagesXml() {
+        return "<MessageCollection>"
+                + "<Plugin>"
+                + "<ShortDescription>SpotBugs runner test plugin</ShortDescription>"
+                + "<Details>SpotBugs runner test plugin</Details>"
+                + "</Plugin>"
+                + "</MessageCollection>";
+    }
+
+    private static final class CapturingFindBugs extends FindBugs2 {
+
+        private final String expectedPluginId;
+        private final String expectedDetectorClassName;
+        private final String expectedBugPattern;
+        private DetectorFactoryCollection detectorFactoryCollection;
+        private boolean executed;
+
+        private CapturingFindBugs(String expectedPluginId) {
+            this(expectedPluginId, null, null);
+        }
+
+        private CapturingFindBugs(String expectedPluginId, String expectedDetectorClassName, String expectedBugPattern) {
+            this.expectedPluginId = expectedPluginId;
+            this.expectedDetectorClassName = expectedDetectorClassName;
+            this.expectedBugPattern = expectedBugPattern;
+        }
+
+        @Override
+        public void setDetectorFactoryCollection(DetectorFactoryCollection detectorFactoryCollection) {
+            super.setDetectorFactoryCollection(detectorFactoryCollection);
+            this.detectorFactoryCollection = detectorFactoryCollection;
+        }
+
+        @Override
+        public void execute() throws IOException, InterruptedException {
+            this.executed = true;
+            assertNotNull(detectorFactoryCollection);
+            assertNotNull(
+                    "Configured plugin should be loaded before analysis executes",
+                    detectorFactoryCollection.getPluginById(expectedPluginId)
+            );
+            if (expectedDetectorClassName != null) {
+                assertNotNull(
+                        "Configured detector should be registered before analysis executes",
+                        detectorFactoryCollection.getFactoryByClassName(expectedDetectorClassName)
+                );
+            }
+            if (expectedBugPattern != null) {
+                assertNotNull(
+                        "Configured bug pattern should be registered before analysis executes",
+                        detectorFactoryCollection.lookupBugPattern(expectedBugPattern)
+                );
+            }
+        }
+
+        private boolean wasExecuted() {
+            return executed;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Load configured SpotBugs plugin jars through `Plugin.loadCustomPlugin` so configured detectors are registered before analysis.
- Serialize SpotBugs execution while per-run plugins are loaded, then unload custom plugins and reset detector factories after analysis.
- Clean up partially registered plugin state after failed plugin loads so a later valid plugin with the same id can load.
- Add Java regression coverage for configured detector registration and failed-load recovery.

## Validation
- `git diff --check`
- `./mvnw -B -ntp -pl com.spotbugs.runner test` - 33 tests, 0 failures

## Follow-up
- Non-terminal cleanup warnings for `Plugin.close()` failures are intentionally left for a separate patch.