### PR TITLE
fix(runner): surface SpotBugs plugin cleanup warnings

### DIFF
--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/api/CommandResponse.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/api/CommandResponse.java
@@ -9,17 +9,28 @@ public class CommandResponse {
     private final int schemaVersion;
     private final Object results;
     private final List<CommandError> errors;
+    private final List<CommandWarning> warnings;
     private final RunAnalysisSummary stats;
 
-    private CommandResponse(Object results, List<CommandError> errors, RunAnalysisSummary stats) {
+    private CommandResponse(
+            Object results,
+            List<CommandError> errors,
+            List<CommandWarning> warnings,
+            RunAnalysisSummary stats
+    ) {
         this.schemaVersion = SCHEMA_VERSION;
         this.results = results != null ? results : Collections.emptyList();
         this.errors = errors != null ? errors : Collections.emptyList();
+        this.warnings = warnings != null && !warnings.isEmpty() ? warnings : null;
         this.stats = stats;
     }
 
     public static CommandResponse success(Object results, RunAnalysisSummary stats) {
-        return new CommandResponse(results, Collections.emptyList(), stats);
+        return new CommandResponse(results, Collections.emptyList(), null, stats);
+    }
+
+    public static CommandResponse success(Object results, RunAnalysisSummary stats, List<CommandWarning> warnings) {
+        return new CommandResponse(results, Collections.emptyList(), warnings, stats);
     }
 
     public static CommandResponse error(String code, String message) {
@@ -28,7 +39,7 @@ public class CommandResponse {
 
     public static CommandResponse error(String code, String message, RunAnalysisSummary stats) {
         CommandError error = new CommandError(code, message);
-        return new CommandResponse(Collections.emptyList(), Collections.singletonList(error), stats);
+        return new CommandResponse(Collections.emptyList(), Collections.singletonList(error), null, stats);
     }
 
     public int getSchemaVersion() {
@@ -41,6 +52,10 @@ public class CommandResponse {
 
     public List<CommandError> getErrors() {
         return errors;
+    }
+
+    public List<CommandWarning> getWarnings() {
+        return warnings != null ? warnings : Collections.emptyList();
     }
 
     public RunAnalysisSummary getStats() {

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/api/CommandWarning.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/api/CommandWarning.java
@@ -1,0 +1,19 @@
+package com.spotbugs.vscode.runner.api;
+
+public class CommandWarning {
+    private final String code;
+    private final String message;
+
+    public CommandWarning(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/AnalyzerService.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/AnalyzerService.java
@@ -63,22 +63,28 @@ public class AnalyzerService {
 
     public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths)
             throws java.io.IOException, InterruptedException {
+        return analyzeToBugsWithWarnings(monitor, filePaths).getBugs();
+    }
+
+    public SpotBugsAnalysisResult analyzeToBugsWithWarnings(IProgressMonitor monitor, String... filePaths)
+            throws java.io.IOException, InterruptedException {
         PreparedAnalysis prepared = prepareAnalysis(monitor, filePaths);
         if (prepared == null) {
-            return java.util.Collections.emptyList();
+            return SpotBugsAnalysisResult.empty();
         }
         SpotBugsRunner runner = new SpotBugsRunner();
         checkCanceled(monitor);
-        List<BugInfo> bugs = runner.run(
+        SpotBugsAnalysisResult result = runner.runWithWarnings(
                 this.findBugs,
                 prepared.project,
                 prepared.reporterPriorityThreshold,
                 prepared.plugins
         );
         checkCanceled(monitor);
+        List<BugInfo> bugs = result != null ? result.getBugs() : java.util.Collections.emptyList();
         applyFullPaths(bugs, monitor, filePaths);
         applyRankThreshold(bugs, monitor);
-        return bugs;
+        return result != null ? new SpotBugsAnalysisResult(bugs, result.getWarnings()) : SpotBugsAnalysisResult.empty();
     }
 
     public String analyzeToNativeSarif(String... filePaths) {

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/AnalyzerService.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/AnalyzerService.java
@@ -81,10 +81,10 @@ public class AnalyzerService {
                 prepared.plugins
         );
         checkCanceled(monitor);
-        List<BugInfo> bugs = result != null ? result.getBugs() : java.util.Collections.emptyList();
+        List<BugInfo> bugs = result.getBugs();
         applyFullPaths(bugs, monitor, filePaths);
         applyRankThreshold(bugs, monitor);
-        return result != null ? new SpotBugsAnalysisResult(bugs, result.getWarnings()) : SpotBugsAnalysisResult.empty();
+        return new SpotBugsAnalysisResult(bugs, result.getWarnings());
     }
 
     public String analyzeToNativeSarif(String... filePaths) {

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/PluginLifecycle.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/PluginLifecycle.java
@@ -8,8 +8,7 @@ import edu.umd.cs.findbugs.PluginException;
 import edu.umd.cs.findbugs.Project;
 
 interface PluginLifecycle {
-    PluginLifecycle DEFAULT = new PluginLifecycle() {
-    };
+    PluginLifecycle DEFAULT = new PluginLifecycle() {};
 
     default Plugin loadCustomPlugin(File pluginJar, Project project) throws PluginException {
         return Plugin.loadCustomPlugin(pluginJar, project);

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/PluginLifecycle.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/PluginLifecycle.java
@@ -1,0 +1,25 @@
+package com.spotbugs.vscode.runner.internal;
+
+import java.io.File;
+import java.io.IOException;
+
+import edu.umd.cs.findbugs.Plugin;
+import edu.umd.cs.findbugs.PluginException;
+import edu.umd.cs.findbugs.Project;
+
+interface PluginLifecycle {
+    PluginLifecycle DEFAULT = new PluginLifecycle() {
+    };
+
+    default Plugin loadCustomPlugin(File pluginJar, Project project) throws PluginException {
+        return Plugin.loadCustomPlugin(pluginJar, project);
+    }
+
+    default void removeCustomPlugin(Plugin plugin) {
+        Plugin.removeCustomPlugin(plugin);
+    }
+
+    default void closePlugin(Plugin plugin) throws IOException {
+        plugin.close();
+    }
+}

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SpotBugsAnalysisResult.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SpotBugsAnalysisResult.java
@@ -1,0 +1,35 @@
+package com.spotbugs.vscode.runner.internal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.spotbugs.vscode.runner.api.BugInfo;
+import com.spotbugs.vscode.runner.api.CommandWarning;
+
+public class SpotBugsAnalysisResult {
+
+    private final List<BugInfo> bugs;
+    private final List<CommandWarning> warnings;
+
+    public SpotBugsAnalysisResult(List<BugInfo> bugs, List<CommandWarning> warnings) {
+        this.bugs = normalize(bugs);
+        this.warnings = normalize(warnings);
+    }
+
+    public List<BugInfo> getBugs() {
+        return bugs;
+    }
+
+    public List<CommandWarning> getWarnings() {
+        return warnings;
+    }
+
+    public static SpotBugsAnalysisResult empty() {
+        return new SpotBugsAnalysisResult(Collections.emptyList(), Collections.emptyList());
+    }
+
+    private static <T> List<T> normalize(List<T> values) {
+        return values != null ? new ArrayList<>(values) : new ArrayList<>();
+    }
+}

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SpotBugsExecutor.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SpotBugsExecutor.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.spotbugs.vscode.runner.api.BugInfo;
+import com.spotbugs.vscode.runner.api.CommandWarning;
 
 import edu.umd.cs.findbugs.BugCollectionBugReporter;
 import edu.umd.cs.findbugs.BugInstance;
@@ -36,13 +37,25 @@ public class SpotBugsExecutor {
     private final BugCollectionBugReporter defaultBugReporter;
     private final Integer reporterPriorityThreshold; // 1..3 (High..Low) or null
     private final List<String> pluginJars; // optional
+    private final PluginLifecycle pluginLifecycle;
 
     public SpotBugsExecutor(FindBugs2 findBugs, Project project, Integer reporterPriorityThreshold, List<String> pluginJars) {
+        this(findBugs, project, reporterPriorityThreshold, pluginJars, PluginLifecycle.DEFAULT);
+    }
+
+    SpotBugsExecutor(
+            FindBugs2 findBugs,
+            Project project,
+            Integer reporterPriorityThreshold,
+            List<String> pluginJars,
+            PluginLifecycle pluginLifecycle
+    ) {
         this.findBugs = findBugs;
         this.project = project;
         this.defaultBugReporter = new BugCollectionBugReporter(project);
         this.reporterPriorityThreshold = reporterPriorityThreshold;
         this.pluginJars = pluginJars;
+        this.pluginLifecycle = pluginLifecycle != null ? pluginLifecycle : PluginLifecycle.DEFAULT;
         // Keep behavior compatible: default to 1 (highest only) if not provided
         this.defaultBugReporter.setPriorityThreshold(
                 this.reporterPriorityThreshold != null ? this.reporterPriorityThreshold.intValue() : 1
@@ -50,24 +63,42 @@ public class SpotBugsExecutor {
     }
 
     public List<BugInfo> executeBugs() throws IOException, InterruptedException {
+        return executeBugsWithWarnings().getBugs();
+    }
+
+    public SpotBugsAnalysisResult executeBugsWithWarnings() throws IOException, InterruptedException {
         synchronized (SPOTBUGS_GLOBAL_LOCK) {
-            try (LoadedPlugins ignored = LoadedPlugins.load(pluginJars, project)) {
+            LoadedPlugins loadedPlugins = LoadedPlugins.load(pluginJars, project, pluginLifecycle);
+            List<BugInfo> bugs;
+            try {
                 execute(defaultBugReporter);
-                return collectBugs(defaultBugReporter);
+                bugs = collectBugs(defaultBugReporter);
+            } catch (IOException | InterruptedException | RuntimeException | Error failure) {
+                loadedPlugins.closeAfterFailure(failure);
+                throw failure;
             }
+            List<CommandWarning> warnings = loadedPlugins.closeAfterSuccess();
+            return new SpotBugsAnalysisResult(bugs, warnings);
         }
     }
 
     public String executeNativeSarif() throws IOException, InterruptedException {
         synchronized (SPOTBUGS_GLOBAL_LOCK) {
-            try (LoadedPlugins ignored = LoadedPlugins.load(pluginJars, project)) {
+            LoadedPlugins loadedPlugins = LoadedPlugins.load(pluginJars, project, pluginLifecycle);
+            String sarif;
+            try {
                 StringWriter writer = new StringWriter();
                 SarifBugReporter reporter = new SarifBugReporter(project);
                 reporter.setPriorityThreshold(this.reporterPriorityThreshold != null ? this.reporterPriorityThreshold.intValue() : 1);
                 reporter.setWriter(new PrintWriter(writer));
                 execute(reporter);
-                return writer.toString();
+                sarif = writer.toString();
+            } catch (IOException | InterruptedException | RuntimeException | Error failure) {
+                loadedPlugins.closeAfterFailure(failure);
+                throw failure;
             }
+            loadedPlugins.closeAfterSuccess();
+            return sarif;
         }
     }
 
@@ -118,19 +149,25 @@ public class SpotBugsExecutor {
         return bugList;
     }
 
-    private static final class LoadedPlugins implements AutoCloseable {
+    private static final class LoadedPlugins {
 
         private final List<Plugin> loadedPlugins = new ArrayList<>();
+        private final PluginLifecycle lifecycle;
 
-        private static LoadedPlugins load(List<String> pluginJars, Project project) throws IOException {
-            LoadedPlugins loaded = new LoadedPlugins();
+        private LoadedPlugins(PluginLifecycle lifecycle) {
+            this.lifecycle = lifecycle;
+        }
+
+        private static LoadedPlugins load(List<String> pluginJars, Project project, PluginLifecycle lifecycle)
+                throws IOException {
+            LoadedPlugins loaded = new LoadedPlugins(lifecycle);
             try {
                 for (File pluginJar : pluginJarFiles(pluginJars)) {
                     loaded.load(pluginJar, project);
                 }
                 return loaded;
             } catch (IOException | RuntimeException e) {
-                loaded.close(e);
+                loaded.closeAfterFailure(e);
                 throw e;
             }
         }
@@ -146,7 +183,7 @@ public class SpotBugsExecutor {
             }
 
             try {
-                Plugin plugin = Plugin.loadCustomPlugin(pluginJar, project);
+                Plugin plugin = lifecycle.loadCustomPlugin(pluginJar, project);
                 if (plugin != null) {
                     loadedPlugins.add(plugin);
                 }
@@ -160,29 +197,36 @@ public class SpotBugsExecutor {
             }
         }
 
-        @Override
-        public void close() {
-            close(null);
-        }
-
-        private void close(Throwable failure) {
+        private List<CommandWarning> closeAfterSuccess() {
             boolean resetDetectorFactories = !loadedPlugins.isEmpty();
-            RuntimeException closeFailure = null;
+            RuntimeException terminalFailure = null;
+            List<CloseFailure> closeFailures = new ArrayList<>();
             try {
                 for (int i = loadedPlugins.size() - 1; i >= 0; i--) {
                     Plugin plugin = loadedPlugins.get(i);
+                    RuntimeException removeFailure = null;
                     try {
-                        Plugin.removeCustomPlugin(plugin);
+                        lifecycle.removeCustomPlugin(plugin);
                     } catch (RuntimeException e) {
-                        if (failure != null) {
-                            failure.addSuppressed(e);
-                        } else if (closeFailure == null) {
-                            closeFailure = e;
+                        removeFailure = e;
+                        if (terminalFailure == null) {
+                            terminalFailure = e;
+                            addSuppressed(terminalFailure, closeFailures);
                         } else {
-                            closeFailure.addSuppressed(e);
+                            terminalFailure.addSuppressed(e);
                         }
                     } finally {
-                        closePlugin(plugin, failure != null ? failure : closeFailure);
+                        try {
+                            lifecycle.closePlugin(plugin);
+                        } catch (IOException e) {
+                            if (removeFailure != null) {
+                                removeFailure.addSuppressed(e);
+                            } else if (terminalFailure != null) {
+                                terminalFailure.addSuppressed(e);
+                            } else {
+                                closeFailures.add(new CloseFailure(plugin, e));
+                            }
+                        }
                     }
                 }
             } finally {
@@ -190,17 +234,42 @@ public class SpotBugsExecutor {
                     DetectorFactoryCollection.resetInstance(null);
                 }
             }
-            if (failure == null && closeFailure != null) {
-                throw closeFailure;
+            if (terminalFailure != null) {
+                throw terminalFailure;
+            }
+            List<CommandWarning> warnings = new ArrayList<>();
+            for (CloseFailure closeFailure : closeFailures) {
+                warnings.add(closeWarning(closeFailure.plugin, closeFailure.failure));
+            }
+            return warnings;
+        }
+
+        private void closeAfterFailure(Throwable failure) {
+            boolean resetDetectorFactories = !loadedPlugins.isEmpty();
+            try {
+                for (int i = loadedPlugins.size() - 1; i >= 0; i--) {
+                    Plugin plugin = loadedPlugins.get(i);
+                    try {
+                        lifecycle.removeCustomPlugin(plugin);
+                    } catch (RuntimeException e) {
+                        failure.addSuppressed(e);
+                    } finally {
+                        closePlugin(plugin, failure);
+                    }
+                }
+            } finally {
+                if (resetDetectorFactories) {
+                    DetectorFactoryCollection.resetInstance(null);
+                }
             }
         }
 
-        private static void cleanupAfterFailedLoad(SpotBugsPluginState stateBeforeLoad, Throwable failure) {
+        private void cleanupAfterFailedLoad(SpotBugsPluginState stateBeforeLoad, Throwable failure) {
             for (Map.Entry<URI, Plugin> entry : Plugin.getAllPluginsMap().entrySet()) {
                 if (!stateBeforeLoad.hasPluginUri(entry.getKey())) {
                     Plugin plugin = entry.getValue();
                     try {
-                        Plugin.removeCustomPlugin(plugin);
+                        lifecycle.removeCustomPlugin(plugin);
                     } catch (RuntimeException e) {
                         failure.addSuppressed(e);
                     } finally {
@@ -212,13 +281,55 @@ public class SpotBugsExecutor {
             DetectorFactoryCollection.resetInstance(null);
         }
 
-        private static void closePlugin(Plugin plugin, Throwable failure) {
+        private void closePlugin(Plugin plugin, Throwable failure) {
             try {
-                plugin.close();
+                lifecycle.closePlugin(plugin);
             } catch (IOException e) {
                 if (failure != null) {
                     failure.addSuppressed(e);
                 }
+            }
+        }
+
+        private static CommandWarning closeWarning(Plugin plugin, IOException failure) {
+            String pluginId = pluginId(plugin);
+            String detail = failure.getMessage();
+            if (detail == null || detail.trim().isEmpty()) {
+                detail = failure.getClass().getName();
+            } else {
+                detail = detail.trim();
+            }
+            String pluginLabel = pluginId != null && !pluginId.trim().isEmpty()
+                    ? " plugin " + pluginId.trim()
+                    : " plugin";
+            return new CommandWarning(
+                    "PLUGIN_CLEANUP_CLOSE_FAILED",
+                    "Failed to close SpotBugs" + pluginLabel + ": " + detail
+            );
+        }
+
+        private static String pluginId(Plugin plugin) {
+            try {
+                return plugin != null ? plugin.getPluginId() : null;
+            } catch (RuntimeException e) {
+                return null;
+            }
+        }
+
+        private static void addSuppressed(Throwable failure, List<CloseFailure> closeFailures) {
+            for (CloseFailure closeFailure : closeFailures) {
+                failure.addSuppressed(closeFailure.failure);
+            }
+        }
+
+        private static final class CloseFailure {
+
+            private final Plugin plugin;
+            private final IOException failure;
+
+            private CloseFailure(Plugin plugin, IOException failure) {
+                this.plugin = plugin;
+                this.failure = failure;
             }
         }
     }

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SpotBugsExecutor.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SpotBugsExecutor.java
@@ -248,14 +248,7 @@ public class SpotBugsExecutor {
             boolean resetDetectorFactories = !loadedPlugins.isEmpty();
             try {
                 for (int i = loadedPlugins.size() - 1; i >= 0; i--) {
-                    Plugin plugin = loadedPlugins.get(i);
-                    try {
-                        lifecycle.removeCustomPlugin(plugin);
-                    } catch (RuntimeException e) {
-                        failure.addSuppressed(e);
-                    } finally {
-                        closePlugin(plugin, failure);
-                    }
+                    removeAndClose(loadedPlugins.get(i), failure);
                 }
             } finally {
                 if (resetDetectorFactories) {
@@ -267,18 +260,21 @@ public class SpotBugsExecutor {
         private void cleanupAfterFailedLoad(SpotBugsPluginState stateBeforeLoad, Throwable failure) {
             for (Map.Entry<URI, Plugin> entry : Plugin.getAllPluginsMap().entrySet()) {
                 if (!stateBeforeLoad.hasPluginUri(entry.getKey())) {
-                    Plugin plugin = entry.getValue();
-                    try {
-                        lifecycle.removeCustomPlugin(plugin);
-                    } catch (RuntimeException e) {
-                        failure.addSuppressed(e);
-                    } finally {
-                        closePlugin(plugin, failure);
-                    }
+                    removeAndClose(entry.getValue(), failure);
                 }
             }
             stateBeforeLoad.restoreLoadedPluginIds(failure);
             DetectorFactoryCollection.resetInstance(null);
+        }
+
+        private void removeAndClose(Plugin plugin, Throwable failure) {
+            try {
+                lifecycle.removeCustomPlugin(plugin);
+            } catch (RuntimeException e) {
+                failure.addSuppressed(e);
+            } finally {
+                closePlugin(plugin, failure);
+            }
         }
 
         private void closePlugin(Plugin plugin, Throwable failure) {

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SpotBugsRunner.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SpotBugsRunner.java
@@ -20,8 +20,17 @@ public class SpotBugsRunner {
 
     public List<BugInfo> run(FindBugs2 findBugs, Project project, Integer reporterPriorityThreshold, java.util.List<String> pluginJars)
             throws IOException, InterruptedException {
+        return runWithWarnings(findBugs, project, reporterPriorityThreshold, pluginJars).getBugs();
+    }
+
+    public SpotBugsAnalysisResult runWithWarnings(
+            FindBugs2 findBugs,
+            Project project,
+            Integer reporterPriorityThreshold,
+            java.util.List<String> pluginJars
+    ) throws IOException, InterruptedException {
         SpotBugsExecutor executor = new SpotBugsExecutor(findBugs, project, reporterPriorityThreshold, pluginJars);
-        return executor.executeBugs();
+        return executor.executeBugsWithWarnings();
     }
 
     public String runNativeSarif(

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/AnalysisPipeline.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/AnalysisPipeline.java
@@ -1,12 +1,11 @@
 package com.spotbugs.vscode.runner.internal.command;
 
-import java.util.List;
 import java.util.concurrent.CancellationException;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 
-import com.spotbugs.vscode.runner.api.BugInfo;
 import com.spotbugs.vscode.runner.internal.AnalyzerService;
+import com.spotbugs.vscode.runner.internal.SpotBugsAnalysisResult;
 
 final class AnalysisPipeline {
 
@@ -25,12 +24,11 @@ final class AnalysisPipeline {
         analyzer.setConfiguration(request.getConfig());
         long startMillis = System.currentTimeMillis();
         try {
-            List<BugInfo> bugs = analyzer.analyzeToBugs(monitor, request.getTargetPath());
-            List<BugInfo> results = bugs != null ? bugs : java.util.Collections.emptyList();
+            SpotBugsAnalysisResult result = analyzer.analyzeToBugsWithWarnings(monitor, request.getTargetPath());
             if (monitor != null && monitor.isCanceled()) {
                 return AnalysisPipelineResult.cancelled(analyzer, startMillis);
             }
-            return AnalysisPipelineResult.success(analyzer, startMillis, results);
+            return AnalysisPipelineResult.success(analyzer, startMillis, result);
         } catch (CancellationException cancellation) {
             return AnalysisPipelineResult.cancelled(analyzer, startMillis);
         } catch (InterruptedException interrupted) {

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/AnalysisPipelineResult.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/AnalysisPipelineResult.java
@@ -38,23 +38,11 @@ final class AnalysisPipelineResult {
     }
 
     static AnalysisPipelineResult cancelled(AnalyzerService analyzer, long startMillis) {
-        return new AnalysisPipelineResult(
-                Status.CANCELLED,
-                analyzer,
-                startMillis,
-                SpotBugsAnalysisResult.empty(),
-                null
-        );
+        return new AnalysisPipelineResult(Status.CANCELLED, analyzer, startMillis, null, null);
     }
 
     static AnalysisPipelineResult failed(AnalyzerService analyzer, long startMillis, Throwable failure) {
-        return new AnalysisPipelineResult(
-                Status.FAILED,
-                analyzer,
-                startMillis,
-                SpotBugsAnalysisResult.empty(),
-                failure
-        );
+        return new AnalysisPipelineResult(Status.FAILED, analyzer, startMillis, null, failure);
     }
 
     Status getStatus() {

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/AnalysisPipelineResult.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/AnalysisPipelineResult.java
@@ -1,9 +1,9 @@
 package com.spotbugs.vscode.runner.internal.command;
 
-import java.util.List;
-
 import com.spotbugs.vscode.runner.api.BugInfo;
+import com.spotbugs.vscode.runner.api.CommandWarning;
 import com.spotbugs.vscode.runner.internal.AnalyzerService;
+import com.spotbugs.vscode.runner.internal.SpotBugsAnalysisResult;
 
 final class AnalysisPipelineResult {
 
@@ -16,25 +16,25 @@ final class AnalysisPipelineResult {
     private final Status status;
     private final AnalyzerService analyzer;
     private final long startMillis;
-    private final List<BugInfo> results;
+    private final SpotBugsAnalysisResult result;
     private final Throwable failure;
 
     private AnalysisPipelineResult(
             Status status,
             AnalyzerService analyzer,
             long startMillis,
-            List<BugInfo> results,
+            SpotBugsAnalysisResult result,
             Throwable failure
     ) {
         this.status = status;
         this.analyzer = analyzer;
         this.startMillis = startMillis;
-        this.results = results != null ? results : java.util.Collections.emptyList();
+        this.result = result != null ? result : SpotBugsAnalysisResult.empty();
         this.failure = failure;
     }
 
-    static AnalysisPipelineResult success(AnalyzerService analyzer, long startMillis, List<BugInfo> results) {
-        return new AnalysisPipelineResult(Status.SUCCESS, analyzer, startMillis, results, null);
+    static AnalysisPipelineResult success(AnalyzerService analyzer, long startMillis, SpotBugsAnalysisResult result) {
+        return new AnalysisPipelineResult(Status.SUCCESS, analyzer, startMillis, result, null);
     }
 
     static AnalysisPipelineResult cancelled(AnalyzerService analyzer, long startMillis) {
@@ -42,7 +42,7 @@ final class AnalysisPipelineResult {
                 Status.CANCELLED,
                 analyzer,
                 startMillis,
-                java.util.Collections.emptyList(),
+                SpotBugsAnalysisResult.empty(),
                 null
         );
     }
@@ -52,7 +52,7 @@ final class AnalysisPipelineResult {
                 Status.FAILED,
                 analyzer,
                 startMillis,
-                java.util.Collections.emptyList(),
+                SpotBugsAnalysisResult.empty(),
                 failure
         );
     }
@@ -69,12 +69,16 @@ final class AnalysisPipelineResult {
         return startMillis;
     }
 
-    List<BugInfo> getResults() {
-        return results;
+    java.util.List<BugInfo> getResults() {
+        return result.getBugs();
+    }
+
+    java.util.List<CommandWarning> getWarnings() {
+        return result.getWarnings();
     }
 
     int getFindingCount() {
-        return results.size();
+        return getResults().size();
     }
 
     Throwable getFailure() {

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisAction.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisAction.java
@@ -84,7 +84,7 @@ public final class RunAnalysisAction extends AbstractCommandAction {
             ));
         }
 
-        return success(CommandResponse.success(pipelineResult.getResults(), stats));
+        return success(CommandResponse.success(pipelineResult.getResults(), stats, pipelineResult.getWarnings()));
     }
 
     private String rootCauseMessage(Throwable throwable) {

--- a/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/SpotBugsExecutorPluginLoadingTest.java
+++ b/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/SpotBugsExecutorPluginLoadingTest.java
@@ -1,6 +1,7 @@
 package com.spotbugs.vscode.runner.internal;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -9,9 +10,13 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
+
+import com.spotbugs.vscode.runner.api.CommandWarning;
 
 import org.junit.After;
 import org.junit.Before;
@@ -97,6 +102,58 @@ public class SpotBugsExecutorPluginLoadingTest {
         assertNull("Retried plugin should not leak after analysis completes", Plugin.getByPluginId(pluginId));
     }
 
+    @Test
+    public void closeOnlyCleanupFailureReturnsWarningAndDoesNotBlockLaterPluginLoad() throws Exception {
+        File pluginJar = findSecBugsPluginJar();
+        SpotBugsExecutor executor = new SpotBugsExecutor(
+                new CapturingFindBugs(FINDSECBUGS_PLUGIN_ID),
+                new Project(),
+                3,
+                Collections.singletonList(pluginJar.getAbsolutePath()),
+                new CloseFailingLifecycle()
+        );
+
+        SpotBugsAnalysisResult result = executor.executeBugsWithWarnings();
+
+        List<CommandWarning> warnings = result.getWarnings();
+        assertEquals(1, warnings.size());
+        assertEquals("PLUGIN_CLEANUP_CLOSE_FAILED", warnings.get(0).getCode());
+        assertTrue(warnings.get(0).getMessage().contains(FINDSECBUGS_PLUGIN_ID));
+        assertTrue(warnings.get(0).getMessage().contains("close failed"));
+        assertNull("Plugin should not remain globally registered after close warning", Plugin.getByPluginId(FINDSECBUGS_PLUGIN_ID));
+
+    }
+
+    @Test
+    public void closeFailureBeforeLaterRemoveFailureIsSuppressedOnTerminalFailure() throws Exception {
+        String removeFailurePluginId = "com.spotbugs.vscode.test.remove." + System.nanoTime();
+        String closeFailurePluginId = "com.spotbugs.vscode.test.close." + System.nanoTime();
+        File removeFailurePlugin = createPluginJar(removeFailurePluginId, "remove-failure-plugin.jar", false);
+        File closeFailurePlugin = createPluginJar(closeFailurePluginId, "close-failure-plugin.jar", false);
+        RuntimeException removeFailure = new RuntimeException("remove failed");
+        IOException closeFailure = new IOException("close failed");
+
+        try {
+            new SpotBugsExecutor(
+                    new CapturingFindBugs(removeFailurePluginId),
+                    new Project(),
+                    3,
+                    Arrays.asList(
+                            removeFailurePlugin.getAbsolutePath(),
+                            closeFailurePlugin.getAbsolutePath()
+                    ),
+                    new TargetedFailingLifecycle(removeFailurePluginId, removeFailure, closeFailurePluginId, closeFailure)
+            ).executeBugsWithWarnings();
+            fail("Expected plugin removal failure to fail analysis");
+        } catch (RuntimeException expected) {
+            assertTrue("Terminal failure should be remove failure", expected == removeFailure);
+            assertSuppressed(expected, closeFailure);
+        } finally {
+            removePluginIfLoaded(removeFailurePluginId);
+            removePluginIfLoaded(closeFailurePluginId);
+        }
+    }
+
     private static File findSecBugsPluginJar() {
         File jar = new File(System.getProperty(
                 "findsecbugs.plugin.jar",
@@ -116,6 +173,26 @@ public class SpotBugsExecutorPluginLoadingTest {
             }
         }
         DetectorFactoryCollection.resetInstance(null);
+    }
+
+    private static void removePluginIfLoaded(String pluginId) {
+        Plugin existing = Plugin.getByPluginId(pluginId);
+        if (existing != null) {
+            Plugin.removeCustomPlugin(existing);
+            try {
+                existing.close();
+            } catch (IOException ignored) {
+            }
+        }
+    }
+
+    private static void assertSuppressed(Throwable failure, Throwable suppressed) {
+        for (Throwable candidate : failure.getSuppressed()) {
+            if (candidate == suppressed) {
+                return;
+            }
+        }
+        fail("Expected suppressed failure: " + suppressed);
     }
 
     private File createPluginJar(String pluginId, String fileName, boolean includeMissingDetector) throws IOException {
@@ -149,6 +226,50 @@ public class SpotBugsExecutorPluginLoadingTest {
                 + "<Details>SpotBugs runner test plugin</Details>"
                 + "</Plugin>"
                 + "</MessageCollection>";
+    }
+
+    private static final class CloseFailingLifecycle implements PluginLifecycle {
+
+        @Override
+        public void closePlugin(Plugin plugin) throws IOException {
+            throw new IOException("close failed");
+        }
+    }
+
+    private static final class TargetedFailingLifecycle implements PluginLifecycle {
+
+        private final String removeFailurePluginId;
+        private final RuntimeException removeFailure;
+        private final String closeFailurePluginId;
+        private final IOException closeFailure;
+
+        private TargetedFailingLifecycle(
+                String removeFailurePluginId,
+                RuntimeException removeFailure,
+                String closeFailurePluginId,
+                IOException closeFailure
+        ) {
+            this.removeFailurePluginId = removeFailurePluginId;
+            this.removeFailure = removeFailure;
+            this.closeFailurePluginId = closeFailurePluginId;
+            this.closeFailure = closeFailure;
+        }
+
+        @Override
+        public void removeCustomPlugin(Plugin plugin) {
+            if (removeFailurePluginId.equals(plugin.getPluginId())) {
+                throw removeFailure;
+            }
+            PluginLifecycle.super.removeCustomPlugin(plugin);
+        }
+
+        @Override
+        public void closePlugin(Plugin plugin) throws IOException {
+            if (closeFailurePluginId.equals(plugin.getPluginId())) {
+                throw closeFailure;
+            }
+            PluginLifecycle.super.closePlugin(plugin);
+        }
     }
 
     private static final class CapturingFindBugs extends FindBugs2 {

--- a/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/command/AnalysisPipelineTest.java
+++ b/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/command/AnalysisPipelineTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 
 import com.spotbugs.vscode.runner.api.BugInfo;
 import com.spotbugs.vscode.runner.internal.AnalyzerService;
+import com.spotbugs.vscode.runner.internal.SpotBugsAnalysisResult;
 import com.spotbugs.vscode.runner.internal.config.AnalysisConfig;
 import com.spotbugs.vscode.runner.internal.config.ConfigParser;
 import com.spotbugs.vscode.runner.internal.config.ConfigValidator;
@@ -55,9 +56,9 @@ public class AnalysisPipelineTest {
         NullProgressMonitor monitor = new NullProgressMonitor();
         AnalysisPipeline pipeline = new AnalysisPipeline(() -> new AnalyzerService() {
             @Override
-            public List<BugInfo> analyzeToBugs(IProgressMonitor progressMonitor, String... filePaths) {
+            public SpotBugsAnalysisResult analyzeToBugsWithWarnings(IProgressMonitor progressMonitor, String... filePaths) {
                 progressMonitor.setCanceled(true);
-                return Collections.nCopies(2, (BugInfo) null);
+                return new SpotBugsAnalysisResult(Collections.nCopies(2, (BugInfo) null), Collections.emptyList());
             }
         });
 
@@ -72,7 +73,7 @@ public class AnalysisPipelineTest {
     public void runReturnsCancelledForCancellationExceptions() throws Exception {
         AnalysisPipeline pipeline = new AnalysisPipeline(() -> new AnalyzerService() {
             @Override
-            public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths) {
+            public SpotBugsAnalysisResult analyzeToBugsWithWarnings(IProgressMonitor monitor, String... filePaths) {
                 throw new CancellationException("stop");
             }
         });
@@ -87,7 +88,7 @@ public class AnalysisPipelineTest {
     public void runReturnsCancelledForInterruptedExceptionsAndRestoresInterruptStatus() throws Exception {
         AnalysisPipeline pipeline = new AnalysisPipeline(() -> new AnalyzerService() {
             @Override
-            public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths)
+            public SpotBugsAnalysisResult analyzeToBugsWithWarnings(IProgressMonitor monitor, String... filePaths)
                     throws IOException, InterruptedException {
                 throw new InterruptedException("stop");
             }
@@ -113,7 +114,7 @@ public class AnalysisPipelineTest {
         IOException failure = new IOException("analysis boom");
         AnalysisPipeline pipeline = new AnalysisPipeline(() -> new AnalyzerService() {
             @Override
-            public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths)
+            public SpotBugsAnalysisResult analyzeToBugsWithWarnings(IProgressMonitor monitor, String... filePaths)
                     throws IOException, InterruptedException {
                 throw failure;
             }
@@ -124,6 +125,7 @@ public class AnalysisPipelineTest {
         assertEquals(AnalysisPipelineResult.Status.FAILED, result.getStatus());
         assertSame(failure, result.getFailure());
         assertEquals(0, result.getResults().size());
+        assertEquals(0, result.getWarnings().size());
         assertEquals(0, result.getFindingCount());
     }
 
@@ -148,12 +150,12 @@ public class AnalysisPipelineTest {
     }
 
     private static final class CapturingAnalyzerService extends AnalyzerService {
-        private final List<BugInfo> result;
+        private final List<BugInfo> bugs;
         private AnalysisConfig config;
         private String targetPath;
 
-        private CapturingAnalyzerService(List<BugInfo> result) {
-            this.result = result;
+        private CapturingAnalyzerService(List<BugInfo> bugs) {
+            this.bugs = bugs;
         }
 
         @Override
@@ -162,9 +164,9 @@ public class AnalysisPipelineTest {
         }
 
         @Override
-        public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths) {
+        public SpotBugsAnalysisResult analyzeToBugsWithWarnings(IProgressMonitor monitor, String... filePaths) {
             this.targetPath = filePaths != null && filePaths.length > 0 ? filePaths[0] : null;
-            return result;
+            return bugs != null ? new SpotBugsAnalysisResult(bugs, Collections.emptyList()) : null;
         }
     }
 }

--- a/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisActionTest.java
+++ b/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisActionTest.java
@@ -17,59 +17,48 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.spotbugs.vscode.runner.api.BugInfo;
+import com.spotbugs.vscode.runner.api.CommandWarning;
 import com.spotbugs.vscode.runner.api.CommandResponse;
 import com.spotbugs.vscode.runner.api.RunAnalysisSummary;
 import com.spotbugs.vscode.runner.internal.AnalyzerService;
+import com.spotbugs.vscode.runner.internal.SpotBugsAnalysisResult;
 
 public class RunAnalysisActionTest {
 
     @Test
     public void executeWrapsAnalyzerFailuresWithRootCauseAsAnalysisFailedEnvelope() throws Exception {
-        JsonObject expected = AnalysisProtocolFixture.readJsonObject("run-analysis-response-error-with-stats.json");
         RunAnalysisAction action = new RunAnalysisAction(() -> new AnalyzerService() {
             @Override
-            public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths) {
+            public SpotBugsAnalysisResult analyzeToBugsWithWarnings(IProgressMonitor monitor, String... filePaths) {
                 throw new RuntimeException("outer", new IllegalStateException("inner"));
             }
         });
 
         JsonObject response = executeDefault(action);
-        JsonObject expectedError = expected.getAsJsonArray("errors").get(0).getAsJsonObject();
-        JsonObject expectedStats = expected.getAsJsonObject("stats");
         JsonObject stats = response.getAsJsonObject("stats");
 
-        assertEquals(expected.get("schemaVersion").getAsInt(), response.get("schemaVersion").getAsInt());
-        assertEquals(expected.getAsJsonArray("results").size(), response.getAsJsonArray("results").size());
-        assertEquals(expectedError.get("code").getAsString(), firstError(response).get("code").getAsString());
-        assertEquals(expectedError.get("message").getAsString(), firstError(response).get("message").getAsString());
-        assertEquals(expectedStats.keySet(), stats.keySet());
-        assertEquals(expectedStats.get("target").getAsString(), stats.get("target").getAsString());
-        assertTrue(stats.get("durationMs").getAsLong() >= expectedStats.get("durationMs").getAsLong());
-        assertEquals(expectedStats.get("findingCount").getAsInt(), stats.get("findingCount").getAsInt());
+        assertEquals(2, response.get("schemaVersion").getAsInt());
+        assertEquals(0, response.getAsJsonArray("results").size());
+        assertEquals("ANALYSIS_FAILED", firstError(response).get("code").getAsString());
+        assertEquals("inner", firstError(response).get("message").getAsString());
+        assertEquals("/workspace/build/classes", stats.get("target").getAsString());
+        assertTrue(stats.get("durationMs").getAsLong() >= 0L);
+        assertEquals(0, stats.get("findingCount").getAsInt());
         assertTrue(stats.get("spotbugsVersion").getAsString().length() > 0);
-        assertEquals(
-                expectedStats.get("targetResolutionRootCount").getAsInt(),
-                stats.get("targetResolutionRootCount").getAsInt()
-        );
-        assertEquals(
-                expectedStats.get("runtimeClasspathCount").getAsInt(),
-                stats.get("runtimeClasspathCount").getAsInt()
-        );
-        assertEquals(
-                expectedStats.get("extraAuxClasspathCount").getAsInt(),
-                stats.get("extraAuxClasspathCount").getAsInt()
-        );
-        assertEquals(expectedStats.get("auxClasspathCount").getAsInt(), stats.get("auxClasspathCount").getAsInt());
-        assertEquals(expectedStats.get("targetCount").getAsInt(), stats.get("targetCount").getAsInt());
-        assertEquals(expectedStats.get("pluginCount").getAsInt(), stats.get("pluginCount").getAsInt());
+        assertEquals(0, stats.get("targetResolutionRootCount").getAsInt());
+        assertEquals(0, stats.get("runtimeClasspathCount").getAsInt());
+        assertEquals(0, stats.get("extraAuxClasspathCount").getAsInt());
+        assertEquals(0, stats.get("auxClasspathCount").getAsInt());
+        assertEquals(0, stats.get("targetCount").getAsInt());
+        assertEquals(0, stats.get("pluginCount").getAsInt());
     }
 
     @Test
     public void executeReportsNonzeroFindingCountFromResults() {
         RunAnalysisAction action = new RunAnalysisAction(() -> new AnalyzerService() {
             @Override
-            public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths) {
-                return Collections.nCopies(2, (BugInfo) null);
+            public SpotBugsAnalysisResult analyzeToBugsWithWarnings(IProgressMonitor monitor, String... filePaths) {
+                return result(Collections.nCopies(2, (BugInfo) null));
             }
         });
 
@@ -79,6 +68,33 @@ public class RunAnalysisActionTest {
         assertEquals(0, response.getAsJsonArray("errors").size());
         assertEquals(2, response.getAsJsonArray("results").size());
         assertEquals(2, response.getAsJsonObject("stats").get("findingCount").getAsInt());
+    }
+
+    @Test
+    public void executeSerializesWarningsFromSuccessfulAnalysis() {
+        RunAnalysisAction action = new RunAnalysisAction(() -> new AnalyzerService() {
+            @Override
+            public SpotBugsAnalysisResult analyzeToBugsWithWarnings(IProgressMonitor monitor, String... filePaths) {
+                return new SpotBugsAnalysisResult(
+                        Collections.emptyList(),
+                        Collections.singletonList(new CommandWarning(
+                                "PLUGIN_CLEANUP_CLOSE_FAILED",
+                                "Failed to close plugin com.example: close failed"
+                        ))
+                );
+            }
+        });
+
+        JsonObject response = executeDefault(action);
+
+        assertEquals(2, response.get("schemaVersion").getAsInt());
+        assertEquals(0, response.getAsJsonArray("results").size());
+        assertEquals(0, response.getAsJsonArray("errors").size());
+        assertTrue(response.has("warnings"));
+        assertEquals(1, response.getAsJsonArray("warnings").size());
+        JsonObject warning = response.getAsJsonArray("warnings").get(0).getAsJsonObject();
+        assertEquals("PLUGIN_CLEANUP_CLOSE_FAILED", warning.get("code").getAsString());
+        assertEquals("Failed to close plugin com.example: close failed", warning.get("message").getAsString());
     }
 
     @Test
@@ -125,9 +141,9 @@ public class RunAnalysisActionTest {
         NullProgressMonitor monitor = new NullProgressMonitor();
         RunAnalysisAction action = new RunAnalysisAction(() -> new AnalyzerService() {
             @Override
-            public List<BugInfo> analyzeToBugs(IProgressMonitor progressMonitor, String... filePaths) {
+            public SpotBugsAnalysisResult analyzeToBugsWithWarnings(IProgressMonitor progressMonitor, String... filePaths) {
                 progressMonitor.setCanceled(true);
-                return Collections.emptyList();
+                return SpotBugsAnalysisResult.empty();
             }
         });
 
@@ -187,6 +203,7 @@ public class RunAnalysisActionTest {
         JsonObject stats = json.getAsJsonObject("stats");
 
         assertSame(summary, response.getStats());
+        assertFalse(json.has("warnings"));
         assertEquals("/workspace/build/classes", stats.get("target").getAsString());
         assertEquals(42L, stats.get("durationMs").getAsLong());
         assertEquals(3, stats.get("findingCount").getAsInt());
@@ -229,16 +246,20 @@ public class RunAnalysisActionTest {
     private static AnalyzerService emptyAnalyzer() {
         return new AnalyzerService() {
             @Override
-            public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths) {
-                return Collections.emptyList();
+            public SpotBugsAnalysisResult analyzeToBugsWithWarnings(IProgressMonitor monitor, String... filePaths) {
+                return SpotBugsAnalysisResult.empty();
             }
         };
     }
 
+    private static SpotBugsAnalysisResult result(List<BugInfo> bugs) {
+        return new SpotBugsAnalysisResult(bugs, Collections.emptyList());
+    }
+
     private static final class CountingAnalyzerService extends AnalyzerService {
         @Override
-        public List<BugInfo> analyzeToBugs(IProgressMonitor monitor, String... filePaths) {
-            return Collections.emptyList();
+        public SpotBugsAnalysisResult analyzeToBugsWithWarnings(IProgressMonitor monitor, String... filePaths) {
+            return SpotBugsAnalysisResult.empty();
         }
 
         @Override

--- a/src/lsp/spotbugsParser.ts
+++ b/src/lsp/spotbugsParser.ts
@@ -1,4 +1,8 @@
-import { AnalysisError, AnalysisStats } from '../model/analysisProtocol';
+import {
+  AnalysisError,
+  AnalysisStats,
+  AnalysisWarning,
+} from '../model/analysisProtocol';
 import { Bug } from '../model/bug';
 
 export type ParseErrorKind = 'invalid-json' | 'analysis-error';
@@ -12,6 +16,8 @@ export interface ParseError {
 export interface ParsedAnalysis {
   bugs: Bug[];
   errors?: AnalysisError[];
+  warnings?: AnalysisWarning[];
+  ignoredMalformedWarnings?: boolean;
   stats?: AnalysisStats;
   schemaVersion?: number;
 }
@@ -55,6 +61,7 @@ export function parseAnalysisResponse(raw: string): ParseResult {
     const envelope = parsed as Record<string, unknown>;
     const hasResults = Object.prototype.hasOwnProperty.call(envelope, 'results');
     const hasErrors = Object.prototype.hasOwnProperty.call(envelope, 'errors');
+    const hasWarnings = Object.prototype.hasOwnProperty.call(envelope, 'warnings');
     if (!hasResults && !hasErrors) {
       return invalidResponse();
     }
@@ -70,6 +77,12 @@ export function parseAnalysisResponse(raw: string): ParseResult {
       return invalidResponse();
     }
 
+    const warnings =
+      hasWarnings && Array.isArray(envelope.warnings)
+        ? normalizeAnalysisWarnings(envelope.warnings)
+        : undefined;
+    const ignoredMalformedWarnings =
+      hasWarnings && !Array.isArray(envelope.warnings) ? true : undefined;
     const bugs = hasResults ? (envelope.results as Bug[]) : [];
     const stats = normalizeAnalysisStats(envelope.stats);
     const schemaVersion =
@@ -79,6 +92,8 @@ export function parseAnalysisResponse(raw: string): ParseResult {
       value: {
         bugs,
         errors,
+        warnings,
+        ignoredMalformedWarnings,
         stats,
         schemaVersion,
       },
@@ -125,6 +140,12 @@ function normalizeAnalysisErrors(value: unknown): AnalysisError[] {
     }
   }
   return errors;
+}
+
+function normalizeAnalysisWarnings(value: unknown[]): AnalysisWarning[] {
+  return normalizeAnalysisErrors(value).filter(
+    (warning) => typeof warning.code === 'string' && typeof warning.message === 'string'
+  );
 }
 
 function normalizeAnalysisStats(value: unknown): AnalysisStats | undefined {

--- a/src/model/analysisErrors.ts
+++ b/src/model/analysisErrors.ts
@@ -1,10 +1,12 @@
 import { AnalysisError } from './analysisProtocol';
 
-export function formatAnalysisErrors(errors: AnalysisError[]): string {
-  const messages = errors.map((err) => {
-    const code = err.code ? `[${err.code}]` : '';
-    const message = err.message || 'Unknown error';
+export function formatAnalysisErrors(
+  errors: Pick<AnalysisError, 'code' | 'message'>[]
+): string {
+  const formatted = errors.map((messageInfo) => {
+    const code = messageInfo.code ? `[${messageInfo.code}]` : '';
+    const message = messageInfo.message || 'Unknown error';
     return `${code} ${message}`.trim();
   });
-  return messages.join('; ');
+  return formatted.join('; ');
 }

--- a/src/model/analysisOutcome.ts
+++ b/src/model/analysisOutcome.ts
@@ -1,5 +1,5 @@
 import { Finding } from './finding';
-import { AnalysisError, AnalysisStats } from './analysisProtocol';
+import { AnalysisError, AnalysisStats, AnalysisWarning } from './analysisProtocol';
 
 export type AnalysisNoticeLevel = 'info' | 'warn' | 'error';
 
@@ -21,6 +21,7 @@ export interface AnalysisFailure {
 export interface AnalysisOutcome {
   findings: Finding[];
   errors?: AnalysisError[];
+  warnings?: AnalysisWarning[];
   stats?: AnalysisStats;
   targetPath?: string;
   schemaVersion?: number;

--- a/src/model/analysisProtocol.ts
+++ b/src/model/analysisProtocol.ts
@@ -28,6 +28,8 @@ export interface AnalysisError {
   message?: string;
 }
 
+export type AnalysisWarning = AnalysisError;
+
 export interface AnalysisStats {
   target?: string;
   durationMs?: number;
@@ -45,5 +47,6 @@ export interface AnalysisResponse<TBug = Bug> {
   schemaVersion?: number;
   results?: TBug[];
   errors?: AnalysisError[];
+  warnings?: AnalysisWarning[];
   stats?: AnalysisStats;
 }

--- a/src/orchestration/analysisNotices.ts
+++ b/src/orchestration/analysisNotices.ts
@@ -43,6 +43,19 @@ export function buildAnalysisNotices(
     }
   }
 
+  if (
+    !hasTerminalFailure &&
+    Array.isArray(outcome.warnings) &&
+    outcome.warnings.length > 0
+  ) {
+    notices.push({
+      level: 'warn',
+      message: `SpotBugs analysis completed with cleanup warnings: ${formatAnalysisErrors(
+        outcome.warnings
+      )}`,
+    });
+  }
+
   notices.push(
     ...buildResolutionIssueNotices(options.resolutionIssues ?? [], {
       terminal: hasTerminalFailure,

--- a/src/orchestration/analysisRunSession.ts
+++ b/src/orchestration/analysisRunSession.ts
@@ -7,6 +7,7 @@ import type { DiagnosticUpdateScope } from '../model/diagnosticScope';
 import type { Finding } from '../model/finding';
 import type {
   AnalysisExecutionResult,
+  ProjectCleanupWarning,
   WorkspaceExecutionResult,
 } from '../services/analysisService';
 import type { ProjectResult } from '../services/projectResult';
@@ -147,6 +148,7 @@ export async function runWorkspaceAnalysisSession(
     let aggregated: Finding[] = [];
     let projectResults: ProjectResult[] = [];
     let resolutionIssues: AnalysisResolutionIssue[] = [];
+    let cleanupWarnings: ProjectCleanupWarning[] = [];
     let cancelled = false;
 
     await args.runWithProgress(async (progress, token) => {
@@ -189,6 +191,7 @@ export async function runWorkspaceAnalysisSession(
       projectResults = res.results;
       aggregated = res.results.flatMap((result) => result.findings);
       resolutionIssues = [...discovery.issues, ...res.context.resolutionIssues];
+      cleanupWarnings = res.context.cleanupWarnings ?? [];
       cancelled =
         res.cancelled === true ||
         token.isCancellationRequested ||
@@ -207,7 +210,12 @@ export async function runWorkspaceAnalysisSession(
 
     emitNotices(
       args.notifier,
-      buildWorkspaceCompletionNotices(projectResults, aggregated.length, resolutionIssues)
+      buildWorkspaceCompletionNotices(
+        projectResults,
+        aggregated.length,
+        resolutionIssues,
+        cleanupWarnings
+      )
     );
   } catch (error) {
     renderWorkspaceAnalysisFailure(args, error);

--- a/src/orchestration/workspaceSummary.ts
+++ b/src/orchestration/workspaceSummary.ts
@@ -2,12 +2,14 @@ import type { AnalysisNotice } from '../model/analysisOutcome';
 import type { AnalysisResolutionIssue } from '../lsp/javaLsOutcome';
 import { buildResolutionIssueNotices } from './analysisNotices';
 import type { ProjectResult } from '../services/projectResult';
+import type { ProjectCleanupWarning } from '../services/analysisService';
 import { NO_CLASS_TARGETS_CODE } from '../workspace/analysisTargetCodes';
 
 export function buildWorkspaceCompletionNotices(
   projectResults: ProjectResult[],
   findingCount: number,
-  resolutionIssues: AnalysisResolutionIssue[] = []
+  resolutionIssues: AnalysisResolutionIssue[] = [],
+  cleanupWarnings: ProjectCleanupWarning[] = []
 ): AnalysisNotice[] {
   const skippedCount = projectResults.filter(
     (result) => result.errorCode === NO_CLASS_TARGETS_CODE
@@ -19,13 +21,16 @@ export function buildWorkspaceCompletionNotices(
   const hasTerminalFailure =
     (projectResults.length > 0 && skippedCount === projectResults.length) ||
     (failedCount > 0 && succeededCount === 0);
+  const cleanupWarningSentence = buildCleanupWarningSentence(cleanupWarnings);
   const notices: AnalysisNotice[] = [];
 
   if (projectResults.length > 0 && skippedCount === projectResults.length) {
     notices.push(
       {
         level: 'warn',
-        message: 'SpotBugs could not build the project. Run a manual build, then try again.',
+        message:
+          'SpotBugs could not build the project. Run a manual build, then try again.' +
+          cleanupWarningSentence,
       }
     );
   } else if (failedCount > 0) {
@@ -40,7 +45,8 @@ export function buildWorkspaceCompletionNotices(
           level: 'error',
           message:
             `SpotBugs: Workspace analysis failed - ${formatProjectCount(failedCount)} failed.` +
-            `${skippedSentence} See the SpotBugs view for project errors.`,
+            `${skippedSentence} See the SpotBugs view for project errors.` +
+            cleanupWarningSentence,
         }
       );
     } else {
@@ -54,7 +60,7 @@ export function buildWorkspaceCompletionNotices(
         message:
           `SpotBugs: Workspace analysis completed with failures - ${formatProjectCount(
             failedCount
-          )} failed.` + `${skippedSentence} ${successSummary}`,
+          )} failed.` + `${skippedSentence} ${successSummary}` + cleanupWarningSentence,
       });
     }
   } else {
@@ -63,16 +69,18 @@ export function buildWorkspaceCompletionNotices(
         level: 'warn',
         message:
           `SpotBugs skipped ${formatProjectCount(skippedCount)} because the build failed. ` +
-          'Run a manual build, then try again.',
+          'Run a manual build, then try again.' +
+          cleanupWarningSentence,
       });
     }
 
     notices.push({
-      level: 'info',
+      level: cleanupWarningSentence.length > 0 && skippedCount === 0 ? 'warn' : 'info',
       message:
-        findingCount === 0
+        (findingCount === 0
           ? 'SpotBugs: Workspace analysis completed - No issues found.'
-          : `SpotBugs: Workspace analysis completed - ${formatIssueCount(findingCount)} found.`,
+          : `SpotBugs: Workspace analysis completed - ${formatIssueCount(findingCount)} found.`) +
+        (skippedCount === 0 ? cleanupWarningSentence : ''),
     });
   }
 
@@ -90,6 +98,18 @@ function formatProjectCount(count: number): string {
 
 function formatIssueCount(count: number): string {
   return `${count} issue${count === 1 ? '' : 's'}`;
+}
+
+function buildCleanupWarningSentence(
+  cleanupWarnings: ProjectCleanupWarning[]
+): string {
+  const uniqueProjectCount = new Set(
+    cleanupWarnings.map((warning) => warning.projectUri)
+  ).size;
+  if (uniqueProjectCount === 0) {
+    return '';
+  }
+  return ` Cleanup warnings occurred in ${formatProjectCount(uniqueProjectCount)}; see the SpotBugs output for details.`;
 }
 
 function dedupeNotices(notices: AnalysisNotice[]): AnalysisNotice[] {

--- a/src/services/analysisExecution.ts
+++ b/src/services/analysisExecution.ts
@@ -216,7 +216,14 @@ export function createAnalysisExecutor(overrides: Partial<AnalysisExecutorDeps> 
     context: AnalysisExecutionTarget
   ): Promise<AnalysisOutcome> {
     const targetPath = context.targetPath;
-    const { bugs, errors, stats, schemaVersion } = parsed;
+    const { bugs, errors, warnings, ignoredMalformedWarnings, stats, schemaVersion } =
+      parsed;
+    const hasErrors = Array.isArray(errors) && errors.length > 0;
+    const hasTerminalErrors = hasErrors && bugs.length === 0;
+    const reportableWarnings =
+      !hasTerminalErrors && Array.isArray(warnings) && warnings.length > 0
+        ? warnings
+        : undefined;
 
     if (
       typeof schemaVersion === 'number' &&
@@ -224,7 +231,17 @@ export function createAnalysisExecutor(overrides: Partial<AnalysisExecutorDeps> 
     ) {
       deps.logger.log(`Unexpected analysis response schemaVersion=${schemaVersion}`);
     }
-    if (Array.isArray(errors) && errors.length > 0) {
+    if (ignoredMalformedWarnings && !hasTerminalErrors) {
+      deps.logger.log(
+        'SpotBugs analysis warning: Ignored malformed warnings field in analysis response.'
+      );
+    }
+    if (reportableWarnings) {
+      deps.logger.log(
+        `SpotBugs analysis warning: ${formatAnalysisErrors(reportableWarnings)}`
+      );
+    }
+    if (hasErrors) {
       const combined = formatAnalysisErrors(errors);
       deps.logger.error(`SpotBugs analysis error: ${combined}`);
       const hasResults = bugs.length > 0;
@@ -260,6 +277,9 @@ export function createAnalysisExecutor(overrides: Partial<AnalysisExecutorDeps> 
     };
     if (Array.isArray(errors) && errors.length > 0) {
       outcome.errors = errors;
+    }
+    if (reportableWarnings) {
+      outcome.warnings = reportableWarnings;
     }
     return outcome;
   }

--- a/src/services/analysisService.ts
+++ b/src/services/analysisService.ts
@@ -3,6 +3,7 @@ import { Logger } from '../core/logger';
 import { Config } from '../core/config';
 import type { AnalysisResolutionIssue } from '../lsp/javaLsOutcome';
 import { AnalysisOutcome } from '../model/analysisOutcome';
+import type { AnalysisWarning } from '../model/analysisProtocol';
 import type { DiagnosticUpdateScope } from '../model/diagnosticScope';
 import { ProjectRef } from '../workspace/classpathService';
 import type { ProjectResult } from './projectResult';
@@ -31,8 +32,14 @@ export interface WorkspaceResult {
   cancelled?: boolean;
 }
 
+export interface ProjectCleanupWarning {
+  projectUri: string;
+  warning: AnalysisWarning;
+}
+
 export interface AnalysisExecutionContext {
   resolutionIssues: AnalysisResolutionIssue[];
+  cleanupWarnings?: ProjectCleanupWarning[];
   diagnosticScope?: DiagnosticUpdateScope;
 }
 
@@ -154,6 +161,7 @@ export async function analyzeWorkspaceFromProjectsDetailed(
     );
     results.push(result.projectResult);
     context.resolutionIssues.push(...result.context.resolutionIssues);
+    context.cleanupWarnings?.push(...(result.context.cleanupWarnings ?? []));
 
     if (isAnalysisCancelledProjectResult(result.projectResult)) {
       Logger.log('Workspace analysis cancelled by backend.');
@@ -235,6 +243,14 @@ async function analyzeProjectDetailed(
 
     try {
       const outcome = await runAnalysis(config, result.resolution.target);
+      if (Array.isArray(outcome.warnings)) {
+        context.cleanupWarnings?.push(
+          ...outcome.warnings.map((warning) => ({
+            projectUri: projectUriString,
+            warning,
+          }))
+        );
+      }
       return {
         projectResult: projectResultFromOutcome(projectUriString, outcome),
         context,
@@ -293,5 +309,6 @@ function normalizeProjectRef(project: ProjectRef): Uri {
 function createExecutionContext(): AnalysisExecutionContext {
   return {
     resolutionIssues: [],
+    cleanupWarnings: [],
   };
 }

--- a/src/test/L0.analysisExecution.test.ts
+++ b/src/test/L0.analysisExecution.test.ts
@@ -350,6 +350,45 @@ describe('analysisExecution', () => {
     );
   });
 
+  it('does not expose cleanup warnings on terminal backend errors', async () => {
+    const { createAnalysisExecutor } = loadAnalysisExecution();
+    const logMessages: string[] = [];
+    const executor = createAnalysisExecutor(
+      makeDeps({
+        parseAnalysisResponse: () => ({
+          ok: true,
+          value: {
+            bugs: [],
+            errors: [{ code: 'ANALYSIS_FAILED', message: 'boom' }],
+            warnings: [
+              {
+                code: 'PLUGIN_CLEANUP_FAILED',
+                message: 'Could not delete plugin',
+              },
+            ],
+          },
+        }),
+        logger: {
+          log: (message) => logMessages.push(String(message)),
+          error: () => undefined,
+        },
+      })
+    );
+
+    const outcome = await executor.run(
+      makeConfig(),
+      makeTarget(installVscodeMock())
+    );
+
+    assert.deepStrictEqual(outcome.findings, []);
+    assert.strictEqual(outcome.warnings, undefined);
+    assert.ok(
+      !logMessages.includes(
+        'SpotBugs analysis warning: [PLUGIN_CLEANUP_FAILED] Could not delete plugin'
+      )
+    );
+  });
+
   it('returns partial-success findings with backend errors and enriched paths', async () => {
     const vscode = installVscodeMock();
     const { createAnalysisExecutor } = loadAnalysisExecution();
@@ -397,4 +436,40 @@ describe('analysisExecution', () => {
     assert.strictEqual(outcome.stats?.durationMs, 12);
     assert.strictEqual(outcome.schemaVersion, 2);
   });
+
+  it('returns successful empty findings with backend warnings', async () => {
+    const { createAnalysisExecutor } = loadAnalysisExecution();
+    const executor = createAnalysisExecutor(
+      makeDeps({
+        parseAnalysisResponse: () => ({
+          ok: true,
+          value: {
+            bugs: [],
+            warnings: [
+              {
+                code: 'PLUGIN_CLEANUP_FAILED',
+                message: 'Could not delete plugin',
+              },
+            ],
+            schemaVersion: 2,
+          },
+        }),
+      })
+    );
+
+    const outcome = await executor.run(
+      makeConfig(),
+      makeTarget(installVscodeMock())
+    );
+
+    assert.deepStrictEqual(outcome.findings, []);
+    assert.strictEqual(outcome.failure, undefined);
+    assert.deepStrictEqual(outcome.warnings, [
+      {
+        code: 'PLUGIN_CLEANUP_FAILED',
+        message: 'Could not delete plugin',
+      },
+    ]);
+  });
+
 });

--- a/src/test/L0.analysisExecution.test.ts
+++ b/src/test/L0.analysisExecution.test.ts
@@ -323,6 +323,12 @@ describe('analysisExecution', () => {
           value: {
             bugs: [],
             errors: [{ code: 'ANALYSIS_FAILED', message: 'boom' }],
+            warnings: [
+              {
+                code: 'PLUGIN_CLEANUP_FAILED',
+                message: 'Could not delete plugin',
+              },
+            ],
             stats: {
               target: '/workspace/build/classes',
               durationMs: 9,
@@ -341,51 +347,13 @@ describe('analysisExecution', () => {
 
     assert.deepStrictEqual(outcome.findings, []);
     assert.strictEqual(outcome.errors?.[0]?.code, 'ANALYSIS_FAILED');
+    assert.strictEqual(outcome.warnings, undefined);
     assert.strictEqual(outcome.stats?.target, '/workspace/build/classes');
     assert.strictEqual(outcome.schemaVersion, 2);
     assert.strictEqual(outcome.failure?.code, 'ANALYSIS_FAILED');
     assert.strictEqual(
       outcome.failure?.message,
       'SpotBugs analysis failed: [ANALYSIS_FAILED] boom'
-    );
-  });
-
-  it('does not expose cleanup warnings on terminal backend errors', async () => {
-    const { createAnalysisExecutor } = loadAnalysisExecution();
-    const logMessages: string[] = [];
-    const executor = createAnalysisExecutor(
-      makeDeps({
-        parseAnalysisResponse: () => ({
-          ok: true,
-          value: {
-            bugs: [],
-            errors: [{ code: 'ANALYSIS_FAILED', message: 'boom' }],
-            warnings: [
-              {
-                code: 'PLUGIN_CLEANUP_FAILED',
-                message: 'Could not delete plugin',
-              },
-            ],
-          },
-        }),
-        logger: {
-          log: (message) => logMessages.push(String(message)),
-          error: () => undefined,
-        },
-      })
-    );
-
-    const outcome = await executor.run(
-      makeConfig(),
-      makeTarget(installVscodeMock())
-    );
-
-    assert.deepStrictEqual(outcome.findings, []);
-    assert.strictEqual(outcome.warnings, undefined);
-    assert.ok(
-      !logMessages.includes(
-        'SpotBugs analysis warning: [PLUGIN_CLEANUP_FAILED] Could not delete plugin'
-      )
     );
   });
 
@@ -435,41 +403,6 @@ describe('analysisExecution', () => {
     assert.strictEqual(outcome.failure, undefined);
     assert.strictEqual(outcome.stats?.durationMs, 12);
     assert.strictEqual(outcome.schemaVersion, 2);
-  });
-
-  it('returns successful empty findings with backend warnings', async () => {
-    const { createAnalysisExecutor } = loadAnalysisExecution();
-    const executor = createAnalysisExecutor(
-      makeDeps({
-        parseAnalysisResponse: () => ({
-          ok: true,
-          value: {
-            bugs: [],
-            warnings: [
-              {
-                code: 'PLUGIN_CLEANUP_FAILED',
-                message: 'Could not delete plugin',
-              },
-            ],
-            schemaVersion: 2,
-          },
-        }),
-      })
-    );
-
-    const outcome = await executor.run(
-      makeConfig(),
-      makeTarget(installVscodeMock())
-    );
-
-    assert.deepStrictEqual(outcome.findings, []);
-    assert.strictEqual(outcome.failure, undefined);
-    assert.deepStrictEqual(outcome.warnings, [
-      {
-        code: 'PLUGIN_CLEANUP_FAILED',
-        message: 'Could not delete plugin',
-      },
-    ]);
   });
 
 });

--- a/src/test/L0.analysisNotices.test.ts
+++ b/src/test/L0.analysisNotices.test.ts
@@ -318,6 +318,34 @@ describe('analysisNotices', () => {
     ]);
   });
 
+  it('emits cleanup warning notices without converting zero-finding outcomes into failures', () => {
+    const notices = buildAnalysisNotices(
+      {
+        findings: [],
+        warnings: [
+          {
+            code: 'PLUGIN_CLEANUP_FAILED',
+            message: 'Could not delete plugin jar',
+          },
+        ],
+      }
+    );
+
+    assert.ok(
+      notices.some(
+        (notice) =>
+          notice.level === 'warn' &&
+          notice.message ===
+            'SpotBugs analysis completed with cleanup warnings: [PLUGIN_CLEANUP_FAILED] Could not delete plugin jar'
+      )
+    );
+    assert.ok(
+      notices.every(
+        (notice) => !notice.message.startsWith('SpotBugs analysis failed:')
+      )
+    );
+  });
+
   it('still surfaces JAVA_LS_REQUEST_FAILED on non-terminal analysis outcomes', () => {
     const notices = buildAnalysisNotices(
       {

--- a/src/test/L0.analysisRunSession.test.ts
+++ b/src/test/L0.analysisRunSession.test.ts
@@ -183,6 +183,60 @@ describe('analysisRunSession file analysis', () => {
     ]);
   });
 
+  it('renders warning-only file outcomes as successful empty results', async () => {
+    const vscode = installVscodeMock();
+    const uri = vscode.Uri.file('/workspace/src/Foo.java') as unknown as Uri;
+    const calls: string[] = [];
+    const warnings: string[] = [];
+    const errors: string[] = [];
+    const deps = createBaseDependencies(vscode);
+
+    deps.analyzeFileDetailed = async () => ({
+      outcome: {
+        findings: [],
+        targetPath: '/workspace/build/classes',
+        warnings: [
+          {
+            code: 'PLUGIN_CLEANUP_FAILED',
+            message: 'Could not delete plugin jar',
+          },
+        ],
+      },
+      context: {
+        resolutionIssues: [],
+      },
+    });
+
+    await runFileAnalysisSession({
+      config: { getAnalysisSettings: () => ({}) } as any,
+      tree: {
+        showLoading: () => calls.push('loading'),
+        showResults: (findings: Finding[]) => calls.push(`results:${findings.length}`),
+        showAnalysisFailure: (message: string, code?: string) =>
+          calls.push(`failure:${code ?? ''}:${message}`),
+      },
+      diagnostics: {
+        replaceForScope: (_scope, findings: Finding[]) =>
+          calls.push(`diagnostics:${findings.length}`),
+        replaceAll: () => calls.push('replaceAll'),
+      },
+      notifier: {
+        info: () => undefined,
+        warn: (message: string) => warnings.push(message),
+        error: (message: string) => errors.push(message),
+      },
+      uri,
+      startedAtMs: 1000,
+      dependencies: deps,
+    });
+
+    assert.deepStrictEqual(calls, ['loading', 'results:0', 'diagnostics:0']);
+    assert.deepStrictEqual(warnings, [
+      'SpotBugs analysis completed with cleanup warnings: [PLUGIN_CLEANUP_FAILED] Could not delete plugin jar',
+    ]);
+    assert.deepStrictEqual(errors, []);
+  });
+
   it('renders file analysis failures without updating diagnostics', async () => {
     const vscode = installVscodeMock();
     const uri = vscode.Uri.file('/workspace/src/Foo.java') as unknown as Uri;
@@ -397,6 +451,53 @@ describe('analysisRunSession workspace analysis', () => {
     assert.deepStrictEqual(harness.infos, [
       'SpotBugs: Workspace analysis completed - 1 issue found.',
     ]);
+  });
+
+  it('renders warning-only workspace results without adding tree-visible warning state', async () => {
+    const projectResult: ProjectResult = {
+      projectUri: 'file:///workspace/project-a',
+      findings: [],
+    };
+    const harness = createWorkspaceHarness({
+      getWorkspaceProjectDiscovery: async () => ({
+        projectUris: ['file:///workspace/project-a'],
+        issues: [],
+      }),
+      analyzeWorkspaceFromProjectsDetailed: async (_config, _workspace, projectUris, notify) => {
+        notify?.onStart?.(projectUris[0], 1, 1);
+        notify?.onDone?.(projectUris[0], 0);
+        return {
+          results: [projectResult],
+          context: {
+            resolutionIssues: [],
+            cleanupWarnings: [
+              {
+                projectUri: projectUris[0],
+                warning: {
+                  code: 'PLUGIN_CLEANUP_FAILED',
+                  message: 'Could not delete plugin jar',
+                },
+              },
+            ],
+          },
+        };
+      },
+    });
+
+    await runWorkspaceAnalysisSession(harness.args);
+
+    assert.deepStrictEqual(harness.calls, [
+      'progress:1',
+      'status:file:///workspace/project-a:running::',
+      'status:file:///workspace/project-a:done:0:',
+      'workspaceResults:1',
+      'replaceAll:0',
+    ]);
+    assert.deepStrictEqual(harness.workspaceResults, [[projectResult]]);
+    assert.deepStrictEqual(harness.warnings, [
+      'SpotBugs: Workspace analysis completed - No issues found. Cleanup warnings occurred in 1 project; see the SpotBugs output for details.',
+    ]);
+    assert.deepStrictEqual(harness.errors, []);
   });
 
   it('renders workspace results only after the progress callback resolves', async () => {

--- a/src/test/L0.spotbugsParser.test.ts
+++ b/src/test/L0.spotbugsParser.test.ts
@@ -49,6 +49,10 @@ describe('spotbugsParser', () => {
       JSON.stringify({ stats: { durationMs: 1 } }),
       JSON.stringify({ errors: [] }),
       JSON.stringify({ errors: [null, 'bad', {}] }),
+      JSON.stringify({
+        schemaVersion: 2,
+        warnings: [{ code: 'PLUGIN_CLEANUP_FAILED', message: 'Could not delete plugin' }],
+      }),
       JSON.stringify(null),
       JSON.stringify('boom'),
     ];
@@ -80,6 +84,24 @@ describe('spotbugsParser', () => {
       assert.strictEqual(result.value.errors?.[0]?.code, 'X');
       assert.strictEqual(result.value.errors?.[0]?.message, 'warn');
       assert.strictEqual(result.value.stats?.target, '/tmp/Foo');
+    }
+  });
+
+  it('parses empty results with warnings as a successful response', () => {
+    const result = parseAnalysisResponse(
+      JSON.stringify({
+        schemaVersion: 2,
+        results: [],
+        warnings: [{ code: 'PLUGIN_CLEANUP_FAILED', message: 'Could not delete plugin' }],
+      })
+    );
+
+    assert.strictEqual(result.ok, true);
+    if (result.ok) {
+      assert.deepStrictEqual(result.value.bugs, []);
+      assert.deepStrictEqual(result.value.warnings, [
+        { code: 'PLUGIN_CLEANUP_FAILED', message: 'Could not delete plugin' },
+      ]);
     }
   });
 

--- a/src/test/L0.workspaceSummary.test.ts
+++ b/src/test/L0.workspaceSummary.test.ts
@@ -131,6 +131,31 @@ describe('workspaceSummary', () => {
     ]);
   });
 
+  it('returns a warning completion notice when cleanup warnings are the only non-success condition', () => {
+    const notices = buildWorkspaceCompletionNotices(
+      [makeProjectResult()],
+      0,
+      [],
+      [
+        {
+          projectUri: 'file:///workspace/project-a',
+          warning: {
+            code: 'PLUGIN_CLEANUP_FAILED',
+            message: 'Could not delete plugin jar',
+          },
+        },
+      ]
+    );
+
+    assert.deepStrictEqual(notices, [
+      {
+        level: 'warn',
+        message:
+          'SpotBugs: Workspace analysis completed - No issues found. Cleanup warnings occurred in 1 project; see the SpotBugs output for details.',
+      },
+    ]);
+  });
+
   it('appends translated resolution notices while suppressing generic workspace fallback notices', () => {
     const notices = buildWorkspaceCompletionNotices([makeProjectResult()], 0, [
       {

--- a/src/test/L1.analysisService.test.ts
+++ b/src/test/L1.analysisService.test.ts
@@ -134,6 +134,66 @@ describe('analysisService', () => {
     assert.strictEqual(legacy.results.length, 2);
   });
 
+  it('aggregates backend cleanup warnings in workspace context without adding project result state', async () => {
+    const vscode = installVscodeMock();
+    const resolverModule =
+      require('../workspace/analysisTargetResolver') as typeof import('../workspace/analysisTargetResolver');
+    const spotbugsClient =
+      require('../lsp/spotbugsClient') as typeof import('../lsp/spotbugsClient');
+    const service = require('../services/analysisService') as typeof import('../services/analysisService');
+
+    resolverModule.resolveProjectAnalysisTargetDetailed = (async (projectUri) => ({
+      resolution: {
+        status: 'ok',
+        target: {
+          targetPath: `/workspace/${projectUri.toString().split('/').pop()}/target/classes`,
+          preferredProject: projectUri,
+          targetResolutionRoots: ['/workspace/project/target/classes'],
+          runtimeClasspaths: ['/workspace/project/target/classes'],
+          sourcepaths: ['/workspace/project/src/main/java'],
+        },
+      },
+      issues: [],
+    })) as typeof resolverModule.resolveProjectAnalysisTargetDetailed;
+    spotbugsClient.runSpotBugsAnalysis = (async () =>
+      JSON.stringify({
+        schemaVersion: 2,
+        results: [],
+        warnings: [
+          {
+            code: 'PLUGIN_CLEANUP_FAILED',
+            message: 'Could not delete plugin jar',
+          },
+        ],
+        stats: {
+          target: '/workspace/project-a/target/classes',
+          durationMs: 4,
+        },
+      })) as typeof spotbugsClient.runSpotBugsAnalysis;
+
+    const result = await service.analyzeWorkspaceFromProjectsDetailed(
+      { getAnalysisSettings: () => ({ effort: 'default' }) } as any,
+      vscode.Uri.file('/workspace') as any,
+      ['file:///workspace/project-a']
+    );
+
+    assert.deepStrictEqual(result.context.cleanupWarnings, [
+      {
+        projectUri: 'file:///workspace/project-a',
+        warning: {
+          code: 'PLUGIN_CLEANUP_FAILED',
+          message: 'Could not delete plugin jar',
+        },
+      },
+    ]);
+    assert.deepStrictEqual(result.results, [
+      {
+        projectUri: 'file:///workspace/project-a',
+        findings: [],
+      },
+    ]);
+  });
+
   it('preserves file resolution issues when analysis execution throws after target resolution', async () => {
     const vscode = installVscodeMock();
     const resolverModule =


### PR DESCRIPTION
## Summary

- Return plugin cleanup failures as non-terminal analysis warnings.
- Preserve successful findings while surfacing warnings in the UI.