### PR TITLE
fix: reject unsafe source paths before file access

### DIFF
--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/api/BugInfo.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/api/BugInfo.java
@@ -1,5 +1,7 @@
 package com.spotbugs.vscode.runner.api;
 
+import com.spotbugs.vscode.runner.internal.SourcePathPolicy;
+
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.ClassAnnotation;
 import edu.umd.cs.findbugs.FieldAnnotation;
@@ -73,12 +75,16 @@ public class BugInfo {
 
         SourceLineAnnotation sla = bugInstance.getPrimarySourceLineAnnotation();
         if (sla != null) {
-            this.sourceFile = safeString(sla.getSourceFile());
+            String safeSourceFile = SourcePathPolicy.sourceFileName(sla.getSourceFile());
+            String safeSourcePath = safeSourceFile == null
+                    ? null
+                    : SourcePathPolicy.relativeSourcePath(sla.getSourcePath());
+            this.sourceFile = safeString(safeSourcePath == null ? null : safeSourceFile);
             int s = sla.getStartLine();
             int e = sla.getEndLine();
             this.startLine = s > 0 ? s : 0;
             this.endLine = e > 0 ? e : this.startLine;
-            this.realSourcePath = safeString(sla.getRealSourcePath());
+            this.realSourcePath = safeString(safeSourcePath);
         } else {
             this.sourceFile = "";
             this.startLine = 0;

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SourcePathPolicy.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SourcePathPolicy.java
@@ -1,0 +1,43 @@
+package com.spotbugs.vscode.runner.internal;
+
+public final class SourcePathPolicy {
+
+    private SourcePathPolicy() {
+    }
+
+    public static String sourceFileName(String value) {
+        if (value == null || value.isEmpty() || ".".equals(value) || "..".equals(value)) {
+            return null;
+        }
+
+        for (int i = 0; i < value.length(); i++) {
+            char character = value.charAt(i);
+            if (character == '/' || character == '\\' || character == ':' || Character.isISOControl(character)) {
+                return null;
+            }
+        }
+
+        return value;
+    }
+
+    public static String relativeSourcePath(String value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+
+        for (int i = 0; i < value.length(); i++) {
+            char character = value.charAt(i);
+            if (character == '\\' || character == ':' || Character.isISOControl(character)) {
+                return null;
+            }
+        }
+
+        for (String segment : value.split("/", -1)) {
+            if (segment.isEmpty() || ".".equals(segment) || "..".equals(segment)) {
+                return null;
+            }
+        }
+
+        return value;
+    }
+}

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SourcePathResolver.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SourcePathResolver.java
@@ -1,6 +1,10 @@
 package com.spotbugs.vscode.runner.internal;
 
 import java.io.File;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -13,13 +17,9 @@ public class SourcePathResolver {
 
     public String resolve(String realSourcePath, List<String> sourcepaths, String targetPath, IProgressMonitor monitor) {
         checkCanceled(monitor);
-        if (realSourcePath == null || realSourcePath.trim().isEmpty()) {
+        String safeRelativePath = SourcePathPolicy.relativeSourcePath(realSourcePath);
+        if (safeRelativePath == null) {
             return null;
-        }
-
-        File realFile = new File(realSourcePath);
-        if (realFile.isAbsolute() && realFile.exists()) {
-            return realFile.getAbsolutePath();
         }
 
         if (sourcepaths != null && !sourcepaths.isEmpty()) {
@@ -28,9 +28,15 @@ public class SourcePathResolver {
                 if (sourceRoot == null || sourceRoot.trim().isEmpty()) {
                     continue;
                 }
-                File candidate = new File(sourceRoot, realSourcePath);
-                if (candidate.exists() && candidate.isFile()) {
-                    return candidate.getAbsolutePath();
+
+                try {
+                    Path normalizedRoot = Paths.get(sourceRoot).toAbsolutePath().normalize();
+                    Path candidate = normalizedRoot.resolve(safeRelativePath).normalize();
+                    if (candidate.startsWith(normalizedRoot) && Files.isRegularFile(candidate)) {
+                        return candidate.toString();
+                    }
+                } catch (InvalidPathException ignored) {
+                    // Ignore malformed configured source roots and try the next one.
                 }
             }
         }
@@ -39,9 +45,9 @@ public class SourcePathResolver {
             File targetFile = new File(targetPath);
             if (targetFile.exists() && targetFile.isFile()) {
                 String normalizedTarget = normalize(targetFile.getPath());
-                String normalizedReal = normalize(realSourcePath);
+                String normalizedReal = normalize(safeRelativePath);
                 if (normalizedTarget.endsWith(normalizedReal) ||
-                    targetFile.getName().equals(new File(realSourcePath).getName())) {
+                    targetFile.getName().equals(new File(safeRelativePath).getName())) {
                     return targetFile.getAbsolutePath();
                 }
             }

--- a/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/SourcePathSecurityTest.java
+++ b/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/SourcePathSecurityTest.java
@@ -1,0 +1,100 @@
+package com.spotbugs.vscode.runner.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.Collections;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.spotbugs.vscode.runner.api.BugInfo;
+
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.Priorities;
+import edu.umd.cs.findbugs.SourceLineAnnotation;
+
+public class SourcePathSecurityTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void bugInfoDropsUnsafeSourceMetadataWithoutDroppingFinding() {
+        for (String sourceFile : new String[] {
+                "\\\\attacker\\share\\Example.java",
+                "\\\\?\\UNC\\attacker\\share\\Example.java",
+                "../Example.java",
+                "/tmp/Example.java",
+                "C:\\tmp\\Example.java"
+        }) {
+            BugInfo info = new BugInfo(bugWithSource("Example", sourceFile));
+
+            assertEquals("ICAST_BAD_SHIFT_AMOUNT", info.getType());
+            assertEquals("", info.getSourceFile());
+            assertEquals("", info.getRealSourcePath());
+        }
+    }
+
+    @Test
+    public void bugInfoPreservesPortableRelativeSourceLocation() {
+        BugInfo info = new BugInfo(bugWithSource("com.acme.Example", "Example.java"));
+
+        assertEquals("Example.java", info.getSourceFile());
+        assertEquals("com/acme/Example.java", info.getRealSourcePath());
+    }
+
+    @Test
+    public void resolverOnlyReadsRelativePathsBelowConfiguredSourceRoot() throws Exception {
+        File workspace = temporaryFolder.newFolder("workspace");
+        File sourceRoot = mkdirs(workspace, "src");
+        File expectedSource = touch(mkdirs(sourceRoot, "com/acme"), "Example.java");
+        File outsideSource = touch(workspace, "Outside.java");
+        SourcePathResolver resolver = new SourcePathResolver();
+
+        assertEquals(
+                expectedSource.getAbsolutePath(),
+                resolver.resolve(
+                        "com/acme/Example.java",
+                        Collections.singletonList(sourceRoot.getAbsolutePath()),
+                        null
+                )
+        );
+        assertNull(resolver.resolve(
+                outsideSource.getAbsolutePath(),
+                Collections.singletonList(sourceRoot.getAbsolutePath()),
+                null
+        ));
+        assertNull(resolver.resolve(
+                "../Outside.java",
+                Collections.singletonList(sourceRoot.getAbsolutePath()),
+                null
+        ));
+        assertNull(resolver.resolve(
+                "\\\\attacker\\share\\Example.java",
+                Collections.singletonList(sourceRoot.getAbsolutePath()),
+                null
+        ));
+    }
+
+    private static BugInstance bugWithSource(String className, String sourceFile) {
+        return new BugInstance("ICAST_BAD_SHIFT_AMOUNT", Priorities.LOW_PRIORITY)
+                .addClass(className)
+                .addSourceLine(new SourceLineAnnotation(className, sourceFile, 1, 1, 0, 0));
+    }
+
+    private static File mkdirs(File parent, String relativePath) {
+        File directory = new File(parent, relativePath);
+        assertTrue(directory.mkdirs());
+        return directory;
+    }
+
+    private static File touch(File parent, String name) throws Exception {
+        File file = new File(parent, name);
+        assertTrue(file.createNewFile());
+        return file;
+    }
+}


### PR DESCRIPTION
## Summary

- Validate source paths against configured source roots before file access.
- Reject unsafe paths while preserving valid source lookup.