### PR TITLE
fix(analysis): propagate workspace cancellation

### DIFF
--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/AnalyzerService.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/AnalyzerService.java
@@ -78,7 +78,8 @@ public class AnalyzerService {
                 this.findBugs,
                 prepared.project,
                 prepared.rankThreshold,
-                prepared.plugins
+                prepared.plugins,
+                monitor
         );
         checkCanceled(monitor);
         List<BugInfo> bugs = result.getBugs();

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SpotBugsExecutor.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SpotBugsExecutor.java
@@ -13,15 +13,19 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
 
 import com.spotbugs.vscode.runner.api.BugInfo;
 import com.spotbugs.vscode.runner.api.CommandWarning;
+
+import org.eclipse.core.runtime.IProgressMonitor;
 
 import edu.umd.cs.findbugs.BugCollectionBugReporter;
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugRanker;
 import edu.umd.cs.findbugs.DetectorFactoryCollection;
 import edu.umd.cs.findbugs.FindBugs2;
+import edu.umd.cs.findbugs.NoOpFindBugsProgress;
 import edu.umd.cs.findbugs.Plugin;
 import edu.umd.cs.findbugs.PluginException;
 import edu.umd.cs.findbugs.PluginLoader;
@@ -71,15 +75,21 @@ public class SpotBugsExecutor {
     }
 
     public List<BugInfo> executeBugs() throws IOException, InterruptedException {
-        return executeBugsWithWarnings().getBugs();
+        return executeBugsWithWarnings(null).getBugs();
     }
 
     public SpotBugsAnalysisResult executeBugsWithWarnings() throws IOException, InterruptedException {
+        return executeBugsWithWarnings(null);
+    }
+
+    public SpotBugsAnalysisResult executeBugsWithWarnings(IProgressMonitor monitor)
+            throws IOException, InterruptedException {
         synchronized (SPOTBUGS_GLOBAL_LOCK) {
+            checkCanceled(monitor);
             LoadedPlugins loadedPlugins = LoadedPlugins.load(pluginJars, project, pluginLifecycle);
             List<BugInfo> bugs;
             try {
-                execute(defaultBugReporter);
+                execute(defaultBugReporter, monitor);
                 bugs = collectBugs(defaultBugReporter);
             } catch (IOException | InterruptedException | RuntimeException | Error failure) {
                 loadedPlugins.closeAfterFailure(failure);
@@ -99,7 +109,7 @@ public class SpotBugsExecutor {
                 SarifBugReporter reporter = new SarifBugReporter(project);
                 configureReporter(reporter);
                 reporter.setWriter(new PrintWriter(writer));
-                execute(reporter);
+                execute(reporter, null);
                 sarif = writer.toString();
             } catch (IOException | InterruptedException | RuntimeException | Error failure) {
                 loadedPlugins.closeAfterFailure(failure);
@@ -110,7 +120,8 @@ public class SpotBugsExecutor {
         }
     }
 
-    private void execute(BugCollectionBugReporter reporter) throws IOException, InterruptedException {
+    private void execute(BugCollectionBugReporter reporter, IProgressMonitor monitor)
+            throws IOException, InterruptedException {
         findBugs.setProject(project);
         findBugs.setBugReporter(reporter);
         UserPreferences currentPreferences = findBugs.getUserPreferences();
@@ -120,7 +131,46 @@ public class SpotBugsExecutor {
         }
         DetectorFactoryCollection dfc = DetectorFactoryCollection.instance();
         findBugs.setDetectorFactoryCollection(dfc);
-        findBugs.execute();
+        if (monitor == null) {
+            findBugs.execute();
+            return;
+        }
+
+        findBugs.setProgressCallback(new NoOpFindBugsProgress() {
+            private void interruptIfCanceled() {
+                if (monitor.isCanceled()) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+
+            @Override
+            public void finishArchive() {
+                interruptIfCanceled();
+            }
+
+            @Override
+            public void startAnalysis(int numClasses) {
+                interruptIfCanceled();
+            }
+
+            @Override
+            public void finishClass() {
+                interruptIfCanceled();
+            }
+        });
+        try {
+            findBugs.execute();
+            checkCanceled(monitor);
+        } finally {
+            findBugs.setProgressCallback(new NoOpFindBugsProgress());
+        }
+    }
+
+    private static void checkCanceled(IProgressMonitor monitor) {
+        if (monitor != null && monitor.isCanceled()) {
+            Thread.interrupted();
+            throw new CancellationException("Command cancelled");
+        }
     }
 
     private void configureReporter(BugCollectionBugReporter reporter) {

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SpotBugsRunner.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SpotBugsRunner.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import com.spotbugs.vscode.runner.api.BugInfo;
 
+import org.eclipse.core.runtime.IProgressMonitor;
+
 import edu.umd.cs.findbugs.FindBugs2;
 import edu.umd.cs.findbugs.Project;
 
@@ -20,17 +22,18 @@ public class SpotBugsRunner {
 
     public List<BugInfo> run(FindBugs2 findBugs, Project project, Integer rankThreshold, java.util.List<String> pluginJars)
             throws IOException, InterruptedException {
-        return runWithWarnings(findBugs, project, rankThreshold, pluginJars).getBugs();
+        return runWithWarnings(findBugs, project, rankThreshold, pluginJars, null).getBugs();
     }
 
     public SpotBugsAnalysisResult runWithWarnings(
             FindBugs2 findBugs,
             Project project,
             Integer rankThreshold,
-            java.util.List<String> pluginJars
+            java.util.List<String> pluginJars,
+            IProgressMonitor monitor
     ) throws IOException, InterruptedException {
         SpotBugsExecutor executor = new SpotBugsExecutor(findBugs, project, rankThreshold, pluginJars);
-        return executor.executeBugsWithWarnings();
+        return executor.executeBugsWithWarnings(monitor);
     }
 
     public String runNativeSarif(

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/AnalysisPipeline.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/AnalysisPipeline.java
@@ -35,6 +35,9 @@ final class AnalysisPipeline {
             Thread.currentThread().interrupt();
             return AnalysisPipelineResult.cancelled(analyzer, startMillis);
         } catch (Exception analysisFailure) {
+            if (monitor != null && monitor.isCanceled()) {
+                return AnalysisPipelineResult.cancelled(analyzer, startMillis);
+            }
             return AnalysisPipelineResult.failed(analyzer, startMillis, analysisFailure);
         }
     }

--- a/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/SpotBugsExecutorCancellationTest.java
+++ b/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/SpotBugsExecutorCancellationTest.java
@@ -1,0 +1,73 @@
+package com.spotbugs.vscode.runner.internal;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.FindBugs2;
+import edu.umd.cs.findbugs.FindBugsProgress;
+import edu.umd.cs.findbugs.Project;
+
+public class SpotBugsExecutorCancellationTest {
+
+    @Test
+    public void progressCancellationInterruptsTheCurrentSpotBugsExecution() throws Exception {
+        NullProgressMonitor monitor = new NullProgressMonitor();
+        AtomicBoolean interrupted = new AtomicBoolean(false);
+        StubFindBugs findBugs = new StubFindBugs(progress -> {
+            if (progress == null) {
+                throw new AssertionError("Cancellation progress callback was not installed");
+            }
+            monitor.setCanceled(true);
+            progress.finishClass();
+            interrupted.set(Thread.interrupted());
+            if (interrupted.get()) {
+                throw new InterruptedException("cancelled");
+            }
+        });
+        SpotBugsExecutor executor = new SpotBugsExecutor(
+                findBugs,
+                new Project(),
+                9,
+                Collections.emptyList()
+        );
+
+        try {
+            executor.executeBugsWithWarnings(monitor);
+            fail("Expected current SpotBugs execution to be interrupted");
+        } catch (InterruptedException expected) {
+            assertTrue(interrupted.get());
+        }
+    }
+
+    private static final class StubFindBugs extends FindBugs2 {
+
+        private final Execution execution;
+        private FindBugsProgress progress;
+
+        private StubFindBugs(Execution execution) {
+            this.execution = execution;
+        }
+
+        @Override
+        public void setProgressCallback(FindBugsProgress progress) {
+            this.progress = progress;
+        }
+
+        @Override
+        public void execute() throws IOException, InterruptedException {
+            execution.run(progress);
+        }
+    }
+
+    @FunctionalInterface
+    private interface Execution {
+        void run(FindBugsProgress progress) throws IOException, InterruptedException;
+    }
+}

--- a/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/command/AnalysisPipelineTest.java
+++ b/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/command/AnalysisPipelineTest.java
@@ -110,6 +110,24 @@ public class AnalysisPipelineTest {
     }
 
     @Test
+    public void runReturnsCancelledWhenAnalyzerFailureFollowsMonitorCancellation() throws Exception {
+        NullProgressMonitor monitor = new NullProgressMonitor();
+        AnalysisPipeline pipeline = new AnalysisPipeline(() -> new AnalyzerService() {
+            @Override
+            public SpotBugsAnalysisResult analyzeToBugsWithWarnings(IProgressMonitor progressMonitor, String... filePaths)
+                    throws IOException {
+                progressMonitor.setCanceled(true);
+                throw new IOException("wrapped interruption");
+            }
+        });
+
+        AnalysisPipelineResult result = pipeline.run(monitor, request("/workspace/build/classes"));
+
+        assertEquals(AnalysisPipelineResult.Status.CANCELLED, result.getStatus());
+        assertEquals(0, result.getFindingCount());
+    }
+
+    @Test
     public void runReturnsFailedResultWithOriginalException() throws Exception {
         IOException failure = new IOException("analysis boom");
         AnalysisPipeline pipeline = new AnalysisPipeline(() -> new AnalyzerService() {

--- a/src/constants/commands.ts
+++ b/src/constants/commands.ts
@@ -1,9 +1,15 @@
 export namespace JavaLanguageServerCommands {
   export const EXECUTE_WORKSPACE_COMMAND: string = 'java.execute.workspaceCommand';
-  // vscode-java standardLanguageClient commands, true is full compile, false is incremental compile
-  export const BUILD_WORKSPACE: string = 'java.project.build';
+  // vscode-java standardLanguageClient command, true is full compile, false is incremental compile
+  export const COMPILE_WORKSPACE: string = 'java.workspace.compile';
   export const GET_CLASSPATHS: string = 'java.project.getClasspaths';
   export const GET_ALL_JAVA_PROJECTS: string = 'java.project.getAll';
+}
+
+export enum JavaCompileWorkspaceStatus {
+  failed = 0,
+  succeeded = 1,
+  cancelled = 3,
 }
 
 // VS Code command IDs owned by this extension (used in menus/UI)

--- a/src/lsp/javaLsGateway.ts
+++ b/src/lsp/javaLsGateway.ts
@@ -1,4 +1,4 @@
-import { commands } from 'vscode';
+import { commands, type CancellationToken } from 'vscode';
 import { JavaLanguageServerCommands } from '../constants/commands';
 
 export interface JavaLsClasspathResponse {
@@ -35,10 +35,12 @@ export async function requestAllJavaProjects(): Promise<string[] | undefined> {
 }
 
 export async function requestWorkspaceBuild(
-  full: boolean
+  full: boolean,
+  token?: CancellationToken
 ): Promise<number | undefined> {
+  const args = token ? [full, token] : [full];
   return commands.executeCommand<number>(
-    JavaLanguageServerCommands.BUILD_WORKSPACE,
-    full
+    JavaLanguageServerCommands.COMPILE_WORKSPACE,
+    ...args
   );
 }

--- a/src/lsp/spotbugsClient.ts
+++ b/src/lsp/spotbugsClient.ts
@@ -1,13 +1,16 @@
+import type { CancellationToken } from 'vscode';
 import { executeWorkspaceCommand } from './javaLsGateway';
 import { SpotBugsLSCommands } from '../constants/commands';
 import { AnalysisRequest } from '../model/analysisProtocol';
 
 export async function runSpotBugsAnalysis(
-  request: AnalysisRequest
+  request: AnalysisRequest,
+  token?: CancellationToken
 ): Promise<string | undefined> {
   return executeWorkspaceCommand<string>(
     SpotBugsLSCommands.RUN_ANALYSIS,
     request.targetPath,
-    JSON.stringify(request.payload)
+    JSON.stringify(request.payload),
+    ...(token ? [token] : [])
   );
 }

--- a/src/orchestration/analysisRunSession.ts
+++ b/src/orchestration/analysisRunSession.ts
@@ -13,6 +13,7 @@ import type {
 import type { ProjectResult } from '../services/projectResult';
 import type { WorkspaceProjectDiscoveryResult } from '../workspace/projectDiscovery';
 import type { AnalysisRunLease } from './analysisRunCoordinator';
+import { JavaCompileWorkspaceStatus } from '../constants/commands';
 import { buildAnalysisNotices } from './analysisNotices';
 import { buildWorkspaceCompletionNotices } from './workspaceSummary';
 
@@ -72,7 +73,7 @@ export interface AnalysisSessionDependencies {
     notify?: WorkspaceProgressCallbacks,
     token?: CancellationToken
   ): Promise<WorkspaceExecutionResult>;
-  buildWorkspaceAuto(): Promise<number | undefined>;
+  buildWorkspaceAuto(token?: CancellationToken): Promise<number | undefined>;
   getPrimaryWorkspaceFolder(): WorkspaceFolder | undefined;
   getWorkspaceProjectDiscovery(
     workspaceFolder: Uri
@@ -171,8 +172,15 @@ export async function runWorkspaceAnalysisSession(
         return;
       }
       progress.report({ message: 'Building Java workspace...' });
-      const buildResult = await dependencies.buildWorkspaceAuto();
+      const buildResult = await dependencies.buildWorkspaceAuto(token);
       if (!args.lease.isCurrent()) {
+        return;
+      }
+      if (
+        token.isCancellationRequested ||
+        buildResult === JavaCompileWorkspaceStatus.cancelled
+      ) {
+        cancelled = true;
         return;
       }
       if (buildResult !== undefined && buildResult !== 0) {
@@ -191,6 +199,10 @@ export async function runWorkspaceAnalysisSession(
 
       const discovery = await dependencies.getWorkspaceProjectDiscovery(wsFolder.uri);
       if (!args.lease.isCurrent()) {
+        return;
+      }
+      if (token.isCancellationRequested) {
+        cancelled = true;
         return;
       }
       args.tree.showWorkspaceProgress(discovery.projectUris);

--- a/src/services/analysisExecution.ts
+++ b/src/services/analysisExecution.ts
@@ -1,4 +1,4 @@
-import type { Uri } from 'vscode';
+import type { CancellationToken, Uri } from 'vscode';
 import { Logger } from '../core/logger';
 import type { AnalysisSettings, Config } from '../core/config';
 import type { AnalysisOutcome } from '../model/analysisOutcome';
@@ -66,7 +66,8 @@ export function createAnalysisExecutor(overrides: Partial<AnalysisExecutorDeps> 
 
   async function run(
     config: AnalysisConfigProvider,
-    context: AnalysisExecutionTarget
+    context: AnalysisExecutionTarget,
+    token?: CancellationToken
   ): Promise<AnalysisOutcome> {
     const settings = config.getAnalysisSettings(context.preferredProject);
     const preflightFailure = await validateAnalysisPreflight(
@@ -77,7 +78,7 @@ export function createAnalysisExecutor(overrides: Partial<AnalysisExecutorDeps> 
       return preflightFailure;
     }
 
-    const raw = await executeAnalysisRequest(settings, context);
+    const raw = await executeAnalysisRequest(settings, context, token);
     return analysisOutcomeFromRawResponse(raw, context);
   }
 
@@ -144,7 +145,8 @@ export function createAnalysisExecutor(overrides: Partial<AnalysisExecutorDeps> 
 
   async function executeAnalysisRequest(
     settings: AnalysisSettings,
-    context: AnalysisExecutionTarget
+    context: AnalysisExecutionTarget,
+    token?: CancellationToken
   ): Promise<string | undefined> {
     const payload = deps.buildAnalysisRequestPayload(settings, {
       targetResolutionRoots: context.targetResolutionRoots ?? null,
@@ -152,10 +154,13 @@ export function createAnalysisExecutor(overrides: Partial<AnalysisExecutorDeps> 
       extraAuxClasspaths: settings.extraAuxClasspaths ?? null,
       sourcepaths: context.sourcepaths ?? null,
     });
-    return deps.runSpotBugsAnalysis({
-      targetPath: context.targetPath,
-      payload,
-    });
+    return deps.runSpotBugsAnalysis(
+      {
+        targetPath: context.targetPath,
+        payload,
+      },
+      token
+    );
   }
 
   async function analysisOutcomeFromRawResponse(
@@ -329,9 +334,10 @@ export function createAnalysisExecutor(overrides: Partial<AnalysisExecutorDeps> 
 
 export function runAnalysisTarget(
   config: Config,
-  context: AnalysisExecutionTarget
+  context: AnalysisExecutionTarget,
+  token?: CancellationToken
 ): Promise<AnalysisOutcome> {
-  return createAnalysisExecutor().run(config, context);
+  return createAnalysisExecutor().run(config, context, token);
 }
 
 export function createAnalysisFailureOutcome(

--- a/src/services/analysisService.ts
+++ b/src/services/analysisService.ts
@@ -157,13 +157,17 @@ export async function analyzeWorkspaceFromProjectsDetailed(
     const result = await analyzeProjectDetailed(
       config,
       Uri.parse(uriString),
-      workspaceFolder
+      workspaceFolder,
+      token
     );
     results.push(result.projectResult);
     context.resolutionIssues.push(...result.context.resolutionIssues);
     context.cleanupWarnings?.push(...(result.context.cleanupWarnings ?? []));
 
-    if (isAnalysisCancelledProjectResult(result.projectResult)) {
+    if (
+      token?.isCancellationRequested ||
+      isAnalysisCancelledProjectResult(result.projectResult)
+    ) {
       Logger.log('Workspace analysis cancelled by backend.');
       cancelled = true;
       break;
@@ -219,7 +223,8 @@ async function analyzeProject(
 async function analyzeProjectDetailed(
   config: Config,
   project: ProjectRef,
-  workspaceFolder: Uri
+  workspaceFolder: Uri,
+  token?: CancellationToken
 ): Promise<{ projectResult: ProjectResult; context: AnalysisExecutionContext }> {
   const projectUri = normalizeProjectRef(project);
   const projectUriString = projectUri.toString();
@@ -228,6 +233,10 @@ async function analyzeProjectDetailed(
   try {
     const result = await resolveProjectAnalysisTargetDetailed(projectUri, workspaceFolder);
     context.resolutionIssues.push(...result.issues);
+
+    if (token?.isCancellationRequested) {
+      return { projectResult: cancelledProjectResult(projectUriString), context };
+    }
 
     if (result.resolution.status !== 'ok') {
       return {
@@ -242,7 +251,7 @@ async function analyzeProjectDetailed(
     }
 
     try {
-      const outcome = await runAnalysis(config, result.resolution.target);
+      const outcome = await runAnalysis(config, result.resolution.target, token);
       if (Array.isArray(outcome.warnings)) {
         context.cleanupWarnings?.push(
           ...outcome.warnings.map((warning) => ({
@@ -273,9 +282,10 @@ async function analyzeProjectDetailed(
 
 async function runAnalysis(
   config: Config,
-  context: AnalysisExecutionTarget
+  context: AnalysisExecutionTarget,
+  token?: CancellationToken
 ): Promise<AnalysisOutcome> {
-  return runAnalysisTarget(config, context);
+  return runAnalysisTarget(config, context, token);
 }
 
 function messageFromUnknown(error: unknown): string {
@@ -288,6 +298,14 @@ function messageFromUnknown(error: unknown): string {
 
 function isAnalysisCancelledProjectResult(result: ProjectResult): boolean {
   return result.errorCode === ERROR_ANALYSIS_CANCELLED;
+}
+
+function cancelledProjectResult(projectUri: string): ProjectResult {
+  return {
+    projectUri,
+    findings: [],
+    errorCode: ERROR_ANALYSIS_CANCELLED,
+  };
 }
 
 function normalizeProjectRef(project: ProjectRef): Uri {

--- a/src/services/workspaceBuildService.ts
+++ b/src/services/workspaceBuildService.ts
@@ -1,5 +1,8 @@
-import { commands } from 'vscode';
-import { JavaLanguageServerCommands } from '../constants/commands';
+import { commands, type CancellationToken } from 'vscode';
+import {
+  JavaCompileWorkspaceStatus,
+  JavaLanguageServerCommands,
+} from '../constants/commands';
 import { ensureJavaCommandsAvailable } from '../core/utils';
 import { Logger } from '../core/logger';
 import { requestWorkspaceBuild } from '../lsp/javaLsGateway';
@@ -12,7 +15,8 @@ export interface BuildWorkspaceOptions {
 }
 
 export async function buildWorkspace(
-  options: BuildWorkspaceOptions = {}
+  options: BuildWorkspaceOptions = {},
+  token?: CancellationToken
 ): Promise<number | undefined> {
   const { mode = 'auto', ensureCommands = true } = options;
 
@@ -20,7 +24,7 @@ export async function buildWorkspace(
 
   if (ensureCommands) {
     const waited = await ensureJavaCommandsAvailable([
-      JavaLanguageServerCommands.BUILD_WORKSPACE,
+      JavaLanguageServerCommands.COMPILE_WORKSPACE,
       JavaLanguageServerCommands.GET_CLASSPATHS,
     ]);
     Logger.log(`Checked Java command availability (waited=${waited})`);
@@ -28,7 +32,7 @@ export async function buildWorkspace(
 
   try {
     const available = await commands.getCommands(true);
-    const hasBuild = available.includes(JavaLanguageServerCommands.BUILD_WORKSPACE);
+    const hasBuild = available.includes(JavaLanguageServerCommands.COMPILE_WORKSPACE);
     const hasGetCp = available.includes(JavaLanguageServerCommands.GET_CLASSPATHS);
     Logger.log(`Commands available - build:${hasBuild} getClasspaths:${hasGetCp}`);
   } catch {
@@ -36,15 +40,22 @@ export async function buildWorkspace(
   }
 
   const tryBuild = async (full: boolean): Promise<number | undefined> => {
+    if (token?.isCancellationRequested) {
+      return JavaCompileWorkspaceStatus.cancelled;
+    }
     const modeLabel = full ? 'full' : 'incremental';
     try {
-      Logger.log(`Invoking java.project.build(${full}) - ${modeLabel} build`);
-      const value = await requestWorkspaceBuild(full);
-      Logger.log(`java.project.build(${full}) returned: ${String(value)}`);
-      return value;
+      Logger.log(`Invoking java.workspace.compile(${full}) - ${modeLabel} build`);
+      const value = await requestWorkspaceBuild(full, token);
+      Logger.log(`java.workspace.compile(${full}) returned: ${String(value)}`);
+      return normalizeCompileStatus(value);
     } catch (e) {
+      if (token?.isCancellationRequested) {
+        Logger.log('Java workspace build cancelled by user.');
+        return JavaCompileWorkspaceStatus.cancelled;
+      }
       Logger.log(
-        `Error during java.project.build(${full}): ${e instanceof Error ? e.message : String(e)}`
+        `Error during java.workspace.compile(${full}): ${e instanceof Error ? e.message : String(e)}`
       );
       return undefined;
     }
@@ -57,6 +68,13 @@ export async function buildWorkspace(
     result = await tryBuild(false);
   }
 
+  if (
+    token?.isCancellationRequested ||
+    result === JavaCompileWorkspaceStatus.cancelled
+  ) {
+    return JavaCompileWorkspaceStatus.cancelled;
+  }
+
   const shouldRunFull = mode === 'full' || (mode === 'auto' && result !== 0);
   if (shouldRunFull) {
     result = await tryBuild(true);
@@ -67,6 +85,14 @@ export async function buildWorkspace(
   return result;
 }
 
-export async function buildWorkspaceAuto(): Promise<number | undefined> {
-  return buildWorkspace({ mode: 'auto' });
+function normalizeCompileStatus(status: number | undefined): number | undefined {
+  if (status === JavaCompileWorkspaceStatus.succeeded) return 0;
+  if (status === JavaCompileWorkspaceStatus.failed) return 1;
+  return status;
+}
+
+export async function buildWorkspaceAuto(
+  token?: CancellationToken
+): Promise<number | undefined> {
+  return buildWorkspace({ mode: 'auto' }, token);
 }

--- a/src/test/L0.analysisRunSession.test.ts
+++ b/src/test/L0.analysisRunSession.test.ts
@@ -16,6 +16,7 @@ import {
 import type { AnalysisExecutionResult } from '../services/analysisService';
 import type { Finding } from '../model/finding';
 import type { ProjectResult } from '../services/projectResult';
+import { JavaCompileWorkspaceStatus } from '../constants/commands';
 import { installVscodeMock, resetVscodeMock } from './helpers/mockVscode';
 
 installVscodeMock();
@@ -511,6 +512,33 @@ function createWorkspaceHarness(overrides: Partial<AnalysisSessionDependencies> 
 }
 
 describe('analysisRunSession workspace analysis', () => {
+  it('stops before discovery when the workspace build is cancelled', async () => {
+    let receivedToken: unknown;
+    let discoveryCalled = false;
+    let analysisCalled = false;
+    const harness = createWorkspaceHarness({
+      buildWorkspaceAuto: async (token) => {
+        receivedToken = token;
+        return JavaCompileWorkspaceStatus.cancelled;
+      },
+      getWorkspaceProjectDiscovery: async () => {
+        discoveryCalled = true;
+        return { projectUris: [], issues: [] };
+      },
+      analyzeWorkspaceFromProjectsDetailed: async () => {
+        analysisCalled = true;
+        return { results: [], context: { resolutionIssues: [] } };
+      },
+    });
+
+    await runWorkspaceAnalysisSession(harness.args);
+
+    assert.strictEqual(receivedToken, harness.token);
+    assert.strictEqual(discoveryCalled, false);
+    assert.strictEqual(analysisCalled, false);
+    assert.deepStrictEqual(harness.calls, ['cancelled']);
+  });
+
   it('applies all-success workspace results and replaces diagnostics once', async () => {
     const finding = createFinding('/workspace/project-a/src/Foo.java');
     const harness = createWorkspaceHarness({
@@ -882,6 +910,7 @@ describe('analysisRunSession workspace analysis', () => {
     {
       name: 'service cancellation flag',
       tokenCancelled: false,
+      expectedCalls: ['progress:1', 'cancelled'],
       result: {
         results: [],
         cancelled: true,
@@ -893,6 +922,7 @@ describe('analysisRunSession workspace analysis', () => {
     {
       name: 'VS Code token cancellation',
       tokenCancelled: true,
+      expectedCalls: ['cancelled'],
       result: {
         results: [],
         cancelled: false,
@@ -904,6 +934,7 @@ describe('analysisRunSession workspace analysis', () => {
     {
       name: 'backend cancellation envelope',
       tokenCancelled: false,
+      expectedCalls: ['progress:1', 'cancelled'],
       result: {
         results: [
           {
@@ -932,7 +963,7 @@ describe('analysisRunSession workspace analysis', () => {
 
       await runWorkspaceAnalysisSession(harness.args);
 
-      assert.deepStrictEqual(harness.calls, ['progress:1', 'cancelled']);
+      assert.deepStrictEqual(harness.calls, scenario.expectedCalls);
       assert.deepStrictEqual(harness.errors, []);
     });
   }

--- a/src/test/L1.analysisService.test.ts
+++ b/src/test/L1.analysisService.test.ts
@@ -354,4 +354,46 @@ describe('analysisService', () => {
     assert.strictEqual(result.results[0].errorCode, 'ANALYSIS_CANCELLED');
     assert.deepStrictEqual(analyzedTargets, ['/workspace/project-a/target/classes']);
   });
+
+  it('treats a rejected backend request as cancellation when the token is cancelled', async () => {
+    const vscode = installVscodeMock();
+    const resolverModule =
+      require('../workspace/analysisTargetResolver') as typeof import('../workspace/analysisTargetResolver');
+    const spotbugsClient =
+      require('../lsp/spotbugsClient') as typeof import('../lsp/spotbugsClient');
+    const service = require('../services/analysisService') as typeof import('../services/analysisService');
+    const token = { isCancellationRequested: false } as any;
+    const analyzedTargets: string[] = [];
+    const failedProjects: string[] = [];
+
+    resolverModule.resolveProjectAnalysisTargetDetailed = (async (projectUri) => ({
+      resolution: {
+        status: 'ok',
+        target: {
+          targetPath: `/workspace/${projectUri.toString().split('/').pop()}/target/classes`,
+          preferredProject: projectUri,
+        },
+      },
+      issues: [],
+    })) as typeof resolverModule.resolveProjectAnalysisTargetDetailed;
+    spotbugsClient.runSpotBugsAnalysis = (async (request, receivedToken) => {
+      analyzedTargets.push(request.targetPath);
+      assert.strictEqual(receivedToken, token);
+      token.isCancellationRequested = true;
+      throw new Error('request cancelled');
+    }) as typeof spotbugsClient.runSpotBugsAnalysis;
+
+    const result = await service.analyzeWorkspaceFromProjectsDetailed(
+      { getAnalysisSettings: () => ({ effort: 'default' }) } as any,
+      vscode.Uri.file('/workspace') as any,
+      ['file:///workspace/project-a', 'file:///workspace/project-b'],
+      { onFail: (projectUri) => failedProjects.push(projectUri) },
+      token
+    );
+
+    assert.strictEqual(result.cancelled, true);
+    assert.strictEqual(result.results.length, 1);
+    assert.deepStrictEqual(failedProjects, []);
+    assert.deepStrictEqual(analyzedTargets, ['/workspace/project-a/target/classes']);
+  });
 });

--- a/src/test/L1.workspaceBuildService.test.ts
+++ b/src/test/L1.workspaceBuildService.test.ts
@@ -1,0 +1,68 @@
+import * as assert from 'assert';
+import type { CancellationToken } from 'vscode';
+import {
+  JavaCompileWorkspaceStatus,
+  JavaLanguageServerCommands,
+} from '../constants/commands';
+import { installVscodeMock, resetVscodeMock } from './helpers/mockVscode';
+
+function clearModules(): void {
+  delete require.cache[require.resolve('../lsp/javaLsGateway')];
+  delete require.cache[require.resolve('../services/workspaceBuildService')];
+}
+
+async function invokeBuild(
+  execute: (...args: unknown[]) => unknown,
+  token?: CancellationToken
+): Promise<{ result: number | undefined; calls: unknown[][] }> {
+  const calls: unknown[][] = [];
+  installVscodeMock({
+    commands: {
+      getCommands: async () => [JavaLanguageServerCommands.COMPILE_WORKSPACE],
+      executeCommand: async (...args: unknown[]) => {
+        calls.push(args);
+        return execute(...args);
+      },
+    },
+  });
+  clearModules();
+  const service =
+    require('../services/workspaceBuildService') as typeof import('../services/workspaceBuildService');
+  const result = await service.buildWorkspace(
+    { mode: 'auto', ensureCommands: false },
+    token
+  );
+  return { result, calls };
+}
+
+describe('workspaceBuildService', () => {
+  beforeEach(() => {
+    installVscodeMock();
+    resetVscodeMock();
+    clearModules();
+  });
+
+  it('passes the token to workspace compilation and does not retry a cancelled build', async () => {
+    const token = { isCancellationRequested: false } as any;
+    const { result, calls } = await invokeBuild(
+      () => JavaCompileWorkspaceStatus.cancelled,
+      token
+    );
+
+    assert.strictEqual(result, JavaCompileWorkspaceStatus.cancelled);
+    assert.deepStrictEqual(calls, [
+      [JavaLanguageServerCommands.COMPILE_WORKSPACE, false, token],
+    ]);
+  });
+
+  it('normalizes a successful incremental compile without starting a full retry', async () => {
+    const { result, calls } = await invokeBuild(
+      () => JavaCompileWorkspaceStatus.succeeded
+    );
+
+    assert.strictEqual(result, 0);
+    assert.deepStrictEqual(calls, [
+      [JavaLanguageServerCommands.COMPILE_WORKSPACE, false],
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Propagate workspace cancellation from VS Code through Java LS to SpotBugs.
- Classify wrapped cancellation failures correctly.