### PR TITLE
fix(sarif): preserve secondary workspace paths

### DIFF
--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -29,9 +29,13 @@ export async function exportSarifReport(
   }
 
   try {
+    const workspaceRootPaths = workspace.workspaceFolders?.map(
+      (folder) => folder.uri.fsPath
+    );
     const sarifLog = buildSarifLog(findings, {
       runName: getWorkspaceName(),
-      workspaceRootPath: workspace.workspaceFolders?.[0]?.uri.fsPath,
+      workspaceRootPath: workspaceRootPaths?.[0],
+      workspaceRootPaths,
     });
     const sarifJson = JSON.stringify(sarifLog, null, 2);
     await workspace.fs.writeFile(saveUri, Buffer.from(sarifJson, 'utf8'));

--- a/src/services/sarifArtifactLocation.ts
+++ b/src/services/sarifArtifactLocation.ts
@@ -4,6 +4,7 @@ import { Finding } from '../model/finding';
 
 export interface SarifArtifactUriOptions {
   workspaceRootPath?: string;
+  workspaceRootPaths?: string[];
 }
 
 export function getSarifArtifactUri(
@@ -11,10 +12,22 @@ export function getSarifArtifactUri(
   options: SarifArtifactUriOptions = {}
 ): string | undefined {
   const fullPath = finding.location.fullPath;
+  const primaryWorkspaceRootPath =
+    options.workspaceRootPath ?? options.workspaceRootPaths?.[0];
   if (fullPath && path.isAbsolute(fullPath)) {
-    const workspaceRelative = toWorkspaceRelativePath(fullPath, options.workspaceRootPath);
+    const workspaceRelative = toWorkspaceRelativePath(
+      fullPath,
+      primaryWorkspaceRootPath
+    );
     if (workspaceRelative) {
       return workspaceRelative;
+    }
+    if (
+      options.workspaceRootPaths
+        ?.slice(1)
+        .some((rootPath) => toWorkspaceRelativePath(fullPath, rootPath))
+    ) {
+      return pathToFileURL(fullPath).toString();
     }
   }
 

--- a/src/services/sarifExporter.ts
+++ b/src/services/sarifExporter.ts
@@ -1,13 +1,15 @@
 import { Finding } from '../model/finding';
 import { Severity } from '../model/severity';
 import { formatFindingSummary, rankToSeverity } from '../formatters/findingFormatting';
-import { getSarifArtifactUri } from './sarifArtifactLocation';
+import {
+  getSarifArtifactUri,
+  type SarifArtifactUriOptions,
+} from './sarifArtifactLocation';
 
-export interface SarifExportOptions {
+export interface SarifExportOptions extends SarifArtifactUriOptions {
   runName?: string;
   toolVersion?: string;
   minRank?: number;
-  workspaceRootPath?: string;
 }
 
 export interface SarifLog {
@@ -98,7 +100,7 @@ export function buildSarifLog(
     if (typeof finding.cweId === 'number' && finding.cweId > 0) {
       cweIds.add(finding.cweId);
     }
-    return createResult(finding, ruleId, options.workspaceRootPath);
+    return createResult(finding, ruleId, options);
   });
 
   const run: SarifRun = {
@@ -172,9 +174,9 @@ function createRule(ruleId: string, finding: Finding): SarifRule {
 function createResult(
   finding: Finding,
   ruleId: string,
-  workspaceRootPath?: string
+  options: SarifArtifactUriOptions
 ): SarifResult {
-  const location = createLocation(finding, workspaceRootPath);
+  const location = createLocation(finding, options);
   const partialFingerprints =
     typeof finding.instanceHash === 'string' && finding.instanceHash.length > 0
       ? { instanceHash: finding.instanceHash }
@@ -190,9 +192,9 @@ function createResult(
 
 function createLocation(
   finding: Finding,
-  workspaceRootPath?: string
+  options: SarifArtifactUriOptions
 ): SarifLocation | undefined {
-  const uri = getSarifArtifactUri(finding, { workspaceRootPath });
+  const uri = getSarifArtifactUri(finding, options);
   const startLine = normalizeLineNumber(finding.location.startLine);
   if (!uri) {
     return undefined;

--- a/src/test/L0.sarifExporter.test.ts
+++ b/src/test/L0.sarifExporter.test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
+import { pathToFileURL } from 'url';
 import { mapBugsToFindings } from '../lsp/spotbugsMapper';
 import { Bug } from '../model/bug';
 import { Finding } from '../model/finding';
@@ -139,9 +140,30 @@ describe('buildSarifLog', () => {
 
     const actual = buildSarifLog([finding], {
       workspaceRootPath: placeholderWorkspaceRoot,
+      workspaceRootPaths: [placeholderWorkspaceRoot, '/__SECONDARY_ROOT__'],
     });
 
     assert.strictEqual(getFirstArtifactUri(actual), 'com/acme/Foo.java');
+  });
+
+  it('keeps an absolute file URI for findings in a secondary workspace root', () => {
+    const secondaryRoot = '/__SECONDARY_ROOT__';
+    const fullPath = `${secondaryRoot}/src/main/java/com/acme/Foo.java`;
+    const finding = makeFinding({
+      location: {
+        fullPath,
+        realSourcePath: 'com/acme/Foo.java',
+        sourceFile: 'Foo.java',
+        startLine: 12,
+      },
+    });
+
+    const actual = buildSarifLog([finding], {
+      workspaceRootPath: placeholderWorkspaceRoot,
+      workspaceRootPaths: [placeholderWorkspaceRoot, secondaryRoot],
+    });
+
+    assert.strictEqual(getFirstArtifactUri(actual), pathToFileURL(fullPath).toString());
   });
 
   it('omits regions when the start line is unknown and normalizes workspace paths', () => {


### PR DESCRIPTION
## Summary

- Resolve SARIF artifacts against their originating project.
- Preserve source paths from secondary workspace roots.