### PR TITLE
fix(ui): distinguish findings with shared instance hashes

### DIFF
--- a/src/test/L0.findingInspectorState.test.ts
+++ b/src/test/L0.findingInspectorState.test.ts
@@ -36,6 +36,19 @@ describe('findingInspectorState', () => {
     assert.strictEqual(state.current.finding, finding);
   });
 
+  it('clears selected findings when the same instance hash belongs to another path', async () => {
+    const findingInspectorState = await import('../ui/findingInspectorState');
+    const finding = makeFinding('NP_ALWAYS_NULL');
+    const state = new findingInspectorState.FindingInspectorState();
+
+    state.select(finding);
+    state.reconcileVisibleFindings([
+      { ...finding, location: { ...finding.location, fullPath: '/tmp/other/Example.java' } },
+    ]);
+
+    assert.strictEqual(state.current.status, 'empty');
+  });
+
   it('keeps visible selected findings after filter reconciliation by stable identity', async () => {
     const findingInspectorState = await import('../ui/findingInspectorState');
     const finding = makeFinding('NP_ALWAYS_NULL', '');

--- a/src/ui/findingInspectorState.ts
+++ b/src/ui/findingInspectorState.ts
@@ -61,8 +61,8 @@ function isSameFinding(left: Finding, right: Finding): boolean {
   if (left === right) {
     return true;
   }
-  if (left.instanceHash && right.instanceHash) {
-    return left.instanceHash === right.instanceHash;
+  if (left.instanceHash && right.instanceHash && left.instanceHash !== right.instanceHash) {
+    return false;
   }
 
   return (


### PR DESCRIPTION
## Summary

- Reconcile inspector findings using rule and source identity in addition to instance hash.
- Distinguish findings that share the same hash.