### PR TITLE
fix: include all classes from selected Java source

### DIFF
--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/TargetResolver.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/TargetResolver.java
@@ -6,12 +6,15 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 
+import org.apache.bcel.classfile.ClassParser;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 /**
@@ -36,6 +39,7 @@ public class TargetResolver {
     ) throws IOException {
         List<String> targets = new ArrayList<>();
         Set<String> seen = new HashSet<>();
+        Map<String, String> sourceFileNames = new HashMap<>();
         List<SourceRoot> sourceRoots = normalizeSourceRoots(sourcepaths);
         if (inputs == null) {
             return targets;
@@ -54,10 +58,11 @@ public class TargetResolver {
                         sourceRoots,
                         targets,
                         seen,
+                        sourceFileNames,
                         monitor
                 );
                 if (sourceDirectoryResolution == SourceDirectoryResolution.NOT_SOURCE_DIRECTORY) {
-                    collectTargetsRecursively(f, targetResolutionRootDirs, sourceRoots, targets, seen, monitor);
+                    collectTargetsRecursively(f, targetResolutionRootDirs, sourceRoots, targets, seen, sourceFileNames, monitor);
                 }
                 continue;
             }
@@ -66,13 +71,13 @@ public class TargetResolver {
                 continue;
             }
             if (isJavaSourceFile(p)) {
-                addTargetsForJavaFile(p, targetResolutionRootDirs, sourceRoots, targets, seen, monitor);
+                addTargetsForJavaFile(p, targetResolutionRootDirs, sourceRoots, targets, seen, sourceFileNames, monitor);
                 continue;
             }
             // Unknown type: add existing file or scan directory
             if (f.exists()) {
                 if (f.isFile()) addIfNew(f.getAbsolutePath(), targets, seen);
-                else if (f.isDirectory()) collectTargetsRecursively(f, targetResolutionRootDirs, sourceRoots, targets, seen, monitor);
+                else if (f.isDirectory()) collectTargetsRecursively(f, targetResolutionRootDirs, sourceRoots, targets, seen, sourceFileNames, monitor);
             }
         }
         return targets;
@@ -84,6 +89,7 @@ public class TargetResolver {
             List<SourceRoot> sourceRoots,
             List<String> out,
             Set<String> seen,
+            Map<String, String> sourceFileNames,
             IProgressMonitor monitor
     ) throws IOException {
         File[] children = dir.listFiles();
@@ -91,7 +97,7 @@ public class TargetResolver {
         for (File c : children) {
             checkCanceled(monitor);
             if (c.isDirectory()) {
-                collectTargetsRecursively(c, targetResolutionRootDirs, sourceRoots, out, seen, monitor);
+                collectTargetsRecursively(c, targetResolutionRootDirs, sourceRoots, out, seen, sourceFileNames, monitor);
                 continue;
             }
             if (!c.isFile()) {
@@ -103,7 +109,7 @@ public class TargetResolver {
                 continue;
             }
             if (isJavaSourceFile(name)) {
-                addTargetsForJavaFile(c.getAbsolutePath(), targetResolutionRootDirs, sourceRoots, out, seen, monitor);
+                addTargetsForJavaFile(c.getAbsolutePath(), targetResolutionRootDirs, sourceRoots, out, seen, sourceFileNames, monitor);
                 continue;
             }
         }
@@ -115,6 +121,7 @@ public class TargetResolver {
             List<SourceRoot> sourceRoots,
             List<String> out,
             Set<String> seen,
+            Map<String, String> sourceFileNames,
             IProgressMonitor monitor
     ) throws IOException {
         List<SourceDirectoryMatch> sourceDirectoryMatches = deriveRelativeDirectoryMatchesFromSource(sourceDir, sourceRoots, monitor);
@@ -144,6 +151,7 @@ public class TargetResolver {
                         sourceRoots,
                         out,
                         seen,
+                        sourceFileNames,
                         monitor
                 );
                 if (out.size() > before) {
@@ -197,6 +205,7 @@ public class TargetResolver {
             List<SourceRoot> sourceRoots,
             List<String> out,
             Set<String> seen,
+            Map<String, String> sourceFileNames,
             IProgressMonitor monitor
     ) throws IOException {
         File[] children = sourceDir.listFiles();
@@ -204,11 +213,11 @@ public class TargetResolver {
         for (File c : children) {
             checkCanceled(monitor);
             if (c.isDirectory()) {
-                collectMappedClassesForSourceTree(c, targetResolutionRootDirs, sourceRoots, out, seen, monitor);
+                collectMappedClassesForSourceTree(c, targetResolutionRootDirs, sourceRoots, out, seen, sourceFileNames, monitor);
                 continue;
             }
             if (c.isFile() && isJavaSourceFile(c.getName())) {
-                addTargetsForJavaFile(c.getAbsolutePath(), targetResolutionRootDirs, sourceRoots, out, seen, monitor);
+                addTargetsForJavaFile(c.getAbsolutePath(), targetResolutionRootDirs, sourceRoots, out, seen, sourceFileNames, monitor);
             }
         }
     }
@@ -239,6 +248,7 @@ public class TargetResolver {
             List<SourceRoot> sourceRoots,
             List<String> out,
             Set<String> seen,
+            Map<String, String> sourceFileNames,
             IProgressMonitor monitor
     ) throws IOException {
         boolean added = false;
@@ -251,7 +261,15 @@ public class TargetResolver {
                 for (File dir : targetResolutionRootDirs) {
                     checkCanceled(monitor);
                     if (dir == null) continue;
-                    if (addClassFamily(dir, classRel, out, seen, monitor)) {
+                    if (addClassFamily(
+                            dir,
+                            classRel,
+                            new File(javaPath).getName(),
+                            out,
+                            seen,
+                            sourceFileNames,
+                            monitor
+                    )) {
                         added = true;
                         break;
                     }
@@ -268,8 +286,10 @@ public class TargetResolver {
     private boolean addClassFamily(
             File outputRoot,
             String classRel,
+            String sourceFileName,
             List<String> out,
             Set<String> seen,
+            Map<String, String> sourceFileNames,
             IProgressMonitor monitor
     ) {
         File anchor = new File(outputRoot, classRel);
@@ -287,24 +307,46 @@ public class TargetResolver {
             return true;
         }
 
-        List<File> nestedClasses = new ArrayList<>();
+        List<File> sourceClasses = new ArrayList<>();
         String nestedPrefix = baseName + "$";
         for (File sibling : siblings) {
             checkCanceled(monitor);
-            if (!sibling.isFile()) {
+            if (!sibling.isFile() || !sibling.getName().endsWith(".class")) {
                 continue;
             }
             String siblingName = sibling.getName();
-            if (siblingName.startsWith(nestedPrefix) && siblingName.endsWith(".class")) {
-                nestedClasses.add(sibling);
+            String siblingSourceFileName = readSourceFileName(sibling, sourceFileNames);
+            if (
+                    sourceFileName.equals(siblingSourceFileName) ||
+                    (siblingSourceFileName == null && siblingName.startsWith(nestedPrefix))
+            ) {
+                sourceClasses.add(sibling);
             }
         }
-        nestedClasses.sort((a, b) -> a.getName().compareTo(b.getName()));
-        for (File nestedClass : nestedClasses) {
+        sourceClasses.sort((a, b) -> a.getName().compareTo(b.getName()));
+        for (File sourceClass : sourceClasses) {
             checkCanceled(monitor);
-            addIfNew(nestedClass.getAbsolutePath(), out, seen);
+            addIfNew(sourceClass.getAbsolutePath(), out, seen);
         }
         return true;
+    }
+
+    private String readSourceFileName(File classFile, Map<String, String> sourceFileNames) {
+        String classPath = classFile.getAbsolutePath();
+        if (sourceFileNames.containsKey(classPath)) {
+            return sourceFileNames.get(classPath);
+        }
+        String sourceFileName = null;
+        try {
+            sourceFileName = new ClassParser(classPath).parse().getSourceFileName();
+            if ("<Unknown>".equals(sourceFileName)) {
+                sourceFileName = null;
+            }
+        } catch (IOException | RuntimeException ignored) {
+            // A malformed or concurrently-written sibling class is handled by the legacy name fallback.
+        }
+        sourceFileNames.put(classPath, sourceFileName);
+        return sourceFileName;
     }
 
     private List<String> deriveRelativePathsFromSource(

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/TargetResolver.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/TargetResolver.java
@@ -258,6 +258,12 @@ public class TargetResolver {
                 if (classRel == null) {
                     continue;
                 }
+                boolean ambiguousSourceFileName = hasSameRelativeSourceInAnotherRoot(
+                        javaPath,
+                        rel,
+                        sourceRoots,
+                        monitor
+                );
                 for (File dir : targetResolutionRootDirs) {
                     checkCanceled(monitor);
                     if (dir == null) continue;
@@ -265,6 +271,7 @@ public class TargetResolver {
                             dir,
                             classRel,
                             new File(javaPath).getName(),
+                            ambiguousSourceFileName,
                             out,
                             seen,
                             sourceFileNames,
@@ -287,6 +294,7 @@ public class TargetResolver {
             File outputRoot,
             String classRel,
             String sourceFileName,
+            boolean ambiguousSourceFileName,
             List<String> out,
             Set<String> seen,
             Map<String, String> sourceFileNames,
@@ -317,8 +325,9 @@ public class TargetResolver {
             String siblingName = sibling.getName();
             String siblingSourceFileName = readSourceFileName(sibling, sourceFileNames);
             if (
-                    sourceFileName.equals(siblingSourceFileName) ||
-                    (siblingSourceFileName == null && siblingName.startsWith(nestedPrefix))
+                    (!ambiguousSourceFileName && sourceFileName.equals(siblingSourceFileName)) ||
+                    (siblingName.startsWith(nestedPrefix) &&
+                            (ambiguousSourceFileName || siblingSourceFileName == null))
             ) {
                 sourceClasses.add(sibling);
             }
@@ -347,6 +356,31 @@ public class TargetResolver {
         }
         sourceFileNames.put(classPath, sourceFileName);
         return sourceFileName;
+    }
+
+    private boolean hasSameRelativeSourceInAnotherRoot(
+            String sourcePath,
+            String relativePath,
+            List<SourceRoot> sourceRoots,
+            IProgressMonitor monitor
+    ) {
+        Path source = toNormalizedPath(sourcePath);
+        if (source == null || sourceRoots == null) {
+            return false;
+        }
+        String normalizedRelativePath = normalizePath(relativePath);
+        for (SourceRoot root : sourceRoots) {
+            checkCanceled(monitor);
+            Path candidate = root.path.resolve(normalizedRelativePath).normalize();
+            if (
+                    candidate.startsWith(root.path) &&
+                    !candidate.equals(source) &&
+                    candidate.toFile().isFile()
+            ) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private List<String> deriveRelativePathsFromSource(

--- a/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/TargetResolverTest.java
+++ b/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/TargetResolverTest.java
@@ -1,12 +1,18 @@
 package com.spotbugs.vscode.runner.internal;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -57,6 +63,54 @@ public class TargetResolverTest {
         );
 
         assertEquals(sortedPaths(classFile, anonymousClassFile, innerClassFile), sorted(actual));
+    }
+
+    @Test
+    public void resolvesAllTopLevelClassesDeclaredInSelectedJavaFile() throws Exception {
+        File project = temporaryFolder.newFolder("multi-top-level-project");
+        File sourceRoot = mkdirs(project, "src/main/java");
+        File sourcePackage = mkdirs(sourceRoot, "demo");
+        File outputRoot = mkdirs(project, "target/classes");
+        File sourceFile = writeJavaSource(
+                sourcePackage,
+                "Repro.java",
+                "package demo; public class Repro { static class Inner {} } " +
+                        "class Helper { static class Nested {} } " +
+                        "class Same$Source {}"
+        );
+        File foreignDollarSourceFile = writeJavaSource(
+                sourcePackage,
+                "Helper$Foreign.java",
+                "package demo; class Helper$Foreign {}"
+        );
+        compileJavaSources(outputRoot, sourceFile, foreignDollarSourceFile);
+
+        File outputPackage = new File(outputRoot, "demo");
+        File reproClass = new File(outputPackage, "Repro.class");
+        File reproInnerClass = new File(outputPackage, "Repro$Inner.class");
+        File helperClass = new File(outputPackage, "Helper.class");
+        File helperNestedClass = new File(outputPackage, "Helper$Nested.class");
+        File sameSourceDollarClass = new File(outputPackage, "Same$Source.class");
+        File foreignDollarClass = new File(outputPackage, "Helper$Foreign.class");
+        assertTrue(foreignDollarClass.isFile());
+
+        List<String> actual = new TargetResolver().resolveTargets(
+                new String[] { sourceFile.getAbsolutePath() },
+                Collections.singletonList(outputRoot),
+                Collections.singletonList(sourceRoot.getAbsolutePath()),
+                null
+        );
+
+        assertEquals(
+                sortedPaths(
+                        reproClass,
+                        reproInnerClass,
+                        helperClass,
+                        helperNestedClass,
+                        sameSourceDollarClass
+                ),
+                sorted(actual)
+        );
     }
 
     @Test
@@ -304,6 +358,29 @@ public class TargetResolverTest {
         File file = new File(parent, name);
         assertTrue(file.createNewFile());
         return file;
+    }
+
+    private File writeJavaSource(File parent, String name, String source) throws Exception {
+        File file = new File(parent, name);
+        Files.write(file.toPath(), source.getBytes(StandardCharsets.UTF_8));
+        return file;
+    }
+
+    private void compileJavaSources(File outputRoot, File... sourceFiles) {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        assertNotNull("Tests require a JDK with javac", compiler);
+        List<String> arguments = listOf(
+                "--release",
+                "8",
+                "-g:source",
+                "-Xlint:-options",
+                "-d",
+                outputRoot.getAbsolutePath()
+        );
+        for (File sourceFile : sourceFiles) {
+            arguments.add(sourceFile.getAbsolutePath());
+        }
+        assertEquals(0, compiler.run(null, null, null, arguments.toArray(new String[0])));
     }
 
     private File mkdirs(File parent, String relativePath) {

--- a/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/TargetResolverTest.java
+++ b/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/TargetResolverTest.java
@@ -114,6 +114,46 @@ public class TargetResolverTest {
     }
 
     @Test
+    public void fallsBackToAnchorFamilyForSameNamedSourcesAcrossSourceRoots() throws Exception {
+        File project = temporaryFolder.newFolder("same-named-source-project");
+        File selectedSourceRoot = mkdirs(project, "src/main/java");
+        File otherSourceRoot = mkdirs(project, "generated/java");
+        File selectedSourcePackage = mkdirs(selectedSourceRoot, "demo");
+        File otherSourcePackage = mkdirs(otherSourceRoot, "demo");
+        File outputRoot = mkdirs(project, "target/classes");
+        File selectedSource = writeJavaSource(
+                selectedSourcePackage,
+                "Repro.java",
+                "package demo; public class Repro { static class Inner {} } " +
+                        "class SelectedOnly {}"
+        );
+        File otherSource = writeJavaSource(
+                otherSourcePackage,
+                "Repro.java",
+                "package demo; class OtherRootOnly {}"
+        );
+        compileJavaSources(outputRoot, selectedSource, otherSource);
+
+        File outputPackage = new File(outputRoot, "demo");
+        File reproClass = new File(outputPackage, "Repro.class");
+        File reproInnerClass = new File(outputPackage, "Repro$Inner.class");
+        assertTrue(new File(outputPackage, "SelectedOnly.class").isFile());
+        assertTrue(new File(outputPackage, "OtherRootOnly.class").isFile());
+
+        List<String> actual = new TargetResolver().resolveTargets(
+                new String[] { selectedSource.getAbsolutePath() },
+                Collections.singletonList(outputRoot),
+                listOf(
+                        selectedSourceRoot.getAbsolutePath(),
+                        otherSourceRoot.getAbsolutePath()
+                ),
+                null
+        );
+
+        assertEquals(sortedPaths(reproClass, reproInnerClass), sorted(actual));
+    }
+
+    @Test
     public void prefersLongestConfiguredSourcepathForJavaFile() throws Exception {
         File project = temporaryFolder.newFolder("project");
         File broadSourceRoot = mkdirs(project, "generated-sources");


### PR DESCRIPTION
## Summary

- Resolve all compiled classes produced by a selected Java source.
- Reject ambiguous source-file matches.

Closed without merge.