### PR TITLE
fix: cancel superseded analysis runs

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,12 @@
-import { ExtensionContext, languages, l10n, window, Uri, workspace } from 'vscode';
+import {
+  CancellationTokenSource,
+  ExtensionContext,
+  languages,
+  l10n,
+  window,
+  Uri,
+  workspace,
+} from 'vscode';
 import { SETTINGS_SECTION, settingKeys } from './constants/settings';
 import { SpotBugsTreeDataProvider } from './ui/spotbugsTreeDataProvider';
 import { PluginInventoryTreeDataProvider } from './ui/pluginInventoryTreeDataProvider';
@@ -71,7 +79,9 @@ async function doActivate(
     const spotbugsTreeDataProvider = new SpotBugsTreeDataProvider();
     const pluginInventoryTreeDataProvider = new PluginInventoryTreeDataProvider();
     const diagnosticsManager = new SpotBugsDiagnosticsManager();
-    const analysisRunCoordinator = new AnalysisRunCoordinator();
+    const analysisRunCoordinator = new AnalysisRunCoordinator(
+      () => new CancellationTokenSource()
+    );
     const findingDescriptionPanel = new FindingDescriptionPanel();
     const findingInspectorState = new FindingInspectorState();
     const findingInspectorViewProvider = new FindingInspectorViewProvider(

--- a/src/orchestration/analysisRunCoordinator.ts
+++ b/src/orchestration/analysisRunCoordinator.ts
@@ -1,20 +1,42 @@
+import type { CancellationToken, CancellationTokenSource } from 'vscode';
+
 export interface AnalysisRunLease {
+  readonly token?: CancellationToken;
   isCurrent(): boolean;
+  cancel(): void;
+}
+
+interface AnalysisCancellationState {
+  readonly source: CancellationTokenSource;
+  cancelled: boolean;
 }
 
 export class AnalysisRunCoordinator {
   private generation = 0;
   private disposed = false;
+  private currentCancellation?: AnalysisCancellationState;
+
+  public constructor(
+    private readonly createCancellationSource?: () => CancellationTokenSource
+  ) {}
 
   public begin(): AnalysisRunLease {
+    this.cancelCurrent();
     const generation = ++this.generation;
+    const source = this.disposed ? undefined : this.createCancellationSource?.();
+    const cancellation = source ? { source, cancelled: false } : undefined;
+    this.currentCancellation = cancellation;
+
     return {
+      token: source?.token,
       isCurrent: () => !this.disposed && generation === this.generation,
+      cancel: () => this.cancelSource(cancellation, false),
     };
   }
 
   public invalidate(): void {
     this.generation += 1;
+    this.cancelCurrent();
   }
 
   public dispose(): void {
@@ -23,5 +45,30 @@ export class AnalysisRunCoordinator {
     }
     this.disposed = true;
     this.invalidate();
+  }
+
+  private cancelCurrent(): void {
+    const cancellation = this.currentCancellation;
+    this.currentCancellation = undefined;
+    this.cancelSource(cancellation, true);
+  }
+
+  private cancelSource(
+    cancellation: AnalysisCancellationState | undefined,
+    dispose: boolean
+  ): void {
+    if (!cancellation) {
+      return;
+    }
+    try {
+      if (!cancellation.cancelled) {
+        cancellation.cancelled = true;
+        cancellation.source.cancel();
+      }
+    } finally {
+      if (dispose) {
+        cancellation.source.dispose();
+      }
+    }
   }
 }

--- a/src/orchestration/analysisRunSession.ts
+++ b/src/orchestration/analysisRunSession.ts
@@ -65,7 +65,11 @@ export interface WorkspaceProgressCallbacks {
 }
 
 export interface AnalysisSessionDependencies {
-  analyzeFileDetailed(config: Config, uri: Uri): Promise<AnalysisExecutionResult>;
+  analyzeFileDetailed(
+    config: Config,
+    uri: Uri,
+    token?: CancellationToken
+  ): Promise<AnalysisExecutionResult>;
   analyzeWorkspaceFromProjectsDetailed(
     config: Config,
     workspaceFolder: Uri,
@@ -113,7 +117,11 @@ export async function runFileAnalysisSession(
   args.tree.showLoading();
 
   try {
-    const result = await dependencies.analyzeFileDetailed(args.config, args.uri);
+    const result = await dependencies.analyzeFileDetailed(
+      args.config,
+      args.uri,
+      args.lease.token
+    );
     if (!args.lease.isCurrent()) {
       return;
     }

--- a/src/orchestration/analysisRunner.ts
+++ b/src/orchestration/analysisRunner.ts
@@ -89,7 +89,19 @@ export async function runWorkspaceAnalysis(
             title: l10n.t('SpotBugs: Analyzing workspace'),
             cancellable: true,
           },
-          task
+          async (progress, token) => {
+            const cancellationRegistration = token.onCancellationRequested(() =>
+              lease.cancel()
+            );
+            try {
+              if (token.isCancellationRequested) {
+                lease.cancel();
+              }
+              await task(progress, lease.token ?? token);
+            } finally {
+              cancellationRegistration.dispose();
+            }
+          }
         )
       ),
     dependencies,

--- a/src/services/analysisService.ts
+++ b/src/services/analysisService.ts
@@ -56,7 +56,8 @@ export interface WorkspaceExecutionResult {
 
 export async function analyzeFileDetailed(
   config: Config,
-  uri: Uri
+  uri: Uri,
+  token?: CancellationToken
 ): Promise<AnalysisExecutionResult> {
   const context = createExecutionContext();
 
@@ -83,7 +84,7 @@ export async function analyzeFileDetailed(
 
     try {
       return {
-        outcome: await runAnalysis(config, result.resolution.target),
+        outcome: await runAnalysis(config, result.resolution.target, token),
         context,
       };
     } catch (error) {

--- a/src/test/L0.analysisRunCoordinator.test.ts
+++ b/src/test/L0.analysisRunCoordinator.test.ts
@@ -1,19 +1,59 @@
 import * as assert from 'assert';
 import { AnalysisRunCoordinator } from '../orchestration/analysisRunCoordinator';
 
+function createCancellationFactory() {
+  const sources: Array<{
+    token: { isCancellationRequested: boolean };
+    cancelCalls: number;
+    disposeCalls: number;
+    cancel(): void;
+    dispose(): void;
+  }> = [];
+
+  return {
+    sources,
+    create: () => {
+      const source = {
+        token: { isCancellationRequested: false },
+        cancelCalls: 0,
+        disposeCalls: 0,
+        cancel() {
+          this.cancelCalls += 1;
+          this.token.isCancellationRequested = true;
+        },
+        dispose() {
+          this.disposeCalls += 1;
+        },
+      };
+      sources.push(source);
+      return source as any;
+    },
+  };
+}
+
 describe('AnalysisRunCoordinator', () => {
   it('makes the previous lease stale when a newer run begins', () => {
-    const coordinator = new AnalysisRunCoordinator();
+    const cancellation = createCancellationFactory();
+    const coordinator = new AnalysisRunCoordinator(cancellation.create);
     const older = coordinator.begin();
 
     const newer = coordinator.begin();
 
     assert.strictEqual(older.isCurrent(), false);
     assert.strictEqual(newer.isCurrent(), true);
+    assert.strictEqual(older.token?.isCancellationRequested, true);
+    assert.strictEqual(newer.token?.isCancellationRequested, false);
+    assert.strictEqual(cancellation.sources[0].cancelCalls, 1);
+    assert.strictEqual(cancellation.sources[0].disposeCalls, 1);
+
+    older.cancel();
+    assert.strictEqual(cancellation.sources[0].cancelCalls, 1);
+    assert.strictEqual(cancellation.sources[1].cancelCalls, 0);
   });
 
   it('invalidates the current lease explicitly and when disposed', () => {
-    const coordinator = new AnalysisRunCoordinator();
+    const cancellation = createCancellationFactory();
+    const coordinator = new AnalysisRunCoordinator(cancellation.create);
     const invalidated = coordinator.begin();
 
     coordinator.invalidate();
@@ -24,5 +64,15 @@ describe('AnalysisRunCoordinator', () => {
     assert.strictEqual(invalidated.isCurrent(), false);
     assert.strictEqual(disposed.isCurrent(), false);
     assert.strictEqual(afterDispose.isCurrent(), false);
+    assert.strictEqual(invalidated.token?.isCancellationRequested, true);
+    assert.strictEqual(disposed.token?.isCancellationRequested, true);
+    assert.strictEqual(afterDispose.token, undefined);
+    assert.deepStrictEqual(
+      cancellation.sources.map((source) => [source.cancelCalls, source.disposeCalls]),
+      [
+        [1, 1],
+        [1, 1],
+      ]
+    );
   });
 });

--- a/src/test/L0.analysisRunSession.test.ts
+++ b/src/test/L0.analysisRunSession.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import type { Uri } from 'vscode';
+import type { CancellationToken, Uri } from 'vscode';
 import {
   runFileAnalysisSession,
   runWorkspaceAnalysisSession,
@@ -21,8 +21,8 @@ import { installVscodeMock, resetVscodeMock } from './helpers/mockVscode';
 
 installVscodeMock();
 
-function createCurrentLease(): AnalysisRunLease {
-  return { isCurrent: () => true };
+function createCurrentLease(token?: CancellationToken): AnalysisRunLease {
+  return { token, isCurrent: () => true, cancel: () => undefined };
 }
 
 function createDeferred<T>() {
@@ -130,10 +130,14 @@ describe('analysisRunSession file analysis', () => {
     const config = { getAnalysisSettings: () => ({}) } as any;
     let receivedConfig: unknown;
     let receivedUri: unknown;
+    let receivedToken: unknown;
+    const token = { isCancellationRequested: false } as CancellationToken;
+    const lease = createCurrentLease(token);
     const deps = createBaseDependencies(vscode);
-    deps.analyzeFileDetailed = async (actualConfig, actualUri) => {
+    deps.analyzeFileDetailed = async (actualConfig, actualUri, actualToken) => {
       receivedConfig = actualConfig;
       receivedUri = actualUri;
+      receivedToken = actualToken;
       return {
         outcome: {
           findings: [finding],
@@ -170,12 +174,13 @@ describe('analysisRunSession file analysis', () => {
       },
       uri,
       startedAtMs: 1000,
-      lease: createCurrentLease(),
+      lease,
       dependencies: deps,
     });
 
     assert.strictEqual(receivedConfig, config);
     assert.strictEqual(receivedUri, uri);
+    assert.strictEqual(receivedToken, token);
     assert.deepStrictEqual(calls, [
       'loading',
       'results:1',

--- a/src/test/L1.analysisRunner.test.ts
+++ b/src/test/L1.analysisRunner.test.ts
@@ -268,7 +268,21 @@ describe('analysisRunner', () => {
   it('opens workspace progress with the current options and forwards token/progress', async () => {
     const vscode = installVscodeMock();
     const progress = { report: () => undefined };
-    const token = { isCancellationRequested: true };
+    let cancellationRegistrationDisposed = false;
+    let cancelProgress: () => void = () => undefined;
+    const token = {
+      isCancellationRequested: false,
+      onCancellationRequested: (listener: () => void) => {
+        cancelProgress = listener;
+        return {
+          dispose: () => {
+            cancellationRegistrationDisposed = true;
+          },
+        };
+      },
+    };
+    const leaseToken = { isCancellationRequested: false } as any;
+    let leaseCancelCalls = 0;
     const optionsSeen: unknown[] = [];
     const progressTokens: unknown[] = [];
     const commandCalls: unknown[][] = [];
@@ -308,6 +322,7 @@ describe('analysisRunner', () => {
         ) => Promise<void>;
       }).runWithProgress(async (progressArg, tokenArg) => {
         progressTokens.push(progressArg, tokenArg);
+        cancelProgress();
       });
     }) as typeof session.runWorkspaceAnalysisSession;
 
@@ -317,7 +332,14 @@ describe('analysisRunner', () => {
       const config = { getAnalysisSettings: () => ({}) } as any;
       const tree = createNoopTree();
       const diagnostics = createNoopDiagnostics();
-      const coordinator = new AnalysisRunCoordinator();
+      const coordinator = new AnalysisRunCoordinator(() => ({
+        token: leaseToken,
+        cancel: () => {
+          leaseCancelCalls += 1;
+          leaseToken.isCancellationRequested = true;
+        },
+        dispose: () => undefined,
+      }));
 
       await runner.runWorkspaceAnalysis({
         config,
@@ -345,7 +367,9 @@ describe('analysisRunner', () => {
       assert.strictEqual(delegatedArgs.tree, tree);
       assert.strictEqual(delegatedArgs.diagnostics, diagnostics);
       assert.strictEqual(delegatedArgs.notifier, notifierModule.defaultNotifier);
-      assert.deepStrictEqual(progressTokens, [progress, token]);
+      assert.deepStrictEqual(progressTokens, [progress, leaseToken]);
+      assert.strictEqual(leaseCancelCalls, 1);
+      assert.strictEqual(cancellationRegistrationDisposed, true);
     } finally {
       session.runWorkspaceAnalysisSession = originalRunWorkspaceAnalysisSession;
     }

--- a/src/test/L1.analysisService.test.ts
+++ b/src/test/L1.analysisService.test.ts
@@ -62,6 +62,8 @@ describe('analysisService', () => {
       require('../workspace/analysisTargetResolver') as typeof import('../workspace/analysisTargetResolver');
     const spotbugsClient =
       require('../lsp/spotbugsClient') as typeof import('../lsp/spotbugsClient');
+    const token = { isCancellationRequested: false } as any;
+    let receivedToken: unknown;
 
     resolverModule.resolveFileAnalysisTargetDetailed = (async () => ({
       resolution: {
@@ -77,15 +79,19 @@ describe('analysisService', () => {
       },
       issues: [],
     })) as typeof resolverModule.resolveFileAnalysisTargetDetailed;
-    spotbugsClient.runSpotBugsAnalysis = (async () =>
-      undefined) as typeof spotbugsClient.runSpotBugsAnalysis;
+    spotbugsClient.runSpotBugsAnalysis = (async (_request, actualToken) => {
+      receivedToken = actualToken;
+      return undefined;
+    }) as typeof spotbugsClient.runSpotBugsAnalysis;
 
     const service = require('../services/analysisService') as typeof import('../services/analysisService');
     const result = await service.analyzeFileDetailed(
       { getAnalysisSettings: () => ({ effort: 'default' }) } as any,
-      folderUri
+      folderUri,
+      token
     );
 
+    assert.strictEqual(receivedToken, token);
     assert.strictEqual(result.context.diagnosticScope?.kind, 'folder');
     assert.strictEqual(result.context.diagnosticScope?.uri.fsPath, folderUri.fsPath);
   });


### PR DESCRIPTION
## Summary

- Cancel an earlier analysis when a newer run starts.
- Stop superseded work from continuing across workspace projects.