### PR TITLE
perf: skip missing output fallback directories

### DIFF
--- a/src/test/L0.outputResolver.test.ts
+++ b/src/test/L0.outputResolver.test.ts
@@ -91,6 +91,22 @@ describe('outputResolver', () => {
     }
   });
 
+  it('skips target checks for missing output folders', async () => {
+    const dir = await makeTempDir();
+    try {
+      let checks = 0;
+      const found = await findOutputFolderFromProject(dir, async () => {
+        checks += 1;
+        return false;
+      });
+
+      assert.strictEqual(found, undefined);
+      assert.strictEqual(checks, 0);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
   it('finds default output folders with archive bytecode targets', async () => {
     const dir = await makeTempDir();
     try {

--- a/src/workspace/outputResolver.ts
+++ b/src/workspace/outputResolver.ts
@@ -79,11 +79,22 @@ export async function findOutputFolderFromProject(
     options
   );
   for (const candidate of candidates) {
+    if (!(await isDirectory(candidate.targetPath))) {
+      continue;
+    }
     if (await hasTargets(candidate.targetPath)) {
       return candidate.targetPath;
     }
   }
   return undefined;
+}
+
+async function isDirectory(targetPath: string): Promise<boolean> {
+  try {
+    return (await fs.promises.stat(targetPath)).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 export function orderOutputFolderCandidates<T extends OutputFolderCandidate>(


### PR DESCRIPTION
## Summary

- Check fallback output directories before scanning them.
- Skip missing paths to reduce unnecessary filesystem work.