### PR TITLE
fix: surface incomplete SpotBugs analysis

### DIFF
--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SpotBugsExecutor.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SpotBugsExecutor.java
@@ -33,6 +33,7 @@ import edu.umd.cs.findbugs.PluginLoader;
 import edu.umd.cs.findbugs.Priorities;
 import edu.umd.cs.findbugs.Project;
 import edu.umd.cs.findbugs.ProjectStats;
+import edu.umd.cs.findbugs.SortedBugCollection;
 import edu.umd.cs.findbugs.config.UserPreferences;
 import edu.umd.cs.findbugs.sarif.SarifBugReporter;
 
@@ -93,6 +94,7 @@ public class SpotBugsExecutor {
             AnalysisReportSummary reportSummary;
             String nativeSarif = null;
             CommandWarning sarifWarning = null;
+            boolean analysisIncomplete;
             try {
                 execute(defaultBugReporter, monitor);
                 try {
@@ -105,6 +107,9 @@ public class SpotBugsExecutor {
                 }
                 bugs = collectBugs(defaultBugReporter);
                 reportSummary = collectReportSummary(defaultBugReporter);
+                analysisIncomplete = !defaultBugReporter.getQueuedErrors().isEmpty()
+                        || ((SortedBugCollection) defaultBugReporter.getBugCollection())
+                                .missingClassIterator().hasNext();
             } catch (IOException | InterruptedException | RuntimeException | Error failure) {
                 loadedPlugins.closeAfterFailure(failure);
                 throw failure;
@@ -112,6 +117,12 @@ public class SpotBugsExecutor {
             List<CommandWarning> warnings = loadedPlugins.closeAfterSuccess();
             if (sarifWarning != null) {
                 warnings.add(sarifWarning);
+            }
+            if (analysisIncomplete) {
+                warnings.add(new CommandWarning(
+                        "ANALYSIS_INCOMPLETE",
+                        "SpotBugs analysis may be incomplete because classes were missing or recoverable errors occurred."
+                ));
             }
             return new SpotBugsAnalysisResult(bugs, warnings, reportSummary, nativeSarif);
         }

--- a/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/SpotBugsExecutorPluginLoadingTest.java
+++ b/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/SpotBugsExecutorPluginLoadingTest.java
@@ -29,6 +29,7 @@ import edu.umd.cs.findbugs.FindBugs2;
 import edu.umd.cs.findbugs.Plugin;
 import edu.umd.cs.findbugs.PluginException;
 import edu.umd.cs.findbugs.Project;
+import edu.umd.cs.findbugs.classfile.ClassDescriptor;
 
 public class SpotBugsExecutorPluginLoadingTest {
 
@@ -154,6 +155,26 @@ public class SpotBugsExecutorPluginLoadingTest {
         assertTrue(warnings.get(0).getMessage().contains("close failed"));
         assertNull("Plugin should not remain globally registered after close warning", Plugin.getByPluginId(FINDSECBUGS_PLUGIN_ID));
 
+    }
+
+    @Test
+    public void missingClassesReturnIncompleteWarning() throws Exception {
+        SpotBugsAnalysisResult result = new SpotBugsExecutor(
+                new FindBugs2() {
+                    @Override
+                    public void execute() {
+                        getBugReporter().reportMissingClass(
+                                ClassDescriptor.createClassDescriptor("com/example/MissingDependency")
+                        );
+                    }
+                },
+                new Project(),
+                3,
+                Collections.emptyList()
+        ).executeBugsWithWarnings();
+
+        assertEquals(1, result.getWarnings().size());
+        assertEquals("ANALYSIS_INCOMPLETE", result.getWarnings().get(0).getCode());
     }
 
     @Test

--- a/src/orchestration/analysisNotices.ts
+++ b/src/orchestration/analysisNotices.ts
@@ -50,7 +50,7 @@ export function buildAnalysisNotices(
   ) {
     notices.push({
       level: 'warn',
-      message: `SpotBugs analysis completed with cleanup warnings: ${formatAnalysisErrors(
+      message: `SpotBugs analysis completed with warnings: ${formatAnalysisErrors(
         outcome.warnings
       )}`,
     });

--- a/src/orchestration/workspaceSummary.ts
+++ b/src/orchestration/workspaceSummary.ts
@@ -22,6 +22,9 @@ export function buildWorkspaceCompletionNotices(
     (projectResults.length > 0 && skippedCount === projectResults.length) ||
     (failedCount > 0 && succeededCount === 0);
   const cleanupWarningSentence = buildCleanupWarningSentence(cleanupWarnings);
+  const hasIncompleteAnalysisWarnings = cleanupWarnings.some(
+    ({ warning }) => warning.code === 'ANALYSIS_INCOMPLETE'
+  );
   const notices: AnalysisNotice[] = [];
 
   if (projectResults.length > 0 && skippedCount === projectResults.length) {
@@ -78,7 +81,9 @@ export function buildWorkspaceCompletionNotices(
       level: cleanupWarningSentence.length > 0 && skippedCount === 0 ? 'warn' : 'info',
       message:
         (findingCount === 0
-          ? 'SpotBugs: Workspace analysis completed - No issues found.'
+          ? hasIncompleteAnalysisWarnings
+            ? 'SpotBugs: Workspace analysis completed - No findings reported.'
+            : 'SpotBugs: Workspace analysis completed - No issues found.'
           : `SpotBugs: Workspace analysis completed - ${formatIssueCount(findingCount)} found.`) +
         (skippedCount === 0 ? cleanupWarningSentence : ''),
     });
@@ -109,7 +114,7 @@ function buildCleanupWarningSentence(
   if (uniqueProjectCount === 0) {
     return '';
   }
-  return ` Cleanup warnings occurred in ${formatProjectCount(uniqueProjectCount)}; see the SpotBugs output for details.`;
+  return ` ${formatProjectCount(uniqueProjectCount)} reported warnings; see the SpotBugs output for details.`;
 }
 
 function dedupeNotices(notices: AnalysisNotice[]): AnalysisNotice[] {

--- a/src/test/L0.analysisNotices.test.ts
+++ b/src/test/L0.analysisNotices.test.ts
@@ -336,7 +336,7 @@ describe('analysisNotices', () => {
         (notice) =>
           notice.level === 'warn' &&
           notice.message ===
-            'SpotBugs analysis completed with cleanup warnings: [PLUGIN_CLEANUP_FAILED] Could not delete plugin jar'
+            'SpotBugs analysis completed with warnings: [PLUGIN_CLEANUP_FAILED] Could not delete plugin jar'
       )
     );
     assert.ok(

--- a/src/test/L0.analysisRunSession.test.ts
+++ b/src/test/L0.analysisRunSession.test.ts
@@ -295,7 +295,7 @@ describe('analysisRunSession file analysis', () => {
 
     assert.deepStrictEqual(calls, ['loading', 'results:0', 'diagnostics:0']);
     assert.deepStrictEqual(warnings, [
-      'SpotBugs analysis completed with cleanup warnings: [PLUGIN_CLEANUP_FAILED] Could not delete plugin jar',
+      'SpotBugs analysis completed with warnings: [PLUGIN_CLEANUP_FAILED] Could not delete plugin jar',
     ]);
     assert.deepStrictEqual(errors, []);
   });
@@ -666,7 +666,7 @@ describe('analysisRunSession workspace analysis', () => {
     ]);
     assert.deepStrictEqual(harness.workspaceResults, [[projectResult]]);
     assert.deepStrictEqual(harness.warnings, [
-      'SpotBugs: Workspace analysis completed - No issues found. Cleanup warnings occurred in 1 project; see the SpotBugs output for details.',
+      'SpotBugs: Workspace analysis completed - No issues found. 1 project reported warnings; see the SpotBugs output for details.',
     ]);
     assert.deepStrictEqual(harness.errors, []);
   });

--- a/src/test/L0.workspaceSummary.test.ts
+++ b/src/test/L0.workspaceSummary.test.ts
@@ -131,7 +131,7 @@ describe('workspaceSummary', () => {
     ]);
   });
 
-  it('returns a warning completion notice when cleanup warnings are the only non-success condition', () => {
+  it('does not report a clean workspace when analysis is incomplete', () => {
     const notices = buildWorkspaceCompletionNotices(
       [makeProjectResult()],
       0,
@@ -140,8 +140,8 @@ describe('workspaceSummary', () => {
         {
           projectUri: 'file:///workspace/project-a',
           warning: {
-            code: 'PLUGIN_CLEANUP_FAILED',
-            message: 'Could not delete plugin jar',
+            code: 'ANALYSIS_INCOMPLETE',
+            message: 'Some checks may have been skipped.',
           },
         },
       ]
@@ -151,7 +151,7 @@ describe('workspaceSummary', () => {
       {
         level: 'warn',
         message:
-          'SpotBugs: Workspace analysis completed - No issues found. Cleanup warnings occurred in 1 project; see the SpotBugs output for details.',
+          'SpotBugs: Workspace analysis completed - No findings reported. 1 project reported warnings; see the SpotBugs output for details.',
       },
     ]);
   });


### PR DESCRIPTION
## Summary

- Detect missing classes and recoverable SpotBugs errors as incomplete analysis.
- Surface a warning instead of reporting a clean no-findings result.