### PR TITLE
feat: export native SpotBugs SARIF reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Analyze Java code with SpotBugs directly in VS Code. View findings in a dedicate
 - Analyze a single file or an entire workspace (Maven/Gradle projects)
 - Group findings by category and pattern with severity icons
 - Navigate to bug locations in source files with matching diagnostics/squiggles
-- Export filtered findings to SARIF for code scanning tools
+- Export filtered findings in SpotBugs' native SARIF format for code scanning tools
 
 ## Requirements
 
@@ -33,7 +33,7 @@ Analyze Java code with SpotBugs directly in VS Code. View findings in a dedicate
 
 ## Privacy / Local Analysis
 
-SpotBugs analysis runs locally in your VS Code workspace. This extension does not send source files, compiled classes, filter files, SARIF output, or SpotBugs findings to a hosted analysis service.
+SpotBugs analysis runs locally in your VS Code workspace. This extension does not send source files, compiled classes, filter files, SARIF output, or SpotBugs findings to a hosted analysis service. Native SARIF reports can contain local source-root URIs, so review them before sharing.
 
 Rule documentation actions may open external SpotBugs documentation links. Basic extension operation telemetry follows VS Code telemetry settings.
 
@@ -49,7 +49,7 @@ Rule documentation actions may open external SpotBugs documentation links. Basic
 
 - `SpotBugs: Analyze File/Folder` — Analyze selected file or folder
 - `SpotBugs: Analyze this workspace` — Build then analyze all projects in the workspace
-- `SpotBugs: Export SpotBugs Findings (SARIF)` — Save current findings to a SARIF report
+- `SpotBugs: Export SpotBugs Findings (SARIF)` — Save current findings in SpotBugs' native SARIF format
 - `SpotBugs: Reset SpotBugs Results` — Clear the SpotBugs view and diagnostics
 
 ## Settings

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/api/CommandResponse.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/api/CommandResponse.java
@@ -12,13 +12,15 @@ public class CommandResponse {
     private final List<CommandWarning> warnings;
     private final RunAnalysisSummary stats;
     private final AnalysisReportSummary reportSummary;
+    private final String nativeSarif;
 
     private CommandResponse(
             Object results,
             List<CommandError> errors,
             List<CommandWarning> warnings,
             RunAnalysisSummary stats,
-            AnalysisReportSummary reportSummary
+            AnalysisReportSummary reportSummary,
+            String nativeSarif
     ) {
         this.schemaVersion = SCHEMA_VERSION;
         this.results = results != null ? results : Collections.emptyList();
@@ -26,14 +28,15 @@ public class CommandResponse {
         this.warnings = warnings != null && !warnings.isEmpty() ? warnings : null;
         this.stats = stats;
         this.reportSummary = reportSummary;
+        this.nativeSarif = nativeSarif;
     }
 
     public static CommandResponse success(Object results, RunAnalysisSummary stats) {
-        return new CommandResponse(results, Collections.emptyList(), null, stats, null);
+        return new CommandResponse(results, Collections.emptyList(), null, stats, null, null);
     }
 
     public static CommandResponse success(Object results, RunAnalysisSummary stats, List<CommandWarning> warnings) {
-        return new CommandResponse(results, Collections.emptyList(), warnings, stats, null);
+        return new CommandResponse(results, Collections.emptyList(), warnings, stats, null, null);
     }
 
     public static CommandResponse success(
@@ -42,7 +45,17 @@ public class CommandResponse {
             AnalysisReportSummary reportSummary,
             List<CommandWarning> warnings
     ) {
-        return new CommandResponse(results, Collections.emptyList(), warnings, stats, reportSummary);
+        return new CommandResponse(results, Collections.emptyList(), warnings, stats, reportSummary, null);
+    }
+
+    public static CommandResponse success(
+            Object results,
+            RunAnalysisSummary stats,
+            AnalysisReportSummary reportSummary,
+            List<CommandWarning> warnings,
+            String nativeSarif
+    ) {
+        return new CommandResponse(results, Collections.emptyList(), warnings, stats, reportSummary, nativeSarif);
     }
 
     public static CommandResponse error(String code, String message) {
@@ -51,7 +64,7 @@ public class CommandResponse {
 
     public static CommandResponse error(String code, String message, RunAnalysisSummary stats) {
         CommandError error = new CommandError(code, message);
-        return new CommandResponse(Collections.emptyList(), Collections.singletonList(error), null, stats, null);
+        return new CommandResponse(Collections.emptyList(), Collections.singletonList(error), null, stats, null, null);
     }
 
     public int getSchemaVersion() {
@@ -76,5 +89,9 @@ public class CommandResponse {
 
     public AnalysisReportSummary getReportSummary() {
         return reportSummary;
+    }
+
+    public String getNativeSarif() {
+        return nativeSarif;
     }
 }

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/AnalyzerService.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/AnalyzerService.java
@@ -84,7 +84,12 @@ public class AnalyzerService {
         checkCanceled(monitor);
         List<BugInfo> bugs = result.getBugs();
         applyFullPaths(bugs, monitor, filePaths);
-        return new SpotBugsAnalysisResult(bugs, result.getWarnings(), result.getReportSummary());
+        return new SpotBugsAnalysisResult(
+                bugs,
+                result.getWarnings(),
+                result.getReportSummary(),
+                result.getNativeSarif()
+        );
     }
 
     public String analyzeToNativeSarif(String... filePaths) {
@@ -125,6 +130,7 @@ public class AnalyzerService {
         List<String> sourcepaths = this.config != null
                 ? this.config.getSourcepaths()
                 : java.util.Collections.emptyList();
+        project.addSourceDirs(sourcepaths);
         this.lastTargetResolutionRootCount = targetResolutionRootDirs.size();
         TargetResolver resolver = new TargetResolver();
         List<String> targets = resolver.resolveTargets(filePaths, targetResolutionRootDirs, sourcepaths, monitor);

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/DeferredSarifBugReporter.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/DeferredSarifBugReporter.java
@@ -1,0 +1,32 @@
+package com.spotbugs.vscode.runner.internal;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import edu.umd.cs.findbugs.Project;
+import edu.umd.cs.findbugs.sarif.SarifBugReporter;
+
+final class DeferredSarifBugReporter extends SarifBugReporter {
+
+    DeferredSarifBugReporter(Project project) {
+        super(project);
+    }
+
+    @Override
+    public void finish() {
+        // FindBugs2 calls finish inside the analysis. Defer serialization so a
+        // report-only failure cannot discard otherwise valid findings.
+    }
+
+    String writeSarif() {
+        StringWriter writer = new StringWriter();
+        setWriter(new PrintWriter(writer));
+        try {
+            super.finish();
+            return writer.toString();
+        } finally {
+            // SarifBugReporter skips this when serialization throws.
+            getBugCollection().bugsPopulated();
+        }
+    }
+}

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SpotBugsAnalysisResult.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SpotBugsAnalysisResult.java
@@ -13,9 +13,10 @@ public class SpotBugsAnalysisResult {
     private final List<BugInfo> bugs;
     private final List<CommandWarning> warnings;
     private final AnalysisReportSummary reportSummary;
+    private final String nativeSarif;
 
     public SpotBugsAnalysisResult(List<BugInfo> bugs, List<CommandWarning> warnings) {
-        this(bugs, warnings, null);
+        this(bugs, warnings, null, null);
     }
 
     public SpotBugsAnalysisResult(
@@ -23,9 +24,19 @@ public class SpotBugsAnalysisResult {
             List<CommandWarning> warnings,
             AnalysisReportSummary reportSummary
     ) {
+        this(bugs, warnings, reportSummary, null);
+    }
+
+    public SpotBugsAnalysisResult(
+            List<BugInfo> bugs,
+            List<CommandWarning> warnings,
+            AnalysisReportSummary reportSummary,
+            String nativeSarif
+    ) {
         this.bugs = normalize(bugs);
         this.warnings = normalize(warnings);
         this.reportSummary = reportSummary;
+        this.nativeSarif = nativeSarif;
     }
 
     public List<BugInfo> getBugs() {
@@ -38,6 +49,10 @@ public class SpotBugsAnalysisResult {
 
     public AnalysisReportSummary getReportSummary() {
         return reportSummary;
+    }
+
+    public String getNativeSarif() {
+        return nativeSarif;
     }
 
     public static SpotBugsAnalysisResult empty() {

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SpotBugsExecutor.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/SpotBugsExecutor.java
@@ -42,7 +42,7 @@ public class SpotBugsExecutor {
 
     private final FindBugs2 findBugs;
     private final Project project;
-    private final BugCollectionBugReporter defaultBugReporter;
+    private final DeferredSarifBugReporter defaultBugReporter;
     private final int effectivePriorityThreshold;
     private final int effectiveRankThreshold;
     private final List<String> pluginJars; // optional
@@ -61,7 +61,7 @@ public class SpotBugsExecutor {
     ) {
         this.findBugs = findBugs;
         this.project = project;
-        this.defaultBugReporter = new BugCollectionBugReporter(project);
+        this.defaultBugReporter = new DeferredSarifBugReporter(project);
         this.effectivePriorityThreshold = rankThreshold == null
                 ? Priorities.HIGH_PRIORITY
                 : Priorities.LOW_PRIORITY;
@@ -91,8 +91,18 @@ public class SpotBugsExecutor {
             LoadedPlugins loadedPlugins = LoadedPlugins.load(pluginJars, project, pluginLifecycle);
             List<BugInfo> bugs;
             AnalysisReportSummary reportSummary;
+            String nativeSarif = null;
+            CommandWarning sarifWarning = null;
             try {
                 execute(defaultBugReporter, monitor);
+                try {
+                    nativeSarif = defaultBugReporter.writeSarif();
+                } catch (RuntimeException | LinkageError e) {
+                    sarifWarning = new CommandWarning(
+                            "SARIF_REPORT_UNAVAILABLE",
+                            "Failed to generate the native SpotBugs SARIF report: " + failureMessage(e)
+                    );
+                }
                 bugs = collectBugs(defaultBugReporter);
                 reportSummary = collectReportSummary(defaultBugReporter);
             } catch (IOException | InterruptedException | RuntimeException | Error failure) {
@@ -100,7 +110,10 @@ public class SpotBugsExecutor {
                 throw failure;
             }
             List<CommandWarning> warnings = loadedPlugins.closeAfterSuccess();
-            return new SpotBugsAnalysisResult(bugs, warnings, reportSummary);
+            if (sarifWarning != null) {
+                warnings.add(sarifWarning);
+            }
+            return new SpotBugsAnalysisResult(bugs, warnings, reportSummary, nativeSarif);
         }
     }
 
@@ -223,6 +236,13 @@ public class SpotBugsExecutor {
                 stats.getNumClasses(),
                 stats.getPackageStats().size()
         );
+    }
+
+    private static String failureMessage(Throwable failure) {
+        String message = failure.getMessage();
+        return message != null && !message.trim().isEmpty()
+                ? message.trim()
+                : failure.getClass().getSimpleName();
     }
 
     private static final class LoadedPlugins {

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/AnalysisPipelineResult.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/AnalysisPipelineResult.java
@@ -70,6 +70,10 @@ final class AnalysisPipelineResult {
         return result.getReportSummary();
     }
 
+    String getNativeSarif() {
+        return result.getNativeSarif();
+    }
+
     int getFindingCount() {
         return getResults().size();
     }

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisAction.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisAction.java
@@ -88,7 +88,8 @@ public final class RunAnalysisAction extends AbstractCommandAction {
                 pipelineResult.getResults(),
                 stats,
                 pipelineResult.getReportSummary(),
-                pipelineResult.getWarnings()
+                pipelineResult.getWarnings(),
+                pipelineResult.getNativeSarif()
         ));
     }
 

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/dev/NativeSarifFixtureCli.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/dev/NativeSarifFixtureCli.java
@@ -10,6 +10,7 @@ import com.spotbugs.vscode.runner.api.BugInfo;
 import com.spotbugs.vscode.runner.api.ConfigError;
 import com.spotbugs.vscode.runner.api.ConfigSchema;
 import com.spotbugs.vscode.runner.internal.AnalyzerService;
+import com.spotbugs.vscode.runner.internal.SpotBugsAnalysisResult;
 import com.spotbugs.vscode.runner.internal.config.AnalysisConfig;
 import com.spotbugs.vscode.runner.internal.config.ConfigParseResult;
 import com.spotbugs.vscode.runner.internal.config.ConfigParser;
@@ -36,13 +37,11 @@ public final class NativeSarifFixtureCli {
                 : "{}";
         AnalysisConfig config = parseAndValidateConfig(configJson);
 
-        AnalyzerService bugAnalyzer = new AnalyzerService();
-        bugAnalyzer.setConfiguration(config);
-        List<BugInfo> bugs = bugAnalyzer.analyzeToBugs(targetPath);
-
-        AnalyzerService sarifAnalyzer = new AnalyzerService();
-        sarifAnalyzer.setConfiguration(config);
-        String nativeSarif = sarifAnalyzer.analyzeToNativeSarif(targetPath);
+        AnalyzerService analyzer = new AnalyzerService();
+        analyzer.setConfiguration(config);
+        SpotBugsAnalysisResult result = analyzer.analyzeToBugsWithWarnings(null, targetPath);
+        List<BugInfo> bugs = result.getBugs();
+        String nativeSarif = result.getNativeSarif();
         if (nativeSarif == null || nativeSarif.trim().isEmpty()) {
             throw new IllegalStateException("SpotBugs native SARIF generation returned no output.");
         }

--- a/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/AnalyzerServiceRankThresholdTest.java
+++ b/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/AnalyzerServiceRankThresholdTest.java
@@ -80,24 +80,38 @@ public class AnalyzerServiceRankThresholdTest {
 
     private void assertNativeSarifPresence(Integer threshold, boolean expected) throws Exception {
         AnalyzerService analyzer = configuredAnalyzer(threshold);
-        String sarif = analyzer.analyzeToNativeSarif((IProgressMonitor) null, fixtureClassPath());
+        SpotBugsAnalysisResult analysis = analyzer.analyzeToBugsWithWarnings(null, fixtureClassPath());
+        String sarif = analysis.getNativeSarif();
         assertNotNull(message("native SARIF", threshold), sarif);
         assertFalse(message("native SARIF", threshold), sarif.trim().isEmpty());
 
-        JsonArray results = JsonParser.parseString(sarif)
+        JsonObject run = JsonParser.parseString(sarif)
                 .getAsJsonObject()
                 .getAsJsonArray("runs")
                 .get(0)
-                .getAsJsonObject()
-                .getAsJsonArray("results");
+                .getAsJsonObject();
+        JsonArray results = run.getAsJsonArray("results");
+        assertEquals(analysis.getBugs().size(), results.size());
         int count = 0;
-        for (JsonElement element : results) {
+        for (int index = 0; index < results.size(); index++) {
+            JsonElement element = results.get(index);
             JsonObject result = element.getAsJsonObject();
+            assertEquals(analysis.getBugs().get(index).getType(), result.get("ruleId").getAsString());
             if (BUG_TYPE.equals(result.get("ruleId").getAsString())) {
                 count++;
             }
         }
         assertEquals(message("native SARIF", threshold), expected ? 1 : 0, count);
+        if (expected) {
+            JsonObject artifact = results.get(0).getAsJsonObject()
+                    .getAsJsonArray("locations").get(0).getAsJsonObject()
+                    .getAsJsonObject("physicalLocation")
+                    .getAsJsonObject("artifactLocation");
+            String baseId = artifact.get("uriBaseId").getAsString();
+            String baseUri = run.getAsJsonObject("originalUriBaseIds")
+                    .getAsJsonObject(baseId).get("uri").getAsString();
+            assertEquals(fixtureSourceRoot().toURI().toString(), baseUri);
+        }
     }
 
     private List<BugInfo> analyzeBugs(Integer threshold) throws Exception {
@@ -111,13 +125,23 @@ public class AnalyzerServiceRankThresholdTest {
     }
 
     private AnalysisConfig config(Integer threshold) {
-        String json = threshold == null ? "{}" : "{\"priorityThreshold\":" + threshold + "}";
-        ConfigParseResult parsed = new ConfigParser().parse(json);
+        JsonObject json = new JsonObject();
+        if (threshold != null) {
+            json.addProperty("priorityThreshold", threshold);
+        }
+        JsonArray sourcepaths = new JsonArray();
+        sourcepaths.add(fixtureSourceRoot().getAbsolutePath());
+        json.add("sourcepaths", sourcepaths);
+        ConfigParseResult parsed = new ConfigParser().parse(json.toString());
         assertFalse(parsed.hasError());
 
         ConfigValidationResult validated = new ConfigValidator().validate(parsed.getSchema());
         assertFalse(validated.hasError());
         return validated.getConfig();
+    }
+
+    private File fixtureSourceRoot() {
+        return new File(System.getProperty("basedir"), "src/test/java").getAbsoluteFile();
     }
 
     private BugInfo onlyFixtureBug(List<BugInfo> bugs) {

--- a/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisActionTest.java
+++ b/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisActionTest.java
@@ -59,7 +59,12 @@ public class RunAnalysisActionTest {
         RunAnalysisAction action = new RunAnalysisAction(() -> new AnalyzerService() {
             @Override
             public SpotBugsAnalysisResult analyzeToBugsWithWarnings(IProgressMonitor monitor, String... filePaths) {
-                return result(Collections.nCopies(2, (BugInfo) null));
+                return new SpotBugsAnalysisResult(
+                        Collections.nCopies(2, (BugInfo) null),
+                        Collections.emptyList(),
+                        null,
+                        "{\"version\":\"2.1.0\",\"runs\":[]}"
+                );
             }
         });
 
@@ -69,6 +74,8 @@ public class RunAnalysisActionTest {
         assertEquals(0, response.getAsJsonArray("errors").size());
         assertEquals(2, response.getAsJsonArray("results").size());
         assertEquals(2, response.getAsJsonObject("stats").get("findingCount").getAsInt());
+        assertEquals("2.1.0", JsonParser.parseString(response.get("nativeSarif").getAsString())
+                .getAsJsonObject().get("version").getAsString());
     }
 
     @Test

--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -105,6 +105,7 @@
   "{0} finding": "{0} finding",
   "{0} findings": "{0} findings",
   "No SpotBugs findings available to export.": "No SpotBugs findings available to export.",
+  "Native SpotBugs SARIF is unavailable. Reload the Java language server and run the analysis again.": "Native SpotBugs SARIF is unavailable. Reload the Java language server and run the analysis again.",
   "Export SARIF": "Export SARIF",
   "Export HTML": "Export HTML",
   "SpotBugs exported {0} finding to {1}": "SpotBugs exported {0} finding to {1}",

--- a/l10n/bundle.l10n.ko.json
+++ b/l10n/bundle.l10n.ko.json
@@ -36,6 +36,7 @@
   "No local SpotBugs description is available for this finding.": "이 발견 항목에 사용할 수 있는 로컬 SpotBugs 설명이 없습니다.",
   "No SpotBugs finding is currently selected.": "현재 선택된 SpotBugs 발견 항목이 없습니다.",
   "No SpotBugs findings available to export.": "내보낼 SpotBugs 발견 항목이 없습니다.",
+  "Native SpotBugs SARIF is unavailable. Reload the Java language server and run the analysis again.": "SpotBugs native SARIF를 사용할 수 없습니다. Java 언어 서버를 다시 로드한 후 분석을 다시 실행하세요.",
   "No SpotBugs rule documentation is available.": "사용 가능한 SpotBugs 규칙 문서가 없습니다.",
   "No cached SpotBugs findings available to clear search.": "검색을 지울 캐시된 SpotBugs 발견 항목이 없습니다.",
   "No cached SpotBugs findings available to filter.": "필터링할 캐시된 SpotBugs 발견 항목이 없습니다.",

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -1,6 +1,6 @@
 import { l10n, window, workspace, Uri } from 'vscode';
 import { SpotBugsTreeDataProvider } from '../ui/spotbugsTreeDataProvider';
-import { buildSarifLog } from '../services/sarifExporter';
+import { buildNativeSarifLog } from '../services/nativeSarifExporter';
 import { Logger } from '../core/logger';
 import * as path from 'path';
 import { resolveSpotBugsSelection } from '../ui/selection';
@@ -14,9 +14,33 @@ export async function exportSarifReport(
   element: unknown
 ): Promise<void> {
   const findings = resolveSpotBugsSelection(provider, element);
+  const reportRuns = provider.getReportRuns();
   if (findings.length === 0) {
-    await window.showInformationMessage(
-      l10n.t('No SpotBugs findings available to export.')
+    if (
+      element !== undefined ||
+      provider.getCachedFindings().length > 0 ||
+      !reportRuns.some((run) => !run.analysisStatus)
+    ) {
+      await window.showInformationMessage(
+        l10n.t('No SpotBugs findings available to export.')
+      );
+      return;
+    }
+  }
+
+  let sarifLog;
+  try {
+    sarifLog = buildNativeSarifLog(
+      reportRuns,
+      findings,
+      element === undefined
+    );
+  } catch (error) {
+    Logger.error('Native SpotBugs SARIF is unavailable', error);
+    await window.showErrorMessage(
+      l10n.t(
+        'Native SpotBugs SARIF is unavailable. Reload the Java language server and run the analysis again.'
+      )
     );
     return;
   }
@@ -33,14 +57,6 @@ export async function exportSarifReport(
   }
 
   try {
-    const workspaceRootPaths = workspace.workspaceFolders?.map(
-      (folder) => folder.uri.fsPath
-    );
-    const sarifLog = buildSarifLog(findings, {
-      runName: getWorkspaceName(),
-      workspaceRootPath: workspaceRootPaths?.[0],
-      workspaceRootPaths,
-    });
     const sarifJson = JSON.stringify(sarifLog, null, 2);
     await workspace.fs.writeFile(saveUri, Buffer.from(sarifJson, 'utf8'));
     Logger.log(

--- a/src/lsp/spotbugsParser.ts
+++ b/src/lsp/spotbugsParser.ts
@@ -21,6 +21,7 @@ export interface ParsedAnalysis {
   ignoredMalformedWarnings?: boolean;
   stats?: AnalysisStats;
   reportSummary?: AnalysisReportSummary;
+  nativeSarif?: string;
   schemaVersion?: number;
 }
 
@@ -88,6 +89,10 @@ export function parseAnalysisResponse(raw: string): ParseResult {
     const bugs = hasResults ? (envelope.results as Bug[]) : [];
     const stats = normalizeAnalysisStats(envelope.stats);
     const reportSummary = normalizeAnalysisReportSummary(envelope.reportSummary);
+    const nativeSarif =
+      typeof envelope.nativeSarif === 'string' && envelope.nativeSarif.trim().length > 0
+        ? envelope.nativeSarif
+        : undefined;
     const schemaVersion =
       typeof envelope.schemaVersion === 'number' ? envelope.schemaVersion : undefined;
     return {
@@ -99,6 +104,7 @@ export function parseAnalysisResponse(raw: string): ParseResult {
         ignoredMalformedWarnings,
         stats,
         reportSummary,
+        nativeSarif,
         schemaVersion,
       },
     };

--- a/src/model/analysisOutcome.ts
+++ b/src/model/analysisOutcome.ts
@@ -25,6 +25,7 @@ export interface AnalysisOutcome {
   warnings?: AnalysisWarning[];
   stats?: AnalysisStats;
   reportSummary?: AnalysisReportSummary;
+  nativeSarif?: string;
   targetPath?: string;
   schemaVersion?: number;
   failure?: AnalysisFailure;

--- a/src/model/analysisProtocol.ts
+++ b/src/model/analysisProtocol.ts
@@ -51,4 +51,5 @@ export interface AnalysisResponse<TBug = Bug> {
   warnings?: AnalysisWarning[];
   stats?: AnalysisStats;
   reportSummary?: AnalysisReportSummary;
+  nativeSarif?: string;
 }

--- a/src/model/analysisReport.ts
+++ b/src/model/analysisReport.ts
@@ -12,4 +12,5 @@ export interface AnalysisReportRun {
   analysisStatus?: 'failed' | 'skipped';
   spotbugsVersion?: string;
   summary?: AnalysisReportSummary;
+  nativeSarif?: string;
 }

--- a/src/orchestration/analysisRunSession.ts
+++ b/src/orchestration/analysisRunSession.ts
@@ -137,6 +137,7 @@ export async function runFileAnalysisSession(
         findings,
         spotbugsVersion: outcome.stats?.spotbugsVersion,
         summary: outcome.reportSummary,
+        nativeSarif: outcome.nativeSarif,
       });
       args.diagnostics.replaceForScope(
         result.context.diagnosticScope ?? { kind: 'file', uri: args.uri },

--- a/src/services/analysisExecution.ts
+++ b/src/services/analysisExecution.ts
@@ -228,6 +228,7 @@ export function createAnalysisExecutor(overrides: Partial<AnalysisExecutorDeps> 
       ignoredMalformedWarnings,
       stats,
       reportSummary,
+      nativeSarif,
       schemaVersion,
     } = parsed;
     const hasErrors = Array.isArray(errors) && errors.length > 0;
@@ -285,6 +286,7 @@ export function createAnalysisExecutor(overrides: Partial<AnalysisExecutorDeps> 
       findings: withFullPaths,
       stats,
       reportSummary,
+      nativeSarif,
       targetPath,
       schemaVersion,
     };

--- a/src/services/nativeSarifExporter.ts
+++ b/src/services/nativeSarifExporter.ts
@@ -37,6 +37,9 @@ export function buildNativeSarifLog(
     if (selectedIndices.length === 0 && !includeEmptyRun) {
       continue;
     }
+    if (includeEmptyRun && !reportRun.nativeSarif) {
+      continue;
+    }
 
     const parsed = parseNativeSarif(reportRun.nativeSarif);
     validateAlignment(reportRun, parsed.runs[0]);

--- a/src/services/nativeSarifExporter.ts
+++ b/src/services/nativeSarifExporter.ts
@@ -1,0 +1,99 @@
+import type { AnalysisReportRun } from '../model/analysisReport';
+import type { Finding } from '../model/finding';
+
+interface NativeSarifLog extends Record<string, unknown> {
+  version: string;
+  runs: NativeSarifRun[];
+}
+
+interface NativeSarifRun extends Record<string, unknown> {
+  results: NativeSarifResult[];
+}
+
+interface NativeSarifResult extends Record<string, unknown> {
+  ruleId?: unknown;
+}
+
+export function buildNativeSarifLog(
+  reportRuns: AnalysisReportRun[],
+  selectedFindings: Finding[],
+  includeOriginallyEmptyRuns = false
+): NativeSarifLog {
+  const selected = new Set(selectedFindings);
+  const nativeRuns: NativeSarifRun[] = [];
+  let root: NativeSarifLog | undefined;
+  let matchedFindings = 0;
+
+  for (const reportRun of reportRuns) {
+    if (reportRun.analysisStatus) {
+      continue;
+    }
+
+    const selectedIndices = reportRun.findings
+      .map((finding, index) => (selected.has(finding) ? index : -1))
+      .filter((index) => index >= 0);
+    const includeEmptyRun =
+      includeOriginallyEmptyRuns && reportRun.findings.length === 0;
+    if (selectedIndices.length === 0 && !includeEmptyRun) {
+      continue;
+    }
+
+    const parsed = parseNativeSarif(reportRun.nativeSarif);
+    validateAlignment(reportRun, parsed.runs[0]);
+    root ??= parsed;
+    nativeRuns.push({
+      ...parsed.runs[0],
+      results: selectedIndices.map((index) => parsed.runs[0].results[index]),
+    });
+    matchedFindings += selectedIndices.length;
+  }
+
+  if (!root || matchedFindings !== selected.size) {
+    throw new Error('Native SpotBugs SARIF does not match the selected findings.');
+  }
+
+  return { ...root, runs: nativeRuns };
+}
+
+function parseNativeSarif(value: string | undefined): NativeSarifLog {
+  if (!value) {
+    throw new Error('Native SpotBugs SARIF is not available for this analysis.');
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch (cause) {
+    throw new Error('Native SpotBugs SARIF is malformed.', { cause });
+  }
+  if (
+    !isRecord(parsed) ||
+    parsed.version !== '2.1.0' ||
+    !Array.isArray(parsed.runs) ||
+    parsed.runs.length !== 1 ||
+    !isRecord(parsed.runs[0]) ||
+    !Array.isArray(parsed.runs[0].results) ||
+    !parsed.runs[0].results.every(isRecord)
+  ) {
+    throw new Error('Native SpotBugs SARIF has an unexpected structure.');
+  }
+  return parsed as NativeSarifLog;
+}
+
+function validateAlignment(
+  reportRun: AnalysisReportRun,
+  nativeRun: NativeSarifRun
+): void {
+  if (nativeRun.results.length !== reportRun.findings.length) {
+    throw new Error('Native SpotBugs SARIF result count does not match the analysis.');
+  }
+  for (let index = 0; index < reportRun.findings.length; index++) {
+    if (nativeRun.results[index].ruleId !== reportRun.findings[index].type) {
+      throw new Error('Native SpotBugs SARIF result order does not match the analysis.');
+    }
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}

--- a/src/services/projectResult.ts
+++ b/src/services/projectResult.ts
@@ -10,6 +10,7 @@ export interface ProjectResult {
   errorCode?: string;
   spotbugsVersion?: string;
   reportSummary?: AnalysisReportSummary;
+  nativeSarif?: string;
 }
 
 export function projectResultFromOutcome(
@@ -45,6 +46,9 @@ export function projectResultFromOutcome(
   }
   if (outcome.reportSummary) {
     result.reportSummary = outcome.reportSummary;
+  }
+  if (outcome.nativeSarif) {
+    result.nativeSarif = outcome.nativeSarif;
   }
   return result;
 }

--- a/src/test/L0.analysisExecution.test.ts
+++ b/src/test/L0.analysisExecution.test.ts
@@ -380,6 +380,7 @@ describe('analysisExecution', () => {
               durationMs: 12,
             },
             reportSummary: { analyzedClassCount: 3 },
+            nativeSarif: '{"version":"2.1.0","runs":[]}',
             schemaVersion: 2,
           },
         }),
@@ -404,6 +405,7 @@ describe('analysisExecution', () => {
     assert.strictEqual(outcome.failure, undefined);
     assert.strictEqual(outcome.stats?.durationMs, 12);
     assert.strictEqual(outcome.reportSummary?.analyzedClassCount, 3);
+    assert.strictEqual(outcome.nativeSarif, '{"version":"2.1.0","runs":[]}');
     assert.strictEqual(outcome.schemaVersion, 2);
   });
 

--- a/src/test/L0.analysisRunSession.test.ts
+++ b/src/test/L0.analysisRunSession.test.ts
@@ -131,6 +131,7 @@ describe('analysisRunSession file analysis', () => {
     let receivedConfig: unknown;
     let receivedUri: unknown;
     let receivedToken: unknown;
+    let reportNativeSarif: string | undefined;
     const token = { isCancellationRequested: false } as CancellationToken;
     const lease = createCurrentLease(token);
     const deps = createBaseDependencies(vscode);
@@ -141,6 +142,7 @@ describe('analysisRunSession file analysis', () => {
       return {
         outcome: {
           findings: [finding],
+          nativeSarif: '{"version":"2.1.0","runs":[]}',
           targetPath: uri.fsPath,
         },
         context: {
@@ -158,7 +160,10 @@ describe('analysisRunSession file analysis', () => {
       config,
       tree: {
         showLoading: () => calls.push('loading'),
-        showResults: (findings: Finding[]) => calls.push(`results:${findings.length}`),
+        showResults: (findings: Finding[], reportRun) => {
+          calls.push(`results:${findings.length}`);
+          reportNativeSarif = reportRun?.nativeSarif;
+        },
         showAnalysisFailure: (message: string, code?: string) =>
           calls.push(`failure:${code ?? ''}:${message}`),
       },
@@ -181,6 +186,7 @@ describe('analysisRunSession file analysis', () => {
     assert.strictEqual(receivedConfig, config);
     assert.strictEqual(receivedUri, uri);
     assert.strictEqual(receivedToken, token);
+    assert.strictEqual(reportNativeSarif, '{"version":"2.1.0","runs":[]}');
     assert.deepStrictEqual(calls, [
       'loading',
       'results:1',

--- a/src/test/L0.nativeSarifExporter.test.ts
+++ b/src/test/L0.nativeSarifExporter.test.ts
@@ -1,0 +1,122 @@
+import * as assert from 'assert';
+import type { AnalysisReportRun } from '../model/analysisReport';
+import type { Finding } from '../model/finding';
+import { buildNativeSarifLog } from '../services/nativeSarifExporter';
+
+function finding(type: string): Finding {
+  return { patternId: type, type, location: {} };
+}
+
+function nativeSarif(ruleIds: string[]): string {
+  return JSON.stringify({
+    version: '2.1.0',
+    $schema: 'https://example.test/sarif-schema.json',
+    runs: [
+      {
+        tool: { driver: { name: 'SpotBugs', rules: ruleIds.map((id) => ({ id })) } },
+        invocations: [{ executionSuccessful: true }],
+        results: ruleIds.map((ruleId, ruleIndex) => ({ ruleId, ruleIndex })),
+        taxonomies: [{ name: 'CWE' }],
+      },
+    ],
+  });
+}
+
+describe('buildNativeSarifLog', () => {
+  it('filters only native results while preserving native run metadata', () => {
+    const first = finding('NP_NULL');
+    const second = finding('UR_UNINIT_READ');
+    const log = buildNativeSarifLog(
+      [
+        {
+          projectUri: 'file:///workspace/a',
+          findings: [first, second],
+          nativeSarif: nativeSarif([first.type!, second.type!]),
+        },
+      ],
+      [second]
+    );
+
+    assert.deepStrictEqual(log.runs[0].results, [
+      { ruleId: 'UR_UNINIT_READ', ruleIndex: 1 },
+    ]);
+    assert.deepStrictEqual(
+      (log.runs[0].tool as any).driver.rules,
+      [{ id: 'NP_NULL' }, { id: 'UR_UNINIT_READ' }]
+    );
+    assert.deepStrictEqual(log.runs[0].invocations, [
+      { executionSuccessful: true },
+    ]);
+    assert.deepStrictEqual(log.runs[0].taxonomies, [{ name: 'CWE' }]);
+  });
+
+  it('combines successful workspace runs and retains an originally empty run', () => {
+    const selected = finding('NP_NULL');
+    const runs: AnalysisReportRun[] = [
+      {
+        projectUri: 'file:///workspace/a',
+        findings: [selected],
+        nativeSarif: nativeSarif([selected.type!]),
+      },
+      {
+        projectUri: 'file:///workspace/b',
+        findings: [],
+        nativeSarif: nativeSarif([]),
+      },
+      {
+        projectUri: 'file:///workspace/c',
+        findings: [],
+        analysisStatus: 'failed',
+      },
+    ];
+
+    const log = buildNativeSarifLog(runs, [selected], true);
+
+    assert.strictEqual(log.runs.length, 2);
+    assert.deepStrictEqual(log.runs.map((run) => run.results.length), [1, 0]);
+  });
+
+  it('rejects missing, malformed, or misaligned native reports', () => {
+    const selected = finding('NP_NULL');
+    const cases: AnalysisReportRun[][] = [
+      [{ projectUri: 'file:///workspace', findings: [selected] }],
+      [
+        {
+          projectUri: 'file:///workspace',
+          findings: [selected],
+          nativeSarif: '{',
+        },
+      ],
+      [
+        {
+          projectUri: 'file:///workspace',
+          findings: [selected],
+          nativeSarif: nativeSarif([]),
+        },
+      ],
+      [
+        {
+          projectUri: 'file:///workspace',
+          findings: [selected],
+          nativeSarif: nativeSarif(['OTHER_RULE']),
+        },
+      ],
+    ];
+
+    for (const reportRuns of cases) {
+      assert.throws(() => buildNativeSarifLog(reportRuns, [selected]));
+    }
+    assert.throws(() =>
+      buildNativeSarifLog(
+        [
+          {
+            projectUri: 'file:///workspace',
+            findings: [selected],
+            nativeSarif: nativeSarif([selected.type!]),
+          },
+        ],
+        [finding('NP_NULL')]
+      )
+    );
+  });
+});

--- a/src/test/L0.nativeSarifExporter.test.ts
+++ b/src/test/L0.nativeSarifExporter.test.ts
@@ -50,7 +50,7 @@ describe('buildNativeSarifLog', () => {
     assert.deepStrictEqual(log.runs[0].taxonomies, [{ name: 'CWE' }]);
   });
 
-  it('combines successful workspace runs and retains an originally empty run', () => {
+  it('combines successful workspace runs and retains usable empty runs', () => {
     const selected = finding('NP_NULL');
     const runs: AnalysisReportRun[] = [
       {
@@ -67,6 +67,10 @@ describe('buildNativeSarifLog', () => {
         projectUri: 'file:///workspace/c',
         findings: [],
         analysisStatus: 'failed',
+      },
+      {
+        projectUri: 'file:///workspace/d',
+        findings: [],
       },
     ];
 

--- a/src/test/L0.projectResult.test.ts
+++ b/src/test/L0.projectResult.test.ts
@@ -72,6 +72,7 @@ describe('projectResult', () => {
         ],
         stats: { spotbugsVersion: '4.9.8' },
         reportSummary: { analyzedCodeSize: 100 },
+        nativeSarif: '{"version":"2.1.0","runs":[]}',
       })
     );
 
@@ -86,6 +87,7 @@ describe('projectResult', () => {
       ],
       spotbugsVersion: '4.9.8',
       reportSummary: { analyzedCodeSize: 100 },
+      nativeSarif: '{"version":"2.1.0","runs":[]}',
     });
   });
 });

--- a/src/test/L0.spotbugsParser.test.ts
+++ b/src/test/L0.spotbugsParser.test.ts
@@ -74,6 +74,7 @@ describe('spotbugsParser', () => {
         results: [{ type: 'UR' }],
         errors: [{ code: 'X', message: 'warn' }],
         stats: { target: '/tmp/Foo', durationMs: 12 },
+        nativeSarif: '{"version":"2.1.0","runs":[]}',
       })
     );
     assert.strictEqual(result.ok, true);
@@ -84,6 +85,10 @@ describe('spotbugsParser', () => {
       assert.strictEqual(result.value.errors?.[0]?.code, 'X');
       assert.strictEqual(result.value.errors?.[0]?.message, 'warn');
       assert.strictEqual(result.value.stats?.target, '/tmp/Foo');
+      assert.strictEqual(
+        result.value.nativeSarif,
+        '{"version":"2.1.0","runs":[]}'
+      );
     }
   });
 

--- a/src/test/L1.spotbugsTreeDataProvider.test.ts
+++ b/src/test/L1.spotbugsTreeDataProvider.test.ts
@@ -303,6 +303,7 @@ describe('spotbugsTreeDataProvider', () => {
         findings: [nextFinding],
         spotbugsVersion: '4.9.8',
         reportSummary: { analyzedClassCount: 1 },
+        nativeSarif: '{"version":"2.1.0","runs":[]}',
       },
     ]);
 
@@ -314,6 +315,7 @@ describe('spotbugsTreeDataProvider', () => {
     const runs = provider.getReportRuns();
     assert.strictEqual(runs[0].findings[0], nextFinding);
     assert.strictEqual(runs[0].spotbugsVersion, '4.9.8');
+    assert.strictEqual(runs[0].nativeSarif, '{"version":"2.1.0","runs":[]}');
   });
 
   it('clears transient search and filters during loading, failure, and workspace progress without resetting group or sort', async () => {

--- a/src/ui/spotbugsTreeDataProvider.ts
+++ b/src/ui/spotbugsTreeDataProvider.ts
@@ -173,6 +173,7 @@ export class SpotBugsTreeDataProvider implements TreeDataProvider<TreeItem> {
         : undefined,
       spotbugsVersion: result.spotbugsVersion,
       summary: result.reportSummary,
+      nativeSarif: result.nativeSarif,
     }));
     this.refreshResultsView();
     this._onDidChangeTreeData.fire(undefined);


### PR DESCRIPTION
## Summary

- Generate native SpotBugs SARIF during analysis.
- Export native SARIF for workspace or selected results.

Fixes #67.