### PR TITLE
fix(java): return envelopes for linkage errors

### DIFF
--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/AnalysisPipeline.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/command/AnalysisPipeline.java
@@ -34,7 +34,7 @@ final class AnalysisPipeline {
         } catch (InterruptedException interrupted) {
             Thread.currentThread().interrupt();
             return AnalysisPipelineResult.cancelled(analyzer, startMillis);
-        } catch (Exception analysisFailure) {
+        } catch (Exception | LinkageError analysisFailure) {
             if (monitor != null && monitor.isCanceled()) {
                 return AnalysisPipelineResult.cancelled(analyzer, startMillis);
             }

--- a/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisActionTest.java
+++ b/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisActionTest.java
@@ -54,6 +54,26 @@ public class RunAnalysisActionTest {
     }
 
     @Test
+    public void executeWrapsLinkageErrorsAsAnalysisFailedEnvelope() {
+        RunAnalysisAction action = new RunAnalysisAction(() -> new AnalyzerService() {
+            @Override
+            public SpotBugsAnalysisResult analyzeToBugsWithWarnings(IProgressMonitor monitor, String... filePaths) {
+                throw new NoClassDefFoundError("missing detector dependency");
+            }
+        });
+
+        JsonObject response = executeDefault(action);
+        JsonObject stats = response.getAsJsonObject("stats");
+
+        assertEquals(2, response.get("schemaVersion").getAsInt());
+        assertEquals("ANALYSIS_FAILED", firstError(response).get("code").getAsString());
+        assertEquals("missing detector dependency", firstError(response).get("message").getAsString());
+        assertEquals("/workspace/build/classes", stats.get("target").getAsString());
+        assertTrue(stats.get("durationMs").getAsLong() >= 0L);
+        assertEquals(0, stats.get("findingCount").getAsInt());
+    }
+
+    @Test
     public void executeReportsNonzeroFindingCountFromResults() {
         RunAnalysisAction action = new RunAnalysisAction(() -> new AnalyzerService() {
             @Override


### PR DESCRIPTION
## Summary

- Return structured command envelopes for Java linkage failures.
- Add analysis pipeline regression coverage.