### PR TITLE
fix: use full rule type in inspector

### DIFF
--- a/src/test/L0.findingInspectorRenderer.test.ts
+++ b/src/test/L0.findingInspectorRenderer.test.ts
@@ -23,7 +23,7 @@ describe('findingInspectorRenderer', () => {
       )
     );
     assert.ok(html.includes('Rule'));
-    assert.ok(html.includes('NP_ALWAYS_NULL'));
+    assert.ok(html.includes('<dt>Pattern</dt><dd>NP_ALWAYS_NULL</dd>'));
     assert.ok(html.includes('CORRECTNESS'));
     assert.ok(html.includes('High'));
     assert.ok(html.includes('<dt>Rank</dt><dd>3</dd>'));
@@ -103,7 +103,7 @@ function makeSnapshot(status: 'selected' | 'retained'): FindingInspectorSnapshot
 
 function makeFinding(overrides: Partial<Finding>): Finding {
   return {
-    patternId: 'NP_ALWAYS_NULL',
+    patternId: 'NP',
     type: 'NP_ALWAYS_NULL',
     abbrev: 'NP',
     category: 'CORRECTNESS',

--- a/src/test/L1.findingInspectorViewProvider.test.ts
+++ b/src/test/L1.findingInspectorViewProvider.test.ts
@@ -22,7 +22,7 @@ describe('findingInspectorViewProvider', () => {
     assert.ok(webview.html.includes('NP_ALWAYS_NULL'));
   });
 
-  it('copies finding.patternId for Copy rule id messages', async () => {
+  it('copies the full rule type', async () => {
     const clipboardWrites: string[] = [];
     resetVscodeMock({
       env: {
@@ -36,7 +36,7 @@ describe('findingInspectorViewProvider', () => {
     const { state, provider, webview } = await createInspectorHarness();
 
     provider.resolveWebviewView({ webview } as never);
-    state.select(makeFinding({ patternId: 'NP_ALWAYS_NULL' }));
+    state.select(makeFinding({ patternId: 'NP' }));
     await webview.dispatch({ type: 'copyRuleId' });
 
     assert.deepStrictEqual(clipboardWrites, ['NP_ALWAYS_NULL']);

--- a/src/ui/findingInspectorRenderer.ts
+++ b/src/ui/findingInspectorRenderer.ts
@@ -148,7 +148,7 @@ function renderFinding(
     </dl>
     <h3>${escapeHtml(vscode.l10n.t('Rule'))}</h3>
     <dl>
-      <dt>${escapeHtml(vscode.l10n.t('Pattern'))}</dt><dd>${escapeHtml(finding.patternId)}</dd>
+      <dt>${escapeHtml(vscode.l10n.t('Pattern'))}</dt><dd>${escapeHtml(finding.type || finding.patternId)}</dd>
       ${finding.category ? `<dt>${escapeHtml(vscode.l10n.t('Category'))}</dt><dd>${escapeHtml(finding.category)}</dd>` : ''}
       ${finding.priority ? `<dt>${escapeHtml(vscode.l10n.t('Priority'))}</dt><dd>${escapeHtml(finding.priority)}</dd>` : ''}
       ${typeof finding.rank === 'number' ? `<dt>${escapeHtml(vscode.l10n.t('Rank'))}</dt><dd>${String(finding.rank)}</dd>` : ''}

--- a/src/ui/findingInspectorViewProvider.ts
+++ b/src/ui/findingInspectorViewProvider.ts
@@ -74,9 +74,10 @@ export class FindingInspectorViewProvider
     }
 
     if (message.type === 'copyRuleId') {
-      await env.clipboard.writeText(finding.patternId);
+      const ruleId = finding.type || finding.patternId;
+      await env.clipboard.writeText(ruleId);
       await window.showInformationMessage(
-        l10n.t('Copied SpotBugs rule id: {0}', finding.patternId)
+        l10n.t('Copied SpotBugs rule id: {0}', ruleId)
       );
       return;
     }


### PR DESCRIPTION
## Summary

- Use the full SpotBugs rule type for inspector identity.
- Prevent collisions between rules with the same abbreviated pattern ID.