### PR TITLE
refactor: remove global sourcepath cache

### DIFF
--- a/src/services/analysisExecution.ts
+++ b/src/services/analysisExecution.ts
@@ -69,17 +69,23 @@ export function createAnalysisExecutor(overrides: Partial<AnalysisExecutorDeps> 
     context: AnalysisExecutionTarget,
     token?: CancellationToken
   ): Promise<AnalysisOutcome> {
-    const settings = config.getAnalysisSettings(context.preferredProject);
+    const analysisContext: AnalysisExecutionTarget = {
+      ...context,
+      sourcepaths: Array.isArray(context.sourcepaths)
+        ? context.sourcepaths.slice()
+        : context.sourcepaths,
+    };
+    const settings = config.getAnalysisSettings(analysisContext.preferredProject);
     const preflightFailure = await validateAnalysisPreflight(
       settings,
-      context.targetPath
+      analysisContext.targetPath
     );
     if (preflightFailure) {
       return preflightFailure;
     }
 
-    const raw = await executeAnalysisRequest(settings, context, token);
-    return analysisOutcomeFromRawResponse(raw, context);
+    const raw = await executeAnalysisRequest(settings, analysisContext, token);
+    return analysisOutcomeFromRawResponse(raw, analysisContext);
   }
 
   async function validateAnalysisPreflight(
@@ -279,7 +285,8 @@ export function createAnalysisExecutor(overrides: Partial<AnalysisExecutorDeps> 
     const findings = deps.mapBugsToFindings(bugs);
     const withFullPaths = await deps.addFullPaths(
       findings,
-      context.preferredProject
+      context.preferredProject,
+      context.sourcepaths
     );
     logSuccessfulAnalysis(withFullPaths.length, stats);
     const outcome: AnalysisOutcome = {

--- a/src/test/L0.analysisExecution.test.ts
+++ b/src/test/L0.analysisExecution.test.ts
@@ -361,6 +361,7 @@ describe('analysisExecution', () => {
     const vscode = installVscodeMock();
     const { createAnalysisExecutor } = loadAnalysisExecution();
     let addFullPathsProject: Uri | undefined;
+    let addFullPathsSourcepaths: readonly string[] | null | undefined;
     const mappedFinding = makeFinding();
     const enrichedFinding = makeFinding({
       location: {
@@ -385,9 +386,10 @@ describe('analysisExecution', () => {
           },
         }),
         mapBugsToFindings: () => [mappedFinding],
-        addFullPaths: async (findings, preferredProject) => {
+        addFullPaths: async (findings, preferredProject, sourcepaths) => {
           assert.deepStrictEqual(findings, [mappedFinding]);
           addFullPathsProject = preferredProject;
+          addFullPathsSourcepaths = sourcepaths;
           return [enrichedFinding];
         },
       })
@@ -400,6 +402,7 @@ describe('analysisExecution', () => {
       addFullPathsProject?.toString(),
       target.preferredProject?.toString()
     );
+    assert.deepStrictEqual(addFullPathsSourcepaths, target.sourcepaths);
     assert.deepStrictEqual(outcome.findings, [enrichedFinding]);
     assert.strictEqual(outcome.errors?.[0]?.code, 'ANALYSIS_WARNING');
     assert.strictEqual(outcome.failure, undefined);
@@ -407,6 +410,42 @@ describe('analysisExecution', () => {
     assert.strictEqual(outcome.reportSummary?.analyzedClassCount, 3);
     assert.strictEqual(outcome.nativeSarif, '{"version":"2.1.0","runs":[]}');
     assert.strictEqual(outcome.schemaVersion, 2);
+  });
+
+  it('keeps the analysis-start sourcepath snapshot through backend execution', async () => {
+    const { createAnalysisExecutor } = loadAnalysisExecution();
+    const target = makeTarget(installVscodeMock());
+    let backendSourcepaths: string[] | null | undefined;
+    let enrichmentSourcepaths: readonly string[] | null | undefined;
+    const executor = createAnalysisExecutor(
+      makeDeps({
+        runSpotBugsAnalysis: async (request) => {
+          backendSourcepaths = request.payload.sourcepaths;
+          target.sourcepaths?.splice(0, target.sourcepaths.length, '/mutated');
+          return JSON.stringify({ schemaVersion: 2, results: [] });
+        },
+        parseAnalysisResponse: () => ({
+          ok: true,
+          value: {
+            bugs: [{ type: 'NP_ALWAYS_NULL' }],
+          },
+        }),
+        mapBugsToFindings: () => [makeFinding()],
+        addFullPaths: async (findings, _preferredProject, sourcepaths) => {
+          enrichmentSourcepaths = sourcepaths;
+          return findings;
+        },
+      })
+    );
+
+    await executor.run(makeConfig(), target);
+
+    assert.deepStrictEqual(backendSourcepaths, [
+      '/workspace/src/main/java',
+    ]);
+    assert.deepStrictEqual(enrichmentSourcepaths, [
+      '/workspace/src/main/java',
+    ]);
   });
 
 });

--- a/src/test/L0.pathResolver.test.ts
+++ b/src/test/L0.pathResolver.test.ts
@@ -1,0 +1,205 @@
+import * as assert from 'assert';
+import type { Uri } from 'vscode';
+import type { Finding } from '../model/finding';
+import type { PathResolverDeps } from '../workspace/pathResolver';
+import { installVscodeMock, resetVscodeMock } from './helpers/mockVscode';
+
+installVscodeMock();
+
+describe('pathResolver', () => {
+  beforeEach(() => {
+    resetVscodeMock();
+  });
+
+  it('uses the provided sourcepath snapshot in order without another classpath lookup', async () => {
+    const { createPathResolver } = await import('../workspace/pathResolver');
+    const sourcepaths = ['/workspace/source-a', '/workspace/source-b'];
+    const statCalls: string[] = [];
+    let classpathCalls = 0;
+    const resolver = createPathResolver(
+      makeDeps({
+        getClasspaths: async () => {
+          classpathCalls += 1;
+          return classpathResult(['/unexpected']);
+        },
+        statPath: async (candidatePath) => {
+          statCalls.push(candidatePath);
+          if (candidatePath === '/workspace/source-b/com/acme/Foo.java') {
+            return {};
+          }
+          throw new Error('not found');
+        },
+      })
+    );
+
+    const resolution = resolver.addFullPaths(
+      [makeFinding('com/acme/Foo.java')],
+      undefined,
+      sourcepaths
+    );
+    sourcepaths[0] = '/workspace/mutated';
+    const [result] = await resolution;
+
+    assert.strictEqual(
+      result.location.fullPath,
+      '/workspace/source-b/com/acme/Foo.java'
+    );
+    assert.deepStrictEqual(statCalls, [
+      '/workspace/source-a/com/acme/Foo.java',
+      '/workspace/source-b/com/acme/Foo.java',
+    ]);
+    assert.strictEqual(classpathCalls, 0);
+  });
+
+  it('treats an empty sourcepath snapshot as authoritative', async () => {
+    const { createPathResolver } = await import('../workspace/pathResolver');
+    const statCalls: string[] = [];
+    let classpathCalls = 0;
+    const resolver = createPathResolver(
+      makeDeps({
+        getClasspaths: async () => {
+          classpathCalls += 1;
+          return classpathResult(['/unexpected']);
+        },
+        getProjectRootPaths: async () => ['/workspace/project'],
+        statPath: async (candidatePath) => {
+          statCalls.push(candidatePath);
+          if (
+            candidatePath ===
+            '/workspace/project/src/test/java/com/acme/Foo.java'
+          ) {
+            return {};
+          }
+          throw new Error('not found');
+        },
+      })
+    );
+
+    const [result] = await resolver.addFullPaths(
+      [makeFinding('com/acme/Foo.java')],
+      undefined,
+      []
+    );
+
+    assert.strictEqual(
+      result.location.fullPath,
+      '/workspace/project/src/test/java/com/acme/Foo.java'
+    );
+    assert.deepStrictEqual(statCalls, [
+      '/workspace/project/src/main/java/com/acme/Foo.java',
+      '/workspace/project/src/test/java/com/acme/Foo.java',
+    ]);
+    assert.strictEqual(classpathCalls, 0);
+  });
+
+  it('looks up unavailable sourcepaths once per finding batch', async () => {
+    const vscode = installVscodeMock();
+    const { createPathResolver } = await import('../workspace/pathResolver');
+    const preferredProject = vscode.Uri.file('/workspace/project-a') as unknown as Uri;
+    const requestedProjects: Array<Uri | string | undefined> = [];
+    const resolver = createPathResolver(
+      makeDeps({
+        getClasspaths: async (project) => {
+          requestedProjects.push(project);
+          return classpathResult(['/workspace/project-a/source']);
+        },
+        statPath: async (candidatePath) => {
+          if (candidatePath.startsWith('/workspace/project-a/source/')) {
+            return {};
+          }
+          throw new Error('not found');
+        },
+      })
+    );
+
+    const results = await resolver.addFullPaths(
+      [
+        makeFinding('com/acme/Foo.java'),
+        makeFinding('com/acme/Bar.java'),
+      ],
+      preferredProject
+    );
+
+    assert.deepStrictEqual(
+      results.map((finding) => finding.location.fullPath),
+      [
+        '/workspace/project-a/source/com/acme/Foo.java',
+        '/workspace/project-a/source/com/acme/Bar.java',
+      ]
+    );
+    assert.deepStrictEqual(requestedProjects, [preferredProject]);
+  });
+
+  it('keeps sequential project batches isolated', async () => {
+    const vscode = installVscodeMock();
+    const { createPathResolver } = await import('../workspace/pathResolver');
+    const projectA = vscode.Uri.file('/workspace/project-a') as unknown as Uri;
+    const projectB = vscode.Uri.file('/workspace/project-b') as unknown as Uri;
+    const requestedProjects: string[] = [];
+    const resolver = createPathResolver(
+      makeDeps({
+        getClasspaths: async (project) => {
+          const projectPath =
+            typeof project === 'string' ? project : project?.fsPath ?? '';
+          requestedProjects.push(projectPath);
+          return classpathResult([`${projectPath}/source`]);
+        },
+        statPath: async () => ({}),
+      })
+    );
+
+    const [findingA] = await resolver.addFullPaths(
+      [makeFinding('com/acme/Foo.java')],
+      projectA
+    );
+    const [findingB] = await resolver.addFullPaths(
+      [makeFinding('com/acme/Foo.java')],
+      projectB
+    );
+
+    assert.strictEqual(
+      findingA.location.fullPath,
+      '/workspace/project-a/source/com/acme/Foo.java'
+    );
+    assert.strictEqual(
+      findingB.location.fullPath,
+      '/workspace/project-b/source/com/acme/Foo.java'
+    );
+    assert.deepStrictEqual(requestedProjects, [
+      '/workspace/project-a',
+      '/workspace/project-b',
+    ]);
+  });
+});
+
+function makeDeps(
+  overrides: Partial<PathResolverDeps> = {}
+): PathResolverDeps {
+  return {
+    getClasspaths: async () => undefined,
+    getProjectRootPaths: async () => [],
+    getPrimaryWorkspaceFolder: () => undefined,
+    statPath: async () => {
+      throw new Error('not found');
+    },
+    logger: { log: () => undefined },
+    ...overrides,
+  };
+}
+
+function classpathResult(sourcepaths: string[]) {
+  return {
+    runtimeClasspaths: [],
+    targetResolutionRoots: [],
+    sourcepaths,
+  };
+}
+
+function makeFinding(realSourcePath: string): Finding {
+  return {
+    patternId: 'NP',
+    type: 'NP_ALWAYS_NULL',
+    message: 'Null pointer',
+    location: { realSourcePath },
+  };
+}

--- a/src/test/L1.analysisTargetResolver.test.ts
+++ b/src/test/L1.analysisTargetResolver.test.ts
@@ -38,7 +38,6 @@ describe('analysisTargetResolver', () => {
       findOutputFolderFromProject: async () => undefined,
       hasClassTargets: async () => true,
       isBytecodeTarget: () => false,
-      primeSourcepathsCache: () => undefined,
       getWorkspaceFolder: () =>
         ({
           name: 'workspace',
@@ -94,7 +93,6 @@ describe('analysisTargetResolver', () => {
       },
       hasClassTargets: async () => true,
       isBytecodeTarget: () => false,
-      primeSourcepathsCache: () => undefined,
       getWorkspaceFolder: () =>
         ({
           name: 'workspace',
@@ -133,7 +131,6 @@ describe('analysisTargetResolver', () => {
       findOutputFolderFromProject: async () => undefined,
       hasClassTargets: async () => false,
       isBytecodeTarget: () => false,
-      primeSourcepathsCache: () => undefined,
       getWorkspaceFolder: () =>
         ({
           name: 'workspace',
@@ -1140,7 +1137,6 @@ function createResolverDeps(
     containsJavaSources: options.containsJavaSources ?? (async () => false),
     isBytecodeTarget: (targetPath: string) =>
       ['.class', '.jar', '.zip'].includes(path.extname(targetPath).toLowerCase()),
-    primeSourcepathsCache: () => undefined,
     getWorkspaceFolder: () =>
       ({
         name: 'workspace',

--- a/src/workspace/analysisTargetResolver.ts
+++ b/src/workspace/analysisTargetResolver.ts
@@ -9,7 +9,6 @@ import {
   filterAdmissibleTargetResolutionRoots,
   getClasspathsOutcome,
 } from './classpathService';
-import { primeSourcepathsCache } from './pathResolver';
 import { NO_CLASS_TARGETS_CODE, NO_CLASS_TARGETS_MESSAGE } from './analysisTargetCodes';
 import {
   findOutputFolderFromProject,
@@ -55,7 +54,6 @@ export interface TargetResolverDeps {
   hasLooseClassTargets: typeof hasLooseClassTargets;
   isBytecodeTarget: typeof isBytecodeTarget;
   containsJavaSources: typeof containsJavaSources;
-  primeSourcepathsCache: typeof primeSourcepathsCache;
   getWorkspaceFolder: typeof workspace.getWorkspaceFolder;
   dirname: typeof path.dirname;
   logger: typeof Logger;
@@ -69,7 +67,6 @@ const defaultDeps: TargetResolverDeps = {
   hasLooseClassTargets,
   isBytecodeTarget,
   containsJavaSources,
-  primeSourcepathsCache,
   getWorkspaceFolder: workspace.getWorkspaceFolder,
   dirname: path.dirname,
   logger: Logger,
@@ -141,8 +138,7 @@ export function createTargetResolver(overrides: Partial<TargetResolverDeps> = {}
       }
       outputPath = cp?.output;
       if (Array.isArray(cp?.sourcepaths)) {
-        sourcepaths = cp.sourcepaths;
-        deps.primeSourcepathsCache(cp.sourcepaths);
+        sourcepaths = cp.sourcepaths.slice();
       }
     } catch (error) {
       if (options.logFailure) {

--- a/src/workspace/pathResolver.ts
+++ b/src/workspace/pathResolver.ts
@@ -6,135 +6,215 @@ import { getClasspaths } from './classpathService';
 import { getProjectRootPaths } from './projectDiscovery';
 import { getPrimaryWorkspaceFolder } from './workspaceRoots';
 
-/**
- * Resolve a SpotBugs realSourcePath (e.g., com/foo/Bar.java) to a full filesystem path.
- * Tries Java LS sourcepaths first, then common workspace fallbacks.
- */
-export async function resolveSourceFullPath(
-  realSourcePath: string,
-  preferredProject?: Uri
-): Promise<string | null> {
-  if (!realSourcePath) {
+const SOURCE_ROOTS = [
+  ['src', 'main', 'java'],
+  ['src', 'test', 'java'],
+  ['src'],
+  [],
+] as const;
+
+type LoggerLike = Pick<typeof Logger, 'log'>;
+
+export interface PathResolverDeps {
+  getClasspaths: typeof getClasspaths;
+  getProjectRootPaths: typeof getProjectRootPaths;
+  getPrimaryWorkspaceFolder: typeof getPrimaryWorkspaceFolder;
+  statPath(candidatePath: string): Promise<unknown>;
+  logger: LoggerLike;
+}
+
+const defaultDeps: PathResolverDeps = {
+  getClasspaths,
+  getProjectRootPaths,
+  getPrimaryWorkspaceFolder,
+  statPath: async (candidatePath) => workspace.fs.stat(Uri.file(candidatePath)),
+  logger: Logger,
+};
+
+export function createPathResolver(overrides: Partial<PathResolverDeps> = {}) {
+  const deps: PathResolverDeps = { ...defaultDeps, ...overrides };
+
+  async function loadSourcepaths(
+    preferredProject?: Uri
+  ): Promise<readonly string[] | undefined> {
+    try {
+      const workspaceFolder = deps.getPrimaryWorkspaceFolder();
+      const classpaths = await deps.getClasspaths(
+        preferredProject ?? workspaceFolder?.uri
+      );
+      return Array.isArray(classpaths?.sourcepaths)
+        ? classpaths.sourcepaths.slice()
+        : undefined;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      deps.logger.log(
+        `Sourcepath lookup failed; falling back to workspace scan: ${message}`
+      );
+      return undefined;
+    }
+  }
+
+  async function firstExistingPath(
+    roots: readonly string[],
+    realSourcePath: string
+  ): Promise<string | null> {
+    for (const root of roots) {
+      const candidatePath = path.join(root, realSourcePath);
+      try {
+        await deps.statPath(candidatePath);
+        return candidatePath;
+      } catch {
+        // Try the next candidate.
+      }
+    }
     return null;
   }
 
-  const wsFolder = getPrimaryWorkspaceFolder();
-
-  // 1) Try Java LS sourcepaths via classpathService
-  try {
-    const sourcepaths = await getSourcepathsCached(preferredProject ?? wsFolder?.uri);
+  async function resolveWithSourcepaths(
+    realSourcePath: string,
+    sourcepaths: readonly string[] | undefined,
+    loadFallbackRoots: () => Promise<readonly string[]>
+  ): Promise<string | null> {
     if (sourcepaths && sourcepaths.length > 0) {
-      for (const sourcePath of sourcepaths) {
-        const candidatePath = path.join(sourcePath, realSourcePath);
+      const resolved = await firstExistingPath(sourcepaths, realSourcePath);
+      if (resolved) {
+        return resolved;
+      }
+    }
+
+    const rootCandidates = await loadFallbackRoots();
+    for (const root of rootCandidates) {
+      for (const segments of SOURCE_ROOTS) {
+        const candidatePath = path.join(root, ...segments, realSourcePath);
         try {
-          await workspace.fs.stat(Uri.file(candidatePath));
+          await deps.statPath(candidatePath);
           return candidatePath;
         } catch {
-          // try next source path
+          // Try the next common source root.
         }
       }
     }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    Logger.log(`Sourcepath lookup failed; falling back to workspace scan: ${message}`);
+
+    return null;
   }
 
-  // 2) Fallback: scan common Java project layout roots under known project/workspace roots
-  const rootCandidates = await getProjectRootPaths();
+  async function resolveSourceFullPath(
+    realSourcePath: string,
+    preferredProject?: Uri
+  ): Promise<string | null> {
+    if (!realSourcePath) {
+      return null;
+    }
 
-  const sourceRoots = [
-    ['src', 'main', 'java'],
-    ['src', 'test', 'java'],
-    ['src'],
-    [],
-  ];
-  for (const root of rootCandidates) {
-    for (const segs of sourceRoots) {
-      const base = path.join(root, ...segs);
-      const candidatePath = path.join(base, realSourcePath);
+    const sourcepaths = await loadSourcepaths(preferredProject);
+    return resolveWithSourcepaths(
+      realSourcePath,
+      sourcepaths,
+      deps.getProjectRootPaths
+    );
+  }
+
+  async function addFullPaths(
+    findings: Finding[],
+    preferredProject?: Uri,
+    sourcepaths?: readonly string[] | null
+  ): Promise<Finding[]> {
+    if (!findings.length) {
+      return [];
+    }
+
+    const hasSnapshot = Array.isArray(sourcepaths);
+    const capturedSourcepaths = hasSnapshot ? sourcepaths.slice() : undefined;
+    let recoveredSourcepaths: Promise<readonly string[] | undefined> | undefined;
+    let fallbackRoots: Promise<readonly string[]> | undefined;
+
+    function getEffectiveSourcepaths(): Promise<
+      readonly string[] | undefined
+    > {
+      if (hasSnapshot) {
+        return Promise.resolve(capturedSourcepaths);
+      }
+      if (!recoveredSourcepaths) {
+        recoveredSourcepaths = loadSourcepaths(preferredProject);
+      }
+      return recoveredSourcepaths;
+    }
+
+    function getFallbackRoots(): Promise<readonly string[]> {
+      if (!fallbackRoots) {
+        fallbackRoots = deps.getProjectRootPaths().then((roots) => roots.slice());
+      }
+      return fallbackRoots;
+    }
+
+    const resolved: Finding[] = [];
+    for (const finding of findings) {
+      if (
+        typeof finding.location.fullPath === 'string' &&
+        finding.location.fullPath.length > 0
+      ) {
+        resolved.push(finding);
+        continue;
+      }
+      if (!finding.location.realSourcePath) {
+        resolved.push(finding);
+        continue;
+      }
       try {
-        await workspace.fs.stat(Uri.file(candidatePath));
-        return candidatePath;
-      } catch {
-        // Continue
+        const full = await resolveWithSourcepaths(
+          finding.location.realSourcePath,
+          await getEffectiveSourcepaths(),
+          getFallbackRoots
+        );
+        if (full) {
+          resolved.push({
+            ...finding,
+            location: {
+              ...finding.location,
+              fullPath: full,
+            },
+          });
+        } else {
+          deps.logger.log(
+            `Could not resolve full path for: ${finding.location.realSourcePath}`
+          );
+          resolved.push(finding);
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        deps.logger.log(
+          `Path resolve failed for ${finding.location.realSourcePath}: ${message}`
+        );
+        resolved.push(finding);
       }
     }
+    return resolved;
   }
 
-  return null;
+  return { addFullPaths, resolveSourceFullPath };
+}
+
+const defaultResolver = createPathResolver();
+
+/**
+ * Resolve a SpotBugs realSourcePath (e.g., com/foo/Bar.java) to a full filesystem path.
+ * Performs an on-demand Java LS lookup, then tries common workspace fallbacks.
+ */
+export function resolveSourceFullPath(
+  realSourcePath: string,
+  preferredProject?: Uri
+): Promise<string | null> {
+  return defaultResolver.resolveSourceFullPath(realSourcePath, preferredProject);
 }
 
 /**
  * Resolve SpotBugs findings to absolute file paths when possible.
+ * A provided sourcepath array is an immutable snapshot for this call, including [].
  */
-export async function addFullPaths(
+export function addFullPaths(
   findings: Finding[],
-  preferredProject?: Uri
+  preferredProject?: Uri,
+  sourcepaths?: readonly string[] | null
 ): Promise<Finding[]> {
-  if (!findings.length) {
-    return [];
-  }
-
-  const resolved: Finding[] = [];
-  for (const finding of findings) {
-    if (
-      typeof finding.location.fullPath === 'string' &&
-      finding.location.fullPath.length > 0
-    ) {
-      resolved.push(finding);
-      continue;
-    }
-    if (!finding.location.realSourcePath) {
-      resolved.push(finding);
-      continue;
-    }
-    try {
-      const full = await resolveSourceFullPath(
-        finding.location.realSourcePath,
-        preferredProject
-      );
-      if (full) {
-        resolved.push({
-          ...finding,
-          location: {
-            ...finding.location,
-            fullPath: full,
-          },
-        });
-      } else {
-        Logger.log(`Could not resolve full path for: ${finding.location.realSourcePath}`);
-        resolved.push(finding);
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      Logger.log(`Path resolve failed for ${finding.location.realSourcePath}: ${message}`);
-      resolved.push(finding);
-    }
-  }
-  return resolved;
-}
-
-// Simple in-memory cache to avoid repeated LS calls while resolving many paths
-let cachedSourcepaths: string[] | undefined;
-let cachedAt = 0;
-const CACHE_MS = 5000;
-
-export function primeSourcepathsCache(sourcepaths?: string[]): void {
-  if (Array.isArray(sourcepaths)) {
-    cachedSourcepaths = sourcepaths;
-    cachedAt = Date.now();
-  }
-}
-
-async function getSourcepathsCached(preferred?: Uri): Promise<string[] | undefined> {
-  const now = Date.now();
-  if (cachedSourcepaths && now - cachedAt < CACHE_MS) {
-    return cachedSourcepaths;
-  }
-  const cp = await getClasspaths(preferred);
-  if (Array.isArray(cp?.sourcepaths)) {
-    primeSourcepathsCache(cp.sourcepaths);
-    return cp.sourcepaths.length > 0 ? cp.sourcepaths : undefined;
-  }
-  return undefined;
+  return defaultResolver.addFullPaths(findings, preferredProject, sourcepaths);
 }


### PR DESCRIPTION
## Summary

- Remove the process-wide sourcepath cache.
- Resolve and pass sourcepaths within each analysis flow.