### PR TITLE
refactor: remove legacy exclude filter path

### DIFF
--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/api/ConfigSchema.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/api/ConfigSchema.java
@@ -18,7 +18,6 @@ public class ConfigSchema {
     private List<String> includeFilterPaths;  // optional
     private List<String> excludeFilterPaths;  // optional
     private List<String> excludeBaselineBugsPaths; // optional
-    private String excludeFilterPath;         // optional legacy field
     private List<String> plugins;             // optional
 
     public Integer getSchemaVersion() { return schemaVersion; }
@@ -31,6 +30,5 @@ public class ConfigSchema {
     public List<String> getIncludeFilterPaths() { return includeFilterPaths; }
     public List<String> getExcludeFilterPaths() { return excludeFilterPaths; }
     public List<String> getExcludeBaselineBugsPaths() { return excludeBaselineBugsPaths; }
-    public String getExcludeFilterPath() { return excludeFilterPath; }
     public List<String> getPlugins() { return plugins; }
 }

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/config/AnalysisConfig.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/config/AnalysisConfig.java
@@ -19,7 +19,6 @@ public class AnalysisConfig {
     private final List<String> includeFilterPaths; // optional
     private final List<String> excludeFilterPaths; // optional
     private final List<String> excludeBaselineBugsPaths; // optional
-    private final String excludeFilterPath;  // optional legacy field
     private final List<String> plugins;      // optional
 
     private AnalysisConfig(Builder b) {
@@ -46,7 +45,6 @@ public class AnalysisConfig {
         this.excludeBaselineBugsPaths = b.excludeBaselineBugsPaths == null
                 ? Collections.emptyList()
                 : Collections.unmodifiableList(new ArrayList<>(b.excludeBaselineBugsPaths));
-        this.excludeFilterPath = b.excludeFilterPath;
         this.plugins = b.plugins == null
                 ? Collections.emptyList()
                 : Collections.unmodifiableList(new ArrayList<>(b.plugins));
@@ -61,7 +59,6 @@ public class AnalysisConfig {
     public List<String> getIncludeFilterPaths() { return includeFilterPaths; }
     public List<String> getExcludeFilterPaths() { return excludeFilterPaths; }
     public List<String> getExcludeBaselineBugsPaths() { return excludeBaselineBugsPaths; }
-    public String getExcludeFilterPath() { return excludeFilterPath; }
     public List<String> getPlugins() { return plugins; }
 
     // Package-private to keep creation within the config pipeline
@@ -77,7 +74,6 @@ public class AnalysisConfig {
         private List<String> includeFilterPaths;
         private List<String> excludeFilterPaths;
         private List<String> excludeBaselineBugsPaths;
-        private String excludeFilterPath;
         private List<String> plugins;
 
         Builder effort(Effort e) { this.effort = e; return this; }
@@ -89,7 +85,6 @@ public class AnalysisConfig {
         Builder includeFilterPaths(List<String> p) { this.includeFilterPaths = p; return this; }
         Builder excludeFilterPaths(List<String> p) { this.excludeFilterPaths = p; return this; }
         Builder excludeBaselineBugsPaths(List<String> p) { this.excludeBaselineBugsPaths = p; return this; }
-        Builder excludeFilterPath(String p) { this.excludeFilterPath = p; return this; }
         Builder plugins(List<String> p) { this.plugins = p; return this; }
 
         AnalysisConfig build() { return new AnalysisConfig(this); }

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/config/ConfigValidator.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/config/ConfigValidator.java
@@ -29,11 +29,6 @@ public class ConfigValidator {
         List<String> includeFilterPaths = normalizeList(schema.getIncludeFilterPaths());
         List<String> excludeFilterPaths = normalizeList(schema.getExcludeFilterPaths());
         List<String> excludeBaselineBugsPaths = normalizeList(schema.getExcludeBaselineBugsPaths());
-        String excludeFilterPath = normalizeString(schema.getExcludeFilterPath());
-        if (excludeFilterPaths.isEmpty() && excludeFilterPath != null) {
-            excludeFilterPaths = new ArrayList<>();
-            excludeFilterPaths.add(excludeFilterPath);
-        }
         List<String> plugins = normalizeList(schema.getPlugins());
 
         ConfigError includeFilterError = FilterFileValidator.validateIncludeFilters(includeFilterPaths);
@@ -64,17 +59,10 @@ public class ConfigValidator {
             .includeFilterPaths(includeFilterPaths)
             .excludeFilterPaths(excludeFilterPaths)
             .excludeBaselineBugsPaths(excludeBaselineBugsPaths)
-            .excludeFilterPath(excludeFilterPath)
             .plugins(plugins)
             .build();
 
         return ConfigValidationResult.ok(cfg);
-    }
-
-    private static String normalizeString(String s) {
-        if (s == null) return null;
-        String t = s.trim();
-        return t.isEmpty() ? null : t;
     }
 
     private static List<String> normalizeList(List<String> in) {

--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/config/PreferencesApplier.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/internal/config/PreferencesApplier.java
@@ -24,7 +24,7 @@ public class PreferencesApplier {
 
         // Filter files are applied by FindBugs2#setUserPreferences via configureFilters.
         prefs.setIncludeFilterFiles(toEnabledPathMap(cfg.getIncludeFilterPaths()));
-        prefs.setExcludeFilterFiles(toEnabledPathMap(resolveExcludeFilterPaths(cfg)));
+        prefs.setExcludeFilterFiles(toEnabledPathMap(cfg.getExcludeFilterPaths()));
         prefs.setExcludeBugsFiles(toEnabledPathMap(cfg.getExcludeBaselineBugsPaths()));
 
         // rank threshold is handled via BugReporter in SpotBugsExecutor
@@ -38,18 +38,6 @@ public class PreferencesApplier {
             case MAX: return "max";
             default: return "default";
         }
-    }
-
-    private static List<String> resolveExcludeFilterPaths(AnalysisConfig cfg) {
-        List<String> configured = cfg.getExcludeFilterPaths();
-        if (configured != null && !configured.isEmpty()) {
-            return configured;
-        }
-        String legacyPath = normalizePath(cfg.getExcludeFilterPath());
-        if (legacyPath == null) {
-            return Collections.emptyList();
-        }
-        return Collections.singletonList(legacyPath);
     }
 
     private static Map<String, Boolean> toEnabledPathMap(List<String> paths) {

--- a/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisRequestParserTest.java
+++ b/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/command/RunAnalysisRequestParserTest.java
@@ -35,7 +35,6 @@ public class RunAnalysisRequestParserTest {
         resolveFixturePathList(parseablePayload, "includeFilterPaths");
         resolveFixturePathList(parseablePayload, "excludeFilterPaths");
         resolveFixturePathList(parseablePayload, "excludeBaselineBugsPaths");
-        resolveFixturePath(parseablePayload, "excludeFilterPath");
 
         RunAnalysisRequest request = parser.parse(context(
                 fixture.get("targetPath").getAsString(),
@@ -70,10 +69,6 @@ public class RunAnalysisRequestParserTest {
         assertEquals(
                 resolvedFixturePathList(payload, "excludeBaselineBugsPaths"),
                 request.getConfig().getExcludeBaselineBugsPaths()
-        );
-        assertEquals(
-                AnalysisProtocolFixture.resolveRepositoryPath(payload.get("excludeFilterPath").getAsString()),
-                request.getConfig().getExcludeFilterPath()
         );
         assertEquals(
                 Arrays.asList("/workspace/plugin-a.jar", "/workspace/plugin-b.jar"),
@@ -161,13 +156,6 @@ public class RunAnalysisRequestParserTest {
             resolved.add(AnalysisProtocolFixture.resolveRepositoryPath(source.get(index).getAsString()));
         }
         payload.add(fieldName, resolved);
-    }
-
-    private static void resolveFixturePath(JsonObject payload, String fieldName) {
-        payload.addProperty(
-                fieldName,
-                AnalysisProtocolFixture.resolveRepositoryPath(payload.get(fieldName).getAsString())
-        );
     }
 
     private static List<String> resolvedFixturePathList(JsonObject payload, String fieldName) {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -10,8 +10,6 @@ export interface AnalysisSettings {
   includeFilterPaths?: string[];
   excludeFilterPaths?: string[];
   excludeBaselineBugsPaths?: string[];
-  // Legacy payload field kept for compatibility with older Java runner schema.
-  excludeFilterPath?: string;
   plugins?: string[];
 }
 
@@ -25,8 +23,6 @@ export class Config {
   public includeFilterPaths?: string[];
   public excludeFilterPaths?: string[];
   public excludeBaselineBugsPaths?: string[];
-  // Legacy payload field kept for compatibility with older Java runner schema.
-  public excludeFilterPath?: string;
   public plugins?: string[];
   public revealSourceOnSelection!: boolean;
 
@@ -171,8 +167,6 @@ export class Config {
     const excludeFilterPaths = this.resolvePathsToAbsolute(this.excludeFilterPaths, resource);
     if (excludeFilterPaths) {
       settings.excludeFilterPaths = excludeFilterPaths;
-      // Backward compatibility for older Java runner payload schema.
-      settings.excludeFilterPath = excludeFilterPaths[0];
     }
     const excludeBaselineBugsPaths = this.resolvePathsToAbsolute(
       this.excludeBaselineBugsPaths,

--- a/src/lsp/analysisRequestBuilder.ts
+++ b/src/lsp/analysisRequestBuilder.ts
@@ -43,9 +43,6 @@ export function buildAnalysisRequestPayload(
   ) {
     payload.excludeBaselineBugsPaths = settings.excludeBaselineBugsPaths.slice();
   }
-  if (settings.excludeFilterPath) {
-    payload.excludeFilterPath = settings.excludeFilterPath;
-  }
   if (Array.isArray(settings.plugins) && settings.plugins.length > 0) {
     payload.plugins = settings.plugins.slice();
   }

--- a/src/model/analysisProtocol.ts
+++ b/src/model/analysisProtocol.ts
@@ -14,8 +14,6 @@ export interface AnalysisRequestPayload {
   includeFilterPaths?: string[];
   excludeFilterPaths?: string[];
   excludeBaselineBugsPaths?: string[];
-  // Legacy field kept for backward compatibility with older runner schema.
-  excludeFilterPath?: string;
   plugins?: string[];
 }
 

--- a/src/test/L0.analysisRequestBuilder.test.ts
+++ b/src/test/L0.analysisRequestBuilder.test.ts
@@ -19,7 +19,6 @@ describe('analysisRequestBuilder', () => {
     const includeFilterPaths = ['test-fixtures/analysis-protocol/include-filter.xml'];
     const excludeFilterPaths = ['test-fixtures/analysis-protocol/exclude-filter.xml'];
     const excludeBaselineBugsPaths = ['test-fixtures/analysis-protocol/baseline-bugs.xml'];
-    const excludeFilterPath = 'test-fixtures/analysis-protocol/legacy-exclude-filter.xml';
 
     const payload = buildAnalysisRequestPayload(
       makeSettings({
@@ -28,7 +27,6 @@ describe('analysisRequestBuilder', () => {
         includeFilterPaths,
         excludeFilterPaths,
         excludeBaselineBugsPaths,
-        excludeFilterPath,
         plugins: ['/workspace/plugin-a.jar', '/workspace/plugin-b.jar'],
         priorityThreshold: 5,
       }),
@@ -95,19 +93,6 @@ describe('analysisRequestBuilder', () => {
     assert.strictEqual('includeFilterPaths' in payload, false);
     assert.strictEqual('excludeFilterPaths' in payload, false);
     assert.strictEqual('excludeBaselineBugsPaths' in payload, false);
-  });
-
-  it('keeps legacy excludeFilterPath for backward compatibility', () => {
-    const payload = buildAnalysisRequestPayload(
-      makeSettings({
-        excludeFilterPaths: ['/tmp/spotbugs/exclude.xml'],
-        excludeFilterPath: '/tmp/spotbugs/exclude.xml',
-      }),
-      {}
-    );
-
-    assert.deepStrictEqual(payload.excludeFilterPaths, ['/tmp/spotbugs/exclude.xml']);
-    assert.strictEqual(payload.excludeFilterPath, '/tmp/spotbugs/exclude.xml');
   });
 
   it('copies filter arrays to prevent payload mutation from caller arrays', () => {

--- a/test-fixtures/analysis-protocol/legacy-exclude-filter.xml
+++ b/test-fixtures/analysis-protocol/legacy-exclude-filter.xml
@@ -1,1 +1,0 @@
-<FindBugsFilter/>

--- a/test-fixtures/analysis-protocol/run-analysis-request-full.json
+++ b/test-fixtures/analysis-protocol/run-analysis-request-full.json
@@ -28,7 +28,6 @@
     "excludeBaselineBugsPaths": [
       "test-fixtures/analysis-protocol/baseline-bugs.xml"
     ],
-    "excludeFilterPath": "test-fixtures/analysis-protocol/legacy-exclude-filter.xml",
     "plugins": [
       "/workspace/plugin-a.jar",
       "/workspace/plugin-b.jar"


### PR DESCRIPTION
## Summary

- Remove the legacy singular excludeFilterPath request field.
- Use excludeFilterPaths consistently across TypeScript and Java.