### PR TITLE
refactor: extract command response envelope

### DIFF
--- a/src/lsp/commandResponseEnvelope.ts
+++ b/src/lsp/commandResponseEnvelope.ts
@@ -1,0 +1,67 @@
+import type { AnalysisError } from '../model/analysisProtocol';
+
+export interface DecodedCommandResponseEnvelope {
+  envelope: Record<string, unknown>;
+  results?: unknown[];
+  errors?: AnalysisError[];
+}
+
+export function decodeCommandResponseEnvelope(
+  value: unknown
+): DecodedCommandResponseEnvelope | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const hasResults = Object.prototype.hasOwnProperty.call(value, 'results');
+  const hasErrors = Object.prototype.hasOwnProperty.call(value, 'errors');
+  if (!hasResults && !hasErrors) {
+    return undefined;
+  }
+
+  const rawResults = value.results;
+  const rawErrors = value.errors;
+  if (hasResults && !Array.isArray(rawResults)) {
+    return undefined;
+  }
+  if (hasErrors && !Array.isArray(rawErrors)) {
+    return undefined;
+  }
+
+  const results = hasResults ? (rawResults as unknown[]) : undefined;
+  const errors = hasErrors ? normalizeCommandIssues(rawErrors as unknown[]) : undefined;
+  if (!hasResults && (!errors || errors.length === 0)) {
+    return undefined;
+  }
+
+  return {
+    envelope: value,
+    results,
+    errors,
+  };
+}
+
+export function normalizeCommandIssues(values: readonly unknown[]): AnalysisError[] {
+  const issues: AnalysisError[] = [];
+  for (const item of values) {
+    if (!isRecord(item)) {
+      continue;
+    }
+
+    const issue: AnalysisError = {};
+    if (typeof item.code === 'string') {
+      issue.code = item.code;
+    }
+    if (typeof item.message === 'string') {
+      issue.message = item.message;
+    }
+    if (issue.code || issue.message) {
+      issues.push(issue);
+    }
+  }
+  return issues;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}

--- a/src/lsp/spotbugsParser.ts
+++ b/src/lsp/spotbugsParser.ts
@@ -5,6 +5,10 @@ import {
 } from '../model/analysisProtocol';
 import { Bug } from '../model/bug';
 import type { AnalysisReportSummary } from '../model/analysisReport';
+import {
+  decodeCommandResponseEnvelope,
+  normalizeCommandIssues,
+} from './commandResponseEnvelope';
 
 export type ParseErrorKind = 'invalid-json' | 'analysis-error';
 
@@ -60,57 +64,45 @@ export function parseAnalysisResponse(raw: string): ParseResult {
     return isBugArray(parsed) ? { ok: true, value: { bugs: parsed } } : invalidResponse();
   }
 
-  if (parsed && typeof parsed === 'object') {
-    const envelope = parsed as Record<string, unknown>;
-    const hasResults = Object.prototype.hasOwnProperty.call(envelope, 'results');
-    const hasErrors = Object.prototype.hasOwnProperty.call(envelope, 'errors');
-    const hasWarnings = Object.prototype.hasOwnProperty.call(envelope, 'warnings');
-    if (!hasResults && !hasErrors) {
-      return invalidResponse();
-    }
-    if (hasResults && !isBugArray(envelope.results)) {
-      return invalidResponse();
-    }
-    if (hasErrors && !Array.isArray(envelope.errors)) {
-      return invalidResponse();
-    }
-
-    const errors = hasErrors ? normalizeAnalysisErrors(envelope.errors) : undefined;
-    if (!hasResults && Array.isArray(errors) && errors.length === 0) {
-      return invalidResponse();
-    }
-
-    const warnings =
-      hasWarnings && Array.isArray(envelope.warnings)
-        ? normalizeAnalysisWarnings(envelope.warnings)
-        : undefined;
-    const ignoredMalformedWarnings =
-      hasWarnings && !Array.isArray(envelope.warnings) ? true : undefined;
-    const bugs = hasResults ? (envelope.results as Bug[]) : [];
-    const stats = normalizeAnalysisStats(envelope.stats);
-    const reportSummary = normalizeAnalysisReportSummary(envelope.reportSummary);
-    const nativeSarif =
-      typeof envelope.nativeSarif === 'string' && envelope.nativeSarif.trim().length > 0
-        ? envelope.nativeSarif
-        : undefined;
-    const schemaVersion =
-      typeof envelope.schemaVersion === 'number' ? envelope.schemaVersion : undefined;
-    return {
-      ok: true,
-      value: {
-        bugs,
-        errors,
-        warnings,
-        ignoredMalformedWarnings,
-        stats,
-        reportSummary,
-        nativeSarif,
-        schemaVersion,
-      },
-    };
+  const decoded = decodeCommandResponseEnvelope(parsed);
+  if (!decoded) {
+    return invalidResponse();
   }
 
-  return invalidResponse();
+  const { envelope, errors, results } = decoded;
+  if (results && !isBugArray(results)) {
+    return invalidResponse();
+  }
+
+  const hasWarnings = Object.prototype.hasOwnProperty.call(envelope, 'warnings');
+  const warnings =
+    hasWarnings && Array.isArray(envelope.warnings)
+      ? normalizeAnalysisWarnings(envelope.warnings)
+      : undefined;
+  const ignoredMalformedWarnings =
+    hasWarnings && !Array.isArray(envelope.warnings) ? true : undefined;
+  const bugs = results ? (results as Bug[]) : [];
+  const stats = normalizeAnalysisStats(envelope.stats);
+  const reportSummary = normalizeAnalysisReportSummary(envelope.reportSummary);
+  const nativeSarif =
+    typeof envelope.nativeSarif === 'string' && envelope.nativeSarif.trim().length > 0
+      ? envelope.nativeSarif
+      : undefined;
+  const schemaVersion =
+    typeof envelope.schemaVersion === 'number' ? envelope.schemaVersion : undefined;
+  return {
+    ok: true,
+    value: {
+      bugs,
+      errors,
+      warnings,
+      ignoredMalformedWarnings,
+      stats,
+      reportSummary,
+      nativeSarif,
+      schemaVersion,
+    },
+  };
 }
 
 function normalizeAnalysisReportSummary(
@@ -141,33 +133,8 @@ function isBugArray(value: unknown): value is Bug[] {
   return Array.isArray(value) && value.every(isRecord);
 }
 
-function normalizeAnalysisErrors(value: unknown): AnalysisError[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  const errors: AnalysisError[] = [];
-  for (const item of value) {
-    if (!isRecord(item)) {
-      continue;
-    }
-
-    const error: AnalysisError = {};
-    if (typeof item.code === 'string') {
-      error.code = item.code;
-    }
-    if (typeof item.message === 'string') {
-      error.message = item.message;
-    }
-    if (error.code || error.message) {
-      errors.push(error);
-    }
-  }
-  return errors;
-}
-
 function normalizeAnalysisWarnings(value: unknown[]): AnalysisWarning[] {
-  return normalizeAnalysisErrors(value).filter(
+  return normalizeCommandIssues(value).filter(
     (warning) => typeof warning.code === 'string' && typeof warning.message === 'string'
   );
 }

--- a/src/services/pluginInventoryService.ts
+++ b/src/services/pluginInventoryService.ts
@@ -1,6 +1,7 @@
 import type { Uri } from 'vscode';
 import { SpotBugsLSCommands } from '../constants/commands';
 import type { Config } from '../core/config';
+import { decodeCommandResponseEnvelope } from '../lsp/commandResponseEnvelope';
 import { executeWorkspaceCommand } from '../lsp/javaLsGateway';
 import type { AnalysisError } from '../model/analysisProtocol';
 
@@ -57,23 +58,12 @@ export function parsePluginInventoryResponse(raw: string): PluginInventoryParseR
     return invalidResponse();
   }
 
-  if (!isRecord(parsed)) {
+  const decoded = decodeCommandResponseEnvelope(parsed);
+  if (!decoded) {
     return invalidResponse();
   }
 
-  const hasResults = Object.prototype.hasOwnProperty.call(parsed, 'results');
-  const hasErrors = Object.prototype.hasOwnProperty.call(parsed, 'errors');
-  if (!hasResults && !hasErrors) {
-    return invalidResponse();
-  }
-  if (hasResults && !Array.isArray(parsed.results)) {
-    return invalidResponse();
-  }
-  if (hasErrors && !Array.isArray(parsed.errors)) {
-    return invalidResponse();
-  }
-
-  const resultValues = hasResults ? (parsed.results as unknown[]) : [];
+  const resultValues = decoded.results ?? [];
   if (
     resultValues.some(
       (value) => !isRecord(value) || !Number.isInteger(value.index)
@@ -83,16 +73,12 @@ export function parsePluginInventoryResponse(raw: string): PluginInventoryParseR
   }
 
   const items = normalizeItems(resultValues);
-  const errors = hasErrors ? normalizeErrors(parsed.errors) : undefined;
-  if (!hasResults && Array.isArray(errors) && errors.length === 0) {
-    return invalidResponse();
-  }
 
   return {
     ok: true,
     value: {
       items,
-      errors,
+      errors: decoded.errors,
     },
   };
 }
@@ -153,30 +139,6 @@ function normalizeStatus(value: unknown): PluginInventoryStatus {
     default:
       return 'backend-error';
   }
-}
-
-function normalizeErrors(value: unknown): AnalysisError[] | undefined {
-  if (!Array.isArray(value)) {
-    return undefined;
-  }
-
-  const errors: AnalysisError[] = [];
-  for (const item of value) {
-    if (!isRecord(item)) {
-      continue;
-    }
-    const error: AnalysisError = {};
-    if (typeof item.code === 'string') {
-      error.code = item.code;
-    }
-    if (typeof item.message === 'string') {
-      error.message = item.message;
-    }
-    if (error.code || error.message) {
-      errors.push(error);
-    }
-  }
-  return errors;
 }
 
 function invalidResponse(): PluginInventoryParseResult {

--- a/src/test/L0.commandResponseEnvelope.test.ts
+++ b/src/test/L0.commandResponseEnvelope.test.ts
@@ -1,0 +1,75 @@
+import * as assert from 'assert';
+import { decodeCommandResponseEnvelope } from '../lsp/commandResponseEnvelope';
+
+describe('commandResponseEnvelope', () => {
+  it('decodes results-only envelopes and preserves additional fields', () => {
+    const envelope = {
+      results: [{ value: 1 }],
+      metadata: 'preserved',
+    };
+
+    const decoded = decodeCommandResponseEnvelope(envelope);
+
+    assert.ok(decoded);
+    assert.strictEqual(decoded.envelope.metadata, 'preserved');
+    assert.deepStrictEqual(decoded.results, [{ value: 1 }]);
+    assert.strictEqual(decoded.errors, undefined);
+  });
+
+  it('normalizes valid command issues in errors-only envelopes', () => {
+    const decoded = decodeCommandResponseEnvelope({
+      errors: [
+        null,
+        'bad',
+        {},
+        { code: 7, message: 'message only' },
+        { code: 'CODE_ONLY', message: 9 },
+        { code: 'VALID', message: 'valid message', extra: 'ignored' },
+        { code: '', message: 'non-empty message' },
+        { code: 'NON_EMPTY_CODE', message: '' },
+        { code: '', message: '' },
+      ],
+    });
+
+    assert.ok(decoded);
+    assert.strictEqual(decoded.results, undefined);
+    assert.deepStrictEqual(decoded.errors, [
+      { message: 'message only' },
+      { code: 'CODE_ONLY' },
+      { code: 'VALID', message: 'valid message' },
+      { code: '', message: 'non-empty message' },
+      { code: 'NON_EMPTY_CODE', message: '' },
+    ]);
+  });
+
+  it('rejects values without a usable command envelope or array fields', () => {
+    const samples: unknown[] = [
+      null,
+      'bad',
+      [],
+      {},
+      { errors: [] },
+      { errors: [null, 'bad', {}] },
+      { results: null },
+      { results: {} },
+      { errors: null },
+      { errors: {} },
+      { results: [], errors: null },
+    ];
+
+    for (const sample of samples) {
+      assert.strictEqual(decodeCommandResponseEnvelope(sample), undefined);
+    }
+  });
+
+  it('keeps present malformed errors as an empty array when results are present', () => {
+    const decoded = decodeCommandResponseEnvelope({
+      results: [],
+      errors: [null, 'bad', {}],
+    });
+
+    assert.ok(decoded);
+    assert.deepStrictEqual(decoded.results, []);
+    assert.deepStrictEqual(decoded.errors, []);
+  });
+});

--- a/src/test/L0.spotbugsParser.test.ts
+++ b/src/test/L0.spotbugsParser.test.ts
@@ -14,7 +14,14 @@ describe('spotbugsParser', () => {
   });
 
   it('returns analysis-error when payload contains top-level error', () => {
-    const result = parseAnalysisResponse(JSON.stringify({ error: 'boom' }));
+    const result = parseAnalysisResponse(
+      JSON.stringify({
+        error: 'boom',
+        results: [],
+        errors: [],
+      })
+    );
+
     assert.strictEqual(result.ok, false);
     if (!result.ok) {
       assert.strictEqual(result.error.kind, 'analysis-error');
@@ -92,12 +99,35 @@ describe('spotbugsParser', () => {
     }
   });
 
+  it('parses errors-only envelopes without results', () => {
+    const result = parseAnalysisResponse(
+      JSON.stringify({
+        errors: [{ code: 'ANALYSIS_FAILED', message: 'boom' }],
+      })
+    );
+
+    assert.strictEqual(result.ok, true);
+    if (result.ok) {
+      assert.deepStrictEqual(result.value.bugs, []);
+      assert.deepStrictEqual(result.value.errors, [
+        { code: 'ANALYSIS_FAILED', message: 'boom' },
+      ]);
+    }
+  });
+
   it('parses empty results with warnings as a successful response', () => {
     const result = parseAnalysisResponse(
       JSON.stringify({
         schemaVersion: 2,
         results: [],
-        warnings: [{ code: 'PLUGIN_CLEANUP_FAILED', message: 'Could not delete plugin' }],
+        warnings: [
+          { code: 'PLUGIN_CLEANUP_FAILED', message: 'Could not delete plugin' },
+          { code: 'CODE_ONLY' },
+          { message: 'message only' },
+          { code: '', message: 'non-empty message' },
+          { code: 'NON_EMPTY_CODE', message: '' },
+          { code: '', message: '' },
+        ],
       })
     );
 
@@ -106,7 +136,25 @@ describe('spotbugsParser', () => {
       assert.deepStrictEqual(result.value.bugs, []);
       assert.deepStrictEqual(result.value.warnings, [
         { code: 'PLUGIN_CLEANUP_FAILED', message: 'Could not delete plugin' },
+        { code: '', message: 'non-empty message' },
+        { code: 'NON_EMPTY_CODE', message: '' },
       ]);
+      assert.strictEqual(result.value.ignoredMalformedWarnings, undefined);
+    }
+  });
+
+  it('marks malformed warning fields without rejecting the envelope', () => {
+    const malformed = parseAnalysisResponse(
+      JSON.stringify({
+        results: [],
+        warnings: { code: 'INVALID_SHAPE', message: 'not an array' },
+      })
+    );
+
+    assert.strictEqual(malformed.ok, true);
+    if (malformed.ok) {
+      assert.strictEqual(malformed.value.warnings, undefined);
+      assert.strictEqual(malformed.value.ignoredMalformedWarnings, true);
     }
   });
 


### PR DESCRIPTION
## Summary

- Extract shared CommandResponse envelope decoding.
- Reuse it for analysis and plugin inventory responses.