### PR TITLE
Fix diagnostic underlines on indentation

### DIFF
--- a/src/services/diagnosticsManager.ts
+++ b/src/services/diagnosticsManager.ts
@@ -3,6 +3,7 @@ import {
   Diagnostic,
   DiagnosticCollection,
   DiagnosticSeverity,
+  Disposable,
   languages,
   Position,
   Range,
@@ -34,14 +35,22 @@ type FindingBucket = {
 
 export class SpotBugsDiagnosticsManager {
   private readonly collection: DiagnosticCollection;
+  private readonly documentOpenSubscription: Disposable;
   private readonly findingsByFile = new Map<string, FindingRange[]>();
   private readonly filesByReturnedScope = new Map<string, Set<string>>();
 
   constructor() {
     this.collection = languages.createDiagnosticCollection('spotbugs');
+    this.documentOpenSubscription = workspace.onDidOpenTextDocument((document) => {
+      const entries = this.findingsByFile.get(document.uri.toString());
+      if (entries) {
+        this.publishGrouped(this.groupFindings(entries.map(({ finding }) => finding)));
+      }
+    });
   }
 
   dispose(): void {
+    this.documentOpenSubscription.dispose();
     this.collection.dispose();
     this.findingsByFile.clear();
     this.filesByReturnedScope.clear();

--- a/src/services/diagnosticsManager.ts
+++ b/src/services/diagnosticsManager.ts
@@ -151,7 +151,15 @@ export class SpotBugsDiagnosticsManager {
     if (startLine === undefined || endLine === undefined) {
       return undefined;
     }
-    return new Range(startLine, 0, endLine, Number.MAX_SAFE_INTEGER);
+    const uri = this.resolveFileUri(finding);
+    const document = uri
+      ? workspace.textDocuments.find((candidate) => candidate.uri.toString() === uri.toString())
+      : undefined;
+    const startCharacter =
+      document && startLine < document.lineCount
+        ? document.lineAt(startLine).firstNonWhitespaceCharacterIndex
+        : 0;
+    return new Range(startLine, startCharacter, endLine, Number.MAX_SAFE_INTEGER);
   }
 
   private resolveFileUri(finding: Finding): Uri | undefined {

--- a/src/test/L1.diagnosticsRuleDocs.vscode.test.ts
+++ b/src/test/L1.diagnosticsRuleDocs.vscode.test.ts
@@ -156,6 +156,7 @@ describe('SpotBugs scoped diagnostics', () => {
       const { rootUri, fileUri } = await createTempJavaFile(
         'src/main/java/demo/Repro.java'
       );
+      await fs.writeFile(fileUri.fsPath, '    class Example {}\n', 'utf8');
 
       manager.replaceForScope(
         { kind: 'folder', uri: rootUri },
@@ -163,6 +164,8 @@ describe('SpotBugs scoped diagnostics', () => {
       );
 
       assertPublishedFinding(manager, fileUri, 'NP_ALWAYS_NULL');
+      await vscode.workspace.openTextDocument(fileUri);
+      assert.strictEqual(spotbugsDiagnostics(fileUri)[0].range.start.character, 4);
       assert.strictEqual(spotbugsDiagnostics(rootUri).length, 0);
     } finally {
       manager.dispose();

--- a/src/test/L1.diagnosticsRuleDocs.vscode.test.ts
+++ b/src/test/L1.diagnosticsRuleDocs.vscode.test.ts
@@ -27,12 +27,13 @@ describe('SpotBugs diagnostic explanations', () => {
   it('uses a plain diagnostic code when local HTML detail is available', async () => {
     const manager = new SpotBugsDiagnosticsManager();
     try {
-      const document = await openTempJavaDocument();
+      const document = await openTempJavaDocument('    class Example {}\n');
       manager.replaceAll([createFinding(document.uri, { detailHtml, helpUri })]);
 
       const diagnostics = spotbugsDiagnostics(document.uri);
       assert.strictEqual(diagnostics.length, 1);
       assert.strictEqual(diagnostics[0].code, 'NP_ALWAYS_NULL');
+      assert.strictEqual(diagnostics[0].range.start.character, 4);
     } finally {
       manager.dispose();
     }
@@ -314,12 +315,14 @@ describe('SpotBugs scoped diagnostics', () => {
   });
 });
 
-async function openTempJavaDocument(): Promise<vscode.TextDocument> {
+async function openTempJavaDocument(
+  contents = 'class Example {}\n'
+): Promise<vscode.TextDocument> {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'spotbugs-diagnostic-docs-'));
   cleanupPath(tempDir);
 
   const targetFile = path.join(tempDir, 'Example.java');
-  await fs.writeFile(targetFile, 'class Example {}\n', 'utf8');
+  await fs.writeFile(targetFile, contents, 'utf8');
   return vscode.workspace.openTextDocument(vscode.Uri.file(targetFile));
 }
 

--- a/src/test/helpers/mockVscode.ts
+++ b/src/test/helpers/mockVscode.ts
@@ -121,6 +121,7 @@ type VscodeMock = {
   Range: typeof MockRange;
   workspace: {
     workspaceFolders: WorkspaceFolder[];
+    textDocuments: unknown[];
     getConfiguration: (section?: string) => {
       get: <T>(key: string) => T | undefined;
     };
@@ -128,6 +129,7 @@ type VscodeMock = {
     onDidChangeConfiguration: (
       listener: (event: { affectsConfiguration: (section: string) => boolean }) => unknown
     ) => { dispose: () => void };
+    onDidOpenTextDocument: (listener: (document: unknown) => unknown) => { dispose: () => void };
     fs: {
       stat: (uri: MockUri) => Promise<unknown>;
     };
@@ -304,6 +306,7 @@ function createVscodeMock(overrides: Partial<VscodeMock> = {}): VscodeMock {
   const workspaceFolders = overrides.workspace?.workspaceFolders ?? [];
   const workspace = {
     workspaceFolders,
+    textDocuments: overrides.workspace?.textDocuments ?? [],
     getConfiguration:
       overrides.workspace?.getConfiguration ??
       (() => ({
@@ -315,6 +318,9 @@ function createVscodeMock(overrides: Partial<VscodeMock> = {}): VscodeMock {
         workspaceFolders.find((folder) => uri.fsPath.startsWith(folder.uri.fsPath))),
     onDidChangeConfiguration:
       overrides.workspace?.onDidChangeConfiguration ??
+      (() => ({ dispose: () => undefined })),
+    onDidOpenTextDocument:
+      overrides.workspace?.onDidOpenTextDocument ??
       (() => ({ dispose: () => undefined })),
     fs: {
       stat: overrides.workspace?.fs?.stat ?? (async () => ({})),

--- a/src/test/helpers/mockVscode.ts
+++ b/src/test/helpers/mockVscode.ts
@@ -288,9 +288,11 @@ function createTelemetryWrapperMock(
 function updateVscodeMock(target: VscodeMock, source: VscodeMock): void {
   Object.assign(target.workspace.fs, source.workspace.fs);
   target.workspace.workspaceFolders = source.workspace.workspaceFolders;
+  target.workspace.textDocuments = source.workspace.textDocuments;
   target.workspace.getConfiguration = source.workspace.getConfiguration;
   target.workspace.getWorkspaceFolder = source.workspace.getWorkspaceFolder;
   target.workspace.onDidChangeConfiguration = source.workspace.onDidChangeConfiguration;
+  target.workspace.onDidOpenTextDocument = source.workspace.onDidOpenTextDocument;
   Object.assign(target.window, source.window);
   Object.assign(target.commands, source.commands);
   Object.assign(target.env.clipboard, source.env.clipboard);


### PR DESCRIPTION
## Summary

- Start SpotBugs diagnostics at the first non-whitespace character.

## Testing

- [x] `npm run lint`
- [x] `npm run format:check`
- [ ] `npm test`
- [x] Other: `npm run compile`; VS Code integration tests (10 passing)

## Notes

- `npm test` has an unrelated existing `resultsExplorerCommands` failure.

BEGIN_COMMIT_OVERRIDE
fix(ui): align diagnostic underlines with non-whitespace code
END_COMMIT_OVERRIDE