### PR TITLE
Clarify empty SpotBugs search message

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -110,7 +110,7 @@
   "A SpotBugs suppression is already in progress.": "A SpotBugs suppression is already in progress.",
   "Severity / Rank": "Severity / Rank",
   "Path / Line": "Path / Line",
-  "No cached SpotBugs findings available to search.": "No cached SpotBugs findings available to search.",
+  "No SpotBugs results available to search.": "No SpotBugs results available to search.",
   "SpotBugs Search Results": "SpotBugs Search Results",
   "Search SpotBugs results": "Search SpotBugs results",
   "No cached SpotBugs findings available to clear search.": "No cached SpotBugs findings available to clear search.",

--- a/l10n/bundle.l10n.ko.json
+++ b/l10n/bundle.l10n.ko.json
@@ -41,7 +41,7 @@
   "No cached SpotBugs findings available to clear search.": "검색을 지울 캐시된 SpotBugs 발견 항목이 없습니다.",
   "No cached SpotBugs findings available to filter.": "필터링할 캐시된 SpotBugs 발견 항목이 없습니다.",
   "No cached SpotBugs findings available to group.": "그룹화할 캐시된 SpotBugs 발견 항목이 없습니다.",
-  "No cached SpotBugs findings available to search.": "검색할 캐시된 SpotBugs 발견 항목이 없습니다.",
+  "No SpotBugs results available to search.": "검색할 SpotBugs 결과가 없습니다.",
   "No cached SpotBugs findings available to sort.": "정렬할 캐시된 SpotBugs 발견 항목이 없습니다.",
   "No cached findings match the current view.": "현재 보기와 일치하는 캐시된 발견 항목이 없습니다.",
   "No issues found.": "문제가 발견되지 않았습니다.",

--- a/src/commands/resultsExplorer.ts
+++ b/src/commands/resultsExplorer.ts
@@ -26,7 +26,7 @@ export async function searchResults(
 ): Promise<void> {
   if (provider.getCachedFindings().length === 0) {
     await window.showInformationMessage(
-      l10n.t('No cached SpotBugs findings available to search.')
+      l10n.t('No SpotBugs results available to search.')
     );
     return;
   }

--- a/src/test/L1.resultsExplorerCommands.test.ts
+++ b/src/test/L1.resultsExplorerCommands.test.ts
@@ -180,7 +180,7 @@ describe('resultsExplorerCommands', () => {
     assert.strictEqual(inputCount, 0);
     assert.strictEqual(quickPickCount, 0);
     assert.deepStrictEqual(messages, [
-      'No cached SpotBugs findings available to search.',
+      'No SpotBugs results available to search.',
       'No cached SpotBugs findings available to clear search.',
       'No cached SpotBugs findings available to group.',
       'No cached SpotBugs findings available to sort.',


### PR DESCRIPTION
## Summary

- Replace internal cache terminology with user-facing SpotBugs results wording.
- Update English/Korean localization and the related test.

## Testing

- [x] `npm run lint`
- [ ] `npm run format:check`
- [ ] `npm test`
- [x] Other: `npm run compile`; targeted L1 message test

## Notes

- Full unit run: 339 passed, 1 unrelated command-registration test failed.

BEGIN_COMMIT_OVERRIDE
fix(ui): clarify empty SpotBugs search message
END_COMMIT_OVERRIDE