### PR TITLE
Improve source ranges for class-derived findings

### DIFF
--- a/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/api/BugInfo.java
+++ b/javaext/com.spotbugs.runner/src/main/java/com/spotbugs/vscode/runner/api/BugInfo.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import com.google.gson.annotations.SerializedName;
 import com.spotbugs.vscode.runner.internal.SourcePathPolicy;
 
 import edu.umd.cs.findbugs.BugAnnotation;
@@ -40,6 +41,7 @@ public class BugInfo {
     private final String methodName;
     private final String methodSignature;
     private final String fieldName;
+    private final LocationOrigin locationOrigin;
     private String fullPath;
 
     public BugInfo(BugInstance bugInstance) {
@@ -87,6 +89,7 @@ public class BugInfo {
         this.fieldName = optionalString(fieldAnnotation != null ? fieldAnnotation.getFieldName() : null);
 
         SourceLineAnnotation sla = bugInstance.getPrimarySourceLineAnnotation();
+        this.locationOrigin = classifyLocationOrigin(bugInstance, sla);
         if (sla != null) {
             String safeSourceFile = SourcePathPolicy.sourceFileName(sla.getSourceFile());
             String safeSourcePath = safeSourceFile == null
@@ -203,6 +206,10 @@ public class BugInfo {
         return fieldName;
     }
 
+    public LocationOrigin getLocationOrigin() {
+        return locationOrigin;
+    }
+
     public String getFullPath() {
         return fullPath;
     }
@@ -223,6 +230,35 @@ public class BugInfo {
 
     private static Integer optionalInteger(int value) {
         return value > 0 ? Integer.valueOf(value) : null;
+    }
+
+    private static LocationOrigin classifyLocationOrigin(
+            BugInstance bugInstance,
+            SourceLineAnnotation selectedSource
+    ) {
+        if (selectedSource == null) {
+            return LocationOrigin.UNKNOWN;
+        }
+        if (!selectedSource.isUnknown()) {
+            for (BugAnnotation annotation : bugInstance.getAnnotations()) {
+                if (annotation == selectedSource) {
+                    return LocationOrigin.DIRECT_SOURCE_LINE;
+                }
+            }
+        }
+        MethodAnnotation method = bugInstance.getPrimaryMethod();
+        if (method != null && method.getSourceLines() == selectedSource) {
+            return LocationOrigin.PRIMARY_METHOD;
+        }
+        FieldAnnotation field = bugInstance.getPrimaryField();
+        if (field != null && field.getSourceLines() == selectedSource) {
+            return LocationOrigin.PRIMARY_FIELD;
+        }
+        ClassAnnotation clazz = bugInstance.getPrimaryClass();
+        if (clazz != null && clazz.getSourceLines() == selectedSource) {
+            return LocationOrigin.PRIMARY_CLASS;
+        }
+        return LocationOrigin.UNKNOWN;
     }
 
     private static String stablePriority(int priority) {
@@ -256,5 +292,23 @@ public class BugInfo {
             }
         }
         return Collections.unmodifiableList(messages);
+    }
+
+    /** Identifies the SpotBugs branch that supplied the source range, not its precision. */
+    public enum LocationOrigin {
+        @SerializedName("directSourceLine")
+        DIRECT_SOURCE_LINE,
+
+        @SerializedName("primaryMethod")
+        PRIMARY_METHOD,
+
+        @SerializedName("primaryField")
+        PRIMARY_FIELD,
+
+        @SerializedName("primaryClass")
+        PRIMARY_CLASS,
+
+        @SerializedName("unknown")
+        UNKNOWN
     }
 }

--- a/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/BugInfoLocationOriginTest.java
+++ b/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/BugInfoLocationOriginTest.java
@@ -1,0 +1,73 @@
+package com.spotbugs.vscode.runner.internal;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonParser;
+import com.spotbugs.vscode.runner.api.BugInfo;
+
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.ClassAnnotation;
+import edu.umd.cs.findbugs.FieldAnnotation;
+import edu.umd.cs.findbugs.MethodAnnotation;
+import edu.umd.cs.findbugs.Priorities;
+import edu.umd.cs.findbugs.SourceLineAnnotation;
+
+public class BugInfoLocationOriginTest {
+
+    private static final String CLASS_NAME = "com.acme.Example";
+    private static final String SOURCE_FILE = "Example.java";
+
+    @Test
+    public void classifiesSupportedLocationOrigins() {
+        assertEquals(
+                "directSourceLine",
+                origin(info(bug().addClass(CLASS_NAME).addSourceLine(source(10, 10))))
+        );
+
+        MethodAnnotation method = new MethodAnnotation(CLASS_NAME, "run", "()V", false);
+        method.setSourceLines(source(20, 24));
+        assertEquals("primaryMethod", origin(info(bug().addClass(CLASS_NAME).addMethod(method))));
+
+        FieldAnnotation field = new FieldAnnotation(CLASS_NAME, "value", "I", false);
+        field.setSourceLines(source(30, 30));
+        assertEquals("primaryField", origin(info(bug().addClass(CLASS_NAME).addField(field))));
+
+        ClassAnnotation clazz = new ClassAnnotation(CLASS_NAME);
+        clazz.setSourceLines(source(34, 289));
+        BugInfo classInfo = info(bug().add(clazz));
+        assertEquals("primaryClass", origin(classInfo));
+        assertEquals(34, classInfo.getStartLine());
+        assertEquals(289, classInfo.getEndLine());
+        assertEquals("\"unknown\"", new Gson().toJson(BugInfo.LocationOrigin.UNKNOWN));
+    }
+
+    @Test
+    public void sharedUnknownTopLevelSourceKeepsMemberOrigin() {
+        SourceLineAnnotation unknown = SourceLineAnnotation.createUnknown(CLASS_NAME, SOURCE_FILE);
+        MethodAnnotation method = new MethodAnnotation(CLASS_NAME, "run", "()V", false);
+        method.setSourceLines(unknown);
+        BugInstance bug = bug().addClass(CLASS_NAME).addSourceLine(unknown).addMethod(method);
+
+        assertEquals("primaryMethod", origin(info(bug)));
+    }
+
+    private static String origin(BugInfo info) {
+        return JsonParser.parseString(new Gson().toJson(info))
+                .getAsJsonObject().get("locationOrigin").getAsString();
+    }
+
+    private static BugInfo info(BugInstance bug) {
+        return new BugInfo(bug);
+    }
+
+    private static BugInstance bug() {
+        return new BugInstance("ICAST_BAD_SHIFT_AMOUNT", Priorities.LOW_PRIORITY);
+    }
+
+    private static SourceLineAnnotation source(int startLine, int endLine) {
+        return new SourceLineAnnotation(CLASS_NAME, SOURCE_FILE, startLine, endLine, 0, 0);
+    }
+}

--- a/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/SpotBugsExecutorPluginLoadingTest.java
+++ b/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/SpotBugsExecutorPluginLoadingTest.java
@@ -1,5 +1,6 @@
 package com.spotbugs.vscode.runner.internal;
 
+import static com.spotbugs.vscode.runner.api.BugInfo.LocationOrigin.PRIMARY_CLASS;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -9,6 +10,7 @@ import static org.junit.Assert.fail;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
@@ -16,7 +18,9 @@ import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 
+import com.spotbugs.vscode.runner.api.BugInfo;
 import com.spotbugs.vscode.runner.api.CommandWarning;
+import com.spotbugs.vscode.runner.internal.fixtures.Struts2EndpointFixture;
 
 import org.junit.After;
 import org.junit.Before;
@@ -30,6 +34,7 @@ import edu.umd.cs.findbugs.Plugin;
 import edu.umd.cs.findbugs.PluginException;
 import edu.umd.cs.findbugs.Project;
 import edu.umd.cs.findbugs.classfile.ClassDescriptor;
+import edu.umd.cs.findbugs.config.UserPreferences;
 
 public class SpotBugsExecutorPluginLoadingTest {
 
@@ -72,6 +77,26 @@ public class SpotBugsExecutorPluginLoadingTest {
                 "FindSecBugs plugin should not leak after analysis completes",
                 Plugin.getByPluginId(FINDSECBUGS_PLUGIN_ID)
         );
+    }
+
+    @Test
+    public void findSecBugsStruts2EndpointKeepsPrimaryClassRange() throws Exception {
+        FindBugs2 findBugs = new FindBugs2();
+        findBugs.setUserPreferences(UserPreferences.createDefaultUserPreferences());
+        Project project = new Project();
+        project.addFile(struts2FixtureClassPath());
+
+        List<BugInfo> bugs = new SpotBugsExecutor(
+                findBugs,
+                project,
+                20,
+                Collections.singletonList(findSecBugsPluginJar().getAbsolutePath())
+        ).executeBugs();
+        BugInfo finding = onlyBugOfType(bugs, "STRUTS2_ENDPOINT");
+
+        assertEquals(PRIMARY_CLASS, finding.getLocationOrigin());
+        assertTrue(finding.getStartLine() > 0);
+        assertTrue(finding.getEndLine() > finding.getStartLine());
     }
 
     @Test
@@ -215,6 +240,24 @@ public class SpotBugsExecutorPluginLoadingTest {
         ));
         assertTrue("FindSecBugs test plugin jar should exist: " + jar.getAbsolutePath(), jar.isFile());
         return jar;
+    }
+
+    private static String struts2FixtureClassPath() throws Exception {
+        URL classFile = Struts2EndpointFixture.class.getResource("Struts2EndpointFixture.class");
+        assertNotNull("Compiled Struts2 endpoint fixture should be available", classFile);
+        return new File(classFile.toURI()).getAbsolutePath();
+    }
+
+    private static BugInfo onlyBugOfType(List<BugInfo> bugs, String type) {
+        BugInfo match = null;
+        for (BugInfo bug : bugs) {
+            if (type.equals(bug.getType())) {
+                assertNull("Fixture should produce exactly one " + type, match);
+                match = bug;
+            }
+        }
+        assertNotNull("Fixture should produce " + type, match);
+        return match;
     }
 
     private static void resetSpotBugsState() {

--- a/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/fixtures/Struts2EndpointFixture.java
+++ b/javaext/com.spotbugs.runner/src/test/java/com/spotbugs/vscode/runner/internal/fixtures/Struts2EndpointFixture.java
@@ -1,0 +1,16 @@
+package com.spotbugs.vscode.runner.internal.fixtures;
+
+public class Struts2EndpointFixture {
+
+    public String before() {
+        return "before";
+    }
+
+    public String execute() {
+        return "success";
+    }
+
+    public String after() {
+        return "after";
+    }
+}

--- a/src/commands/navigation.ts
+++ b/src/commands/navigation.ts
@@ -50,9 +50,12 @@ export async function revealFindingSource(
       // Calculate zero-based line numbers (VS Code uses zero-based indexing)
       const startLineZeroBased = Math.max(0, startLine - 1);
       const endLineZeroBased = Math.max(0, endLine - 1);
+      const start = new Position(startLineZeroBased, 0);
       range = new Range(
-        new Position(startLineZeroBased, 0),
-        new Position(endLineZeroBased, Number.MAX_SAFE_INTEGER)
+        start,
+        finding.location.locationOrigin === 'primaryClass' && endLine > startLine
+          ? start
+          : new Position(endLineZeroBased, Number.MAX_SAFE_INTEGER)
       );
     }
 

--- a/src/lsp/spotbugsMapper.ts
+++ b/src/lsp/spotbugsMapper.ts
@@ -1,5 +1,5 @@
 import { Bug } from '../model/bug';
-import { Finding, FindingLocation } from '../model/finding';
+import { Finding, FindingLocation, SourceLocationOrigin } from '../model/finding';
 
 export function mapBugsToFindings(bugs: Bug[]): Finding[] {
   return bugs.map(mapBugToFinding);
@@ -12,6 +12,7 @@ export function mapBugToFinding(bug: Bug): Finding {
     sourceFile: bug.sourceFile,
     startLine: bug.startLine,
     endLine: bug.endLine,
+    locationOrigin: normalizeLocationOrigin(bug.locationOrigin),
   };
 
   return {
@@ -38,6 +39,19 @@ export function mapBugToFinding(bug: Bug): Finding {
     fieldName: bug.fieldName,
     location,
   };
+}
+
+function normalizeLocationOrigin(value: unknown): SourceLocationOrigin | undefined {
+  switch (value) {
+    case 'directSourceLine':
+    case 'primaryMethod':
+    case 'primaryField':
+    case 'primaryClass':
+    case 'unknown':
+      return value;
+    default:
+      return undefined;
+  }
 }
 
 function normalizeStringArray(value: unknown): string[] | undefined {

--- a/src/model/bug.ts
+++ b/src/model/bug.ts
@@ -22,6 +22,7 @@ export interface Bug {
   sourceFile?: string;
   startLine?: number;
   endLine?: number;
+  locationOrigin?: unknown;
   realSourcePath?: string;
   fullPath?: string;
 }

--- a/src/model/finding.ts
+++ b/src/model/finding.ts
@@ -1,9 +1,17 @@
+export type SourceLocationOrigin =
+  | 'directSourceLine'
+  | 'primaryMethod'
+  | 'primaryField'
+  | 'primaryClass'
+  | 'unknown';
+
 export interface FindingLocation {
   fullPath?: string;
   realSourcePath?: string;
   sourceFile?: string;
   startLine?: number;
   endLine?: number;
+  locationOrigin?: SourceLocationOrigin;
 }
 
 export interface Finding {

--- a/src/services/diagnosticsManager.ts
+++ b/src/services/diagnosticsManager.ts
@@ -168,7 +168,11 @@ export class SpotBugsDiagnosticsManager {
       document && startLine < document.lineCount
         ? document.lineAt(startLine).firstNonWhitespaceCharacterIndex
         : 0;
-    return new Range(startLine, startCharacter, endLine, Number.MAX_SAFE_INTEGER);
+    const diagnosticEndLine =
+      finding.location.locationOrigin === 'primaryClass' && endLine > startLine
+        ? startLine
+        : endLine;
+    return new Range(startLine, startCharacter, diagnosticEndLine, Number.MAX_SAFE_INTEGER);
   }
 
   private resolveFileUri(finding: Finding): Uri | undefined {

--- a/src/test/L0.htmlExporter.test.ts
+++ b/src/test/L0.htmlExporter.test.ts
@@ -41,7 +41,7 @@ describe('htmlExporter', () => {
     assert.ok(html.includes('<th>Replace</th>'));
     assert.ok(html.includes('<td>new</td>'));
     assert.ok(!html.includes('<script'));
-    assert.ok(html.includes('src/Example.java, line 10'));
+    assert.ok(html.includes('src/Example.java, lines 10 to 12'));
     assert.ok(!html.includes('/workspace/project-a/src/Example.java'));
   });
 
@@ -88,6 +88,8 @@ function finding(overrides: Partial<Finding> = {}): Finding {
       fullPath: '/workspace/project-a/src/Example.java',
       realSourcePath: 'src/Example.java',
       startLine: 10,
+      endLine: 12,
+      locationOrigin: 'primaryClass',
     },
     ...overrides,
   };

--- a/src/test/L0.sarifExporter.test.ts
+++ b/src/test/L0.sarifExporter.test.ts
@@ -42,7 +42,8 @@ describe('buildSarifLog', () => {
       location: {
         fullPath: '/__WORKSPACE_ROOT__/src/main/java/example/Example.java',
         startLine: 12,
-        endLine: 12,
+        endLine: 14,
+        locationOrigin: 'primaryClass',
       },
     });
 
@@ -86,6 +87,7 @@ describe('buildSarifLog', () => {
           message: 'Null pointer dereference',
           uri: 'src/main/java/example/Example.java',
           startLine: 12,
+          endLine: 14,
           instanceHash: 'abc123',
         },
       ],

--- a/src/test/L0.spotbugsMapper.test.ts
+++ b/src/test/L0.spotbugsMapper.test.ts
@@ -15,6 +15,7 @@ describe('spotbugsMapper', () => {
       helpUri: 'https://example.test/rule',
       startLine: 3,
       endLine: 4,
+      locationOrigin: 'primaryClass',
       fullPath: '/tmp/Example.java',
     });
 
@@ -25,6 +26,13 @@ describe('spotbugsMapper', () => {
     assert.strictEqual(finding.longDescription, 'Plain text detail');
     assert.strictEqual(finding.helpUri, 'https://example.test/rule');
     assert.strictEqual(finding.location.fullPath, '/tmp/Example.java');
+    assert.strictEqual(finding.location.locationOrigin, 'primaryClass');
+  });
+
+  it('drops unsupported source location origins', () => {
+    const finding = mapBugToFinding({ locationOrigin: 'futureOrigin' });
+
+    assert.strictEqual(finding.location.locationOrigin, undefined);
   });
 
   it('preserves full SpotBugs type while deriving patternId from abbrev', () => {

--- a/src/test/L1.diagnosticsRuleDocs.vscode.test.ts
+++ b/src/test/L1.diagnosticsRuleDocs.vscode.test.ts
@@ -28,12 +28,16 @@ describe('SpotBugs diagnostic explanations', () => {
     const manager = new SpotBugsDiagnosticsManager();
     try {
       const document = await openTempJavaDocument('    class Example {}\n');
-      manager.replaceAll([createFinding(document.uri, { detailHtml, helpUri })]);
+      const finding = createFinding(document.uri, { detailHtml, helpUri });
+      finding.location.endLine = 3;
+      finding.location.locationOrigin = 'primaryClass';
+      manager.replaceAll([finding]);
 
       const diagnostics = spotbugsDiagnostics(document.uri);
       assert.strictEqual(diagnostics.length, 1);
       assert.strictEqual(diagnostics[0].code, 'NP_ALWAYS_NULL');
       assert.strictEqual(diagnostics[0].range.start.character, 4);
+      assert.strictEqual(diagnostics[0].range.end.line, 0);
     } finally {
       manager.dispose();
     }

--- a/src/test/L1.navigation.test.ts
+++ b/src/test/L1.navigation.test.ts
@@ -24,6 +24,8 @@ describe('navigation', () => {
     } as never);
     const { revealFindingSource } = await import('../commands/navigation');
     const finding = makeFinding();
+    finding.location.endLine = 289;
+    finding.location.locationOrigin = 'primaryClass';
 
     await revealFindingSource(finding);
 
@@ -31,6 +33,14 @@ describe('navigation', () => {
     assert.strictEqual(shown[0].uri.fsPath, '/tmp/Example.java');
     assert.strictEqual(shown[0].options.preserveFocus, false);
     assert.strictEqual(shown[0].options.preview, false);
+    const selection = shown[0].options.selection as {
+      start: { line: number; character: number };
+      end: { line: number; character: number };
+    };
+    assert.deepStrictEqual(
+      [selection.start.line, selection.start.character, selection.end.line, selection.end.character],
+      [9, 0, 9, 0]
+    );
   });
 
   it('can preview a selected finding source without stealing focus', async () => {


### PR DESCRIPTION
## Summary

- expose the SpotBugs source-location origin from the Java runner
- collapse multi-line primary-class diagnostics and source navigation to the start line
- preserve the original source range in details, HTML, and SARIF output

## Testing

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test` (unit and VS Code integration suites run separately)
- [x] Other: Java `clean package`, `npm run build-server`, and fresh VSIX packaging

## Notes

The VS Code integration suite passed with the cached 1.129.1 runtime. The latest 1.133.0 macOS bundle currently uses a `Code` executable name that this `@vscode/test-electron` version does not detect.

BEGIN_COMMIT_OVERRIDE
fix(ui): improve source ranges for class-derived findings
END_COMMIT_OVERRIDE