### PR TITLE
Omit missing source details from SpotBugs findings

### DIFF
--- a/src/model/finding.ts
+++ b/src/model/finding.ts
@@ -39,4 +39,19 @@ export interface Finding {
   location: FindingLocation;
 }
 
+export function getFindingSourcePath(finding: Pick<Finding, 'location'>): string | undefined {
+  const candidates = [
+    finding.location.fullPath,
+    finding.location.realSourcePath,
+    finding.location.sourceFile,
+  ];
+  for (const candidate of candidates) {
+    const normalized = candidate?.trim();
+    if (normalized) {
+      return normalized;
+    }
+  }
+  return undefined;
+}
+
 export type FindingSummary = Pick<Finding, 'type' | 'abbrev' | 'message'>;

--- a/src/test/L0.findingFacets.test.ts
+++ b/src/test/L0.findingFacets.test.ts
@@ -100,6 +100,7 @@ describe('findingFacets', () => {
     assert.strictEqual(facets.filterValues.rule, undefined);
     assert.ok(facets.searchableValues.includes('Uncategorized'));
     assert.ok(facets.searchableValues.includes('Unknown rule'));
+    assert.ok(!facets.searchableValues.includes('Unknown source'));
     assert.ok(!facets.searchableValues.includes(MISSING_GROUP_KEYS.category));
   });
 

--- a/src/test/L0.findingInspectorRenderer.test.ts
+++ b/src/test/L0.findingInspectorRenderer.test.ts
@@ -71,6 +71,18 @@ describe('findingInspectorRenderer', () => {
     }
   });
 
+  it('omits source location when no source is available', () => {
+    const finding = makeFinding({ location: {} });
+    const html = renderFindingInspectorHtml(
+      { status: 'selected', finding },
+      'nonce-1'
+    );
+
+    assert.ok(!html.includes('<dt>Location</dt>'));
+    assert.ok(html.includes('data-command="revealSource"'));
+    assert.ok(html.includes('data-command="openDetails"'));
+  });
+
   it('omits docs action when no docs target exists', () => {
     const snapshot: FindingInspectorSnapshot = {
       status: 'selected',

--- a/src/test/L0.resultViewModel.test.ts
+++ b/src/test/L0.resultViewModel.test.ts
@@ -301,20 +301,13 @@ describe('resultViewModel', () => {
     ]);
   });
 
-  it('uses unknown groups for missing concrete values and filters by search before grouping', () => {
+  it('keeps missing path fallbacks out of search while preserving unknown groups', () => {
     const lowMatch = makeFinding({
       patternId: 'LOW_MATCH',
       type: 'LOW_MATCH',
       rank: 12,
       className: undefined,
       location: {},
-    });
-    const hidden = makeFinding({
-      patternId: 'HIDDEN',
-      type: 'HIDDEN',
-      rank: 1,
-      className: 'com.hidden.Foo',
-      location: { fullPath: '/hidden/Foo.java', startLine: 1 },
     });
     const highMatch = makeFinding({
       patternId: 'HIGH_MATCH',
@@ -323,8 +316,10 @@ describe('resultViewModel', () => {
       className: undefined,
       location: {},
     });
-    const visible = buildResultView([lowMatch, hidden, highMatch], {
-      searchQuery: 'unknown source',
+    assert.strictEqual(matchesFindingSearch(lowMatch, 'unknown source'), false);
+
+    const visible = buildResultView([lowMatch, highMatch], {
+      searchQuery: '',
       groupBy: 'path',
       sortBy: 'severityRank',
     });

--- a/src/test/L1.findingViewModel.test.ts
+++ b/src/test/L1.findingViewModel.test.ts
@@ -9,22 +9,22 @@ describe('findingViewModel', () => {
     resetVscodeMock();
   });
 
-  it('uses shared facet labels in finding leaves', async () => {
+  it('omits source metadata from findings without paths', async () => {
     const { toFindingItemView } = await import('../ui/findingViewModel');
     const view = toFindingItemView(
       makeFinding({
         category: undefined,
         priority: 'unknown',
         rank: 14,
-        location: { startLine: 0 },
+        location: { startLine: 10, endLine: 10 },
       })
     );
 
-    assert.strictEqual(view.description, 'Unknown source • Uncategorized');
+    assert.strictEqual(view.description, 'Uncategorized');
     assert.ok(view.tooltip.includes('Category: Uncategorized'));
     assert.ok(view.tooltip.includes('Priority: Low'));
-    assert.ok(view.tooltip.includes('File: Unknown source'));
-    assert.ok(!view.tooltip.includes('Line: 0'));
+    assert.ok(!view.tooltip.includes('File:'));
+    assert.ok(!view.tooltip.includes('Line: 10'));
   });
 });
 

--- a/src/ui/findingFacets.ts
+++ b/src/ui/findingFacets.ts
@@ -2,7 +2,7 @@ import {
   formatFindingPatternLabel,
   rankToSeverity,
 } from '../formatters/findingFormatting';
-import { Finding } from '../model/finding';
+import { Finding, getFindingSourcePath } from '../model/finding';
 
 export type FindingFacetFilterKind =
   | 'severity'
@@ -56,11 +56,7 @@ export function toFindingFacets(finding: Finding): FindingFacets {
   const categoryLabel = categoryKey;
   const packageKey = extractPackageName(finding);
   const classKey = valueOrUndefined(finding.className);
-  const pathKey = firstDefined(
-    finding.location.fullPath,
-    finding.location.realSourcePath,
-    finding.location.sourceFile
-  );
+  const pathKey = getFindingSourcePath(finding);
   const priority = normalizePriority(finding.priority, finding.rank);
   const severityKey = rankToSeverity(finding.rank);
   const severityLabel =
@@ -106,7 +102,6 @@ export function toFindingFacets(finding: Finding): FindingFacets {
     finding.methodName,
     finding.fieldName,
     pathKey,
-    pathKey ?? 'Unknown source',
     finding.location.fullPath,
     finding.location.realSourcePath,
     finding.location.sourceFile,
@@ -235,16 +230,6 @@ function concreteRuleFilterValue(finding: Finding): string | undefined {
     return undefined;
   }
   return patternId;
-}
-
-function firstDefined(...values: Array<string | undefined>): string | undefined {
-  for (const value of values) {
-    const normalized = valueOrUndefined(value);
-    if (normalized) {
-      return normalized;
-    }
-  }
-  return undefined;
 }
 
 function valueOrUndefined(value?: string): string | undefined {

--- a/src/ui/findingFilters.ts
+++ b/src/ui/findingFilters.ts
@@ -193,7 +193,7 @@ function toFindingFilterOption(
     category: facets.categoryLabel,
     package: facets.packageLabel,
     class: facets.classLabel,
-    path: facets.pathLabel,
+    path: value,
   };
   return { value, label: labelByKind[kind] };
 }

--- a/src/ui/findingInspectorRenderer.ts
+++ b/src/ui/findingInspectorRenderer.ts
@@ -130,7 +130,10 @@ function renderFinding(
       : vscode.l10n.t('Selected finding');
   const reportedMessage = formatReportedMessage(finding);
   const severity = formatSeverityLabel(finding, vscode);
-  const location = formatLocation(finding, vscode);
+  const location = formatLocation(finding);
+  const locationRow = location
+    ? `<dt>${escapeHtml(vscode.l10n.t('Location'))}</dt><dd class="path" title="${escapeAttribute(location)}">${escapeHtml(location)}</dd>`
+    : '';
   const docsAction = getAllowedWebDocumentationUrl(finding.helpUri, finding.type)
     ? `<button class="secondary" data-command="openDocs">${escapeHtml(vscode.l10n.t('Open docs'))}</button>`
     : '';
@@ -141,7 +144,7 @@ function renderFinding(
     <h3>${escapeHtml(vscode.l10n.t('Reported here'))}</h3>
     <p class="reported-message" title="${escapeAttribute(reportedMessage)}">${escapeHtml(reportedMessage)}</p>
     <dl>
-      <dt>${escapeHtml(vscode.l10n.t('Location'))}</dt><dd class="path" title="${escapeAttribute(location)}">${escapeHtml(location)}</dd>
+      ${locationRow}
       ${finding.className ? `<dt>${escapeHtml(vscode.l10n.t('Class'))}</dt><dd title="${escapeAttribute(finding.className)}">${escapeHtml(finding.className)}</dd>` : ''}
       ${finding.methodName ? `<dt>${escapeHtml(vscode.l10n.t('Method'))}</dt><dd title="${escapeAttribute(finding.methodName)}">${escapeHtml(finding.methodName)}</dd>` : ''}
       ${finding.fieldName ? `<dt>${escapeHtml(vscode.l10n.t('Field'))}</dt><dd title="${escapeAttribute(finding.fieldName)}">${escapeHtml(finding.fieldName)}</dd>` : ''}
@@ -181,12 +184,17 @@ function formatSeverityLabel(finding: Finding, vscode: LocalizationApi): string 
   return vscode.l10n.t('SpotBugs finding');
 }
 
-function formatLocation(finding: Finding, vscode: LocalizationApi): string {
-  const file =
-    finding.location.realSourcePath ??
-    finding.location.fullPath ??
-    finding.location.sourceFile ??
-    vscode.l10n.t('Unknown source');
+function formatLocation(finding: Finding): string | undefined {
+  const file = [
+    finding.location.realSourcePath,
+    finding.location.fullPath,
+    finding.location.sourceFile,
+  ]
+    .map((candidate) => candidate?.trim())
+    .find((candidate): candidate is string => !!candidate);
+  if (!file) {
+    return undefined;
+  }
   const start = finding.location.startLine;
   const end = finding.location.endLine;
 

--- a/src/ui/findingViewModel.ts
+++ b/src/ui/findingViewModel.ts
@@ -16,7 +16,7 @@ export function toFindingItemView(finding: Finding): FindingItemViewProps {
 
   const facets = toFindingFacets(finding);
   const filePath = facets.pathKey;
-  const fileName = filePath ? path.basename(filePath) : facets.pathLabel;
+  const fileName = filePath ? path.basename(filePath) : undefined;
   const startLine =
     typeof finding.location.startLine === 'number' && finding.location.startLine > 0
       ? finding.location.startLine
@@ -26,17 +26,19 @@ export function toFindingItemView(finding: Finding): FindingItemViewProps {
       ? finding.location.endLine
       : undefined;
   const lineInfo =
-    startLine !== undefined
+    filePath && startLine !== undefined
       ? endLine !== undefined && endLine !== startLine
         ? `${startLine}-${endLine}`
         : `${startLine}`
       : '';
-  const description = `${fileName}${lineInfo ? `:${lineInfo}` : ''} • ${facets.categoryLabel}`;
+  const description = fileName
+    ? `${fileName}${lineInfo ? `:${lineInfo}` : ''} • ${facets.categoryLabel}`
+    : facets.categoryLabel;
   const tooltip = [
     l10n.t('Pattern: {0}', facets.ruleLabel),
     l10n.t('Category: {0}', facets.categoryLabel),
     l10n.t('Priority: {0}', facets.priorityLabel),
-    l10n.t('File: {0}', facets.pathLabel),
+    facets.pathKey ? l10n.t('File: {0}', facets.pathKey) : undefined,
     lineInfo ? l10n.t('Line: {0}', lineInfo) : undefined,
   ]
     .filter((line): line is string => !!line)


### PR DESCRIPTION
## Summary

- Stop exposing synthetic Unknown source values in finding details, search, and filters.
- Omit file and line metadata when a finding has no usable source path.

## Testing

- [x] npm run lint
- [x] npm run format:check
- [ ] npm test
- [x] Other: npm run compile; npm run test:unit (342 passing)

## Notes

- Source grouping and navigation behavior are intentionally left unchanged.

BEGIN_COMMIT_OVERRIDE
fix(ui): omit missing source details from SpotBugs findings
END_COMMIT_OVERRIDE