### PR TITLE
Handle findings without source locations

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -122,7 +122,7 @@
   "SpotBugs Sort Results By": "SpotBugs Sort Results By",
   "Choose a sorting mode": "Choose a sorting mode",
   "Cannot open file: Could not resolve path for {0}": "Cannot open file: Could not resolve path for {0}",
-  "unknown file": "unknown file",
+  "This SpotBugs finding has no source location.": "This SpotBugs finding has no source location.",
   "Failed to open file: {0}": "Failed to open file: {0}",
   "SpotBugs: {0} uses the Last inspected finding ({1}).": "SpotBugs: {0} uses the Last inspected finding ({1}).",
   "Could not add SpotBugs filter files: {0} is not an XML file.": "Could not add SpotBugs filter files: {0} is not an XML file.",

--- a/l10n/bundle.l10n.ko.json
+++ b/l10n/bundle.l10n.ko.json
@@ -109,7 +109,7 @@
   "Open details": "세부 정보 열기",
   "Open docs": "문서 열기",
   "Open external SpotBugs docs": "외부 SpotBugs 문서 열기",
-  "unknown file": "알 수 없는 파일",
+  "This SpotBugs finding has no source location.": "이 결과의 소스 위치를 확인할 수 없습니다.",
   "{0} available value": "사용 가능한 값 {0}개",
   "{0} available values": "사용 가능한 값 {0}개",
   "{0} finding": "발견 항목 {0}개",

--- a/src/commands/navigation.ts
+++ b/src/commands/navigation.ts
@@ -1,5 +1,5 @@
 import { l10n, window, Uri, Range, Position, TextDocumentShowOptions } from 'vscode';
-import { Finding } from '../model/finding';
+import { Finding, getFindingSourcePath } from '../model/finding';
 import { Logger } from '../core/logger';
 import { defaultNotifier } from '../core/notifier';
 import { resolveFindingFilePath } from '../workspace/findingLocator';
@@ -22,6 +22,12 @@ export async function revealFindingSource(
     Logger.log(`Revealing finding source: ${finding.message ?? 'SpotBugs finding'}`);
     const notifier = defaultNotifier;
 
+    const sourcePath = getFindingSourcePath(finding);
+    if (!sourcePath) {
+      notifier.info(l10n.t('This SpotBugs finding has no source location.'));
+      return;
+    }
+
     const filePath = await resolveFindingFilePath(finding);
 
     if (revealOptions.isCurrentRequest?.() === false) {
@@ -32,7 +38,7 @@ export async function revealFindingSource(
     if (!filePath) {
       const errorMsg = l10n.t(
         'Cannot open file: Could not resolve path for {0}',
-        finding.location.realSourcePath || l10n.t('unknown file')
+        sourcePath
       );
       Logger.error(errorMsg);
       notifier.error(errorMsg);

--- a/src/test/L1.findingInspectorController.test.ts
+++ b/src/test/L1.findingInspectorController.test.ts
@@ -119,26 +119,34 @@ describe('findingInspectorController', () => {
     assert.strictEqual(isCurrentRequest?.(), false);
   });
 
-  it('does not preview the finding source when selection reveal is disabled', async () => {
+  it('only previews findings with source locations when selection reveal is enabled', async () => {
     const { bindFindingInspectorToTree } = await import('../ui/findingInspectorController');
     const findingInspectorState = await import('../ui/findingInspectorState');
     const findingTreeItem = await import('../ui/findingTreeItem');
     const finding = makeFinding();
-    const leaf = new findingTreeItem.FindingItem(finding);
+    const findingWithoutSource = makeFinding({ location: {} });
     const state = new findingInspectorState.FindingInspectorState();
     const tree = createTreeHarness();
+    let revealOnSelection = false;
     let previewCount = 0;
 
     bindFindingInspectorToTree(tree.view, state, {
-      revealSourceOnSelection: () => false,
+      revealSourceOnSelection: () => revealOnSelection,
       revealFindingSource: async () => {
         previewCount += 1;
       },
     });
-    await tree.fireSelection(leaf);
+    await tree.fireSelection(new findingTreeItem.FindingItem(finding));
 
     assert.strictEqual(state.current.status, 'selected');
     assert.strictEqual(state.current.finding, finding);
+    assert.strictEqual(previewCount, 0);
+
+    revealOnSelection = true;
+    await tree.fireSelection(new findingTreeItem.FindingItem(findingWithoutSource));
+
+    assert.strictEqual(state.current.status, 'selected');
+    assert.strictEqual(state.current.finding, findingWithoutSource);
     assert.strictEqual(previewCount, 0);
   });
 

--- a/src/test/L1.navigation.test.ts
+++ b/src/test/L1.navigation.test.ts
@@ -91,6 +91,25 @@ describe('navigation', () => {
 
     assert.deepStrictEqual(shown, []);
   });
+
+  it('reports missing source location without trying to open a file', async () => {
+    const messages: string[] = [];
+    resetVscodeMock({
+      window: {
+        showInformationMessage: async (message: string) => {
+          messages.push(message);
+          return undefined;
+        },
+      },
+    } as never);
+    const { revealFindingSource } = await import('../commands/navigation');
+
+    await revealFindingSource(makeFinding({ location: {} }));
+
+    assert.deepStrictEqual(messages, [
+      'This SpotBugs finding has no source location.',
+    ]);
+  });
 });
 
 function makeFinding(overrides: Partial<Finding> = {}): Finding {

--- a/src/ui/findingInspectorController.ts
+++ b/src/ui/findingInspectorController.ts
@@ -6,7 +6,7 @@ import {
   PatternGroupItem,
 } from './findingTreeItem';
 import { FindingInspectorState } from './findingInspectorState';
-import { Finding } from '../model/finding';
+import { Finding, getFindingSourcePath } from '../model/finding';
 
 export interface FindingSourcePreviewOptions {
   preserveFocus?: boolean;
@@ -34,7 +34,11 @@ export function bindFindingInspectorToTree(
     const selected = event.selection[0];
     if (selected instanceof FindingItem) {
       inspectorState.select(selected.finding);
-      if (options.revealSourceOnSelection?.() === true && options.revealFindingSource) {
+      if (
+        getFindingSourcePath(selected.finding) !== undefined &&
+        options.revealSourceOnSelection?.() === true &&
+        options.revealFindingSource
+      ) {
         await options.revealFindingSource(selected.finding, {
           preserveFocus: true,
           preview: true,


### PR DESCRIPTION
## Summary

- Skip automatic source previews when a finding has no source location.
- Explain unavailable manual navigation without hiding Go to Code actions.

## Testing

- `npm run compile`
- `npm run lint`
- `npm run format:check`
- `npm run test:unit` (345 passing)

BEGIN_COMMIT_OVERRIDE
fix(ui): handle findings without source locations
END_COMMIT_OVERRIDE