### PR TITLE
refactor: remove legacy analysis APIs

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -14,8 +14,6 @@ export interface AnalysisSettings {
 }
 
 export class Config {
-  private _ctx: ExtensionContext;
-
   public effort!: string;
   // Future-ready fields (optional; only sent when defined)
   public priorityThreshold?: number;
@@ -26,8 +24,7 @@ export class Config {
   public plugins?: string[];
   public revealSourceOnSelection!: boolean;
 
-  public constructor(ctx: ExtensionContext) {
-    this._ctx = ctx;
+  public constructor(_ctx: ExtensionContext) {
     this.init();
   }
 

--- a/src/services/analysisService.ts
+++ b/src/services/analysisService.ts
@@ -5,7 +5,6 @@ import type { AnalysisResolutionIssue } from '../lsp/javaLsOutcome';
 import { AnalysisOutcome } from '../model/analysisOutcome';
 import type { AnalysisWarning } from '../model/analysisProtocol';
 import type { DiagnosticUpdateScope } from '../model/diagnosticScope';
-import { ProjectRef } from '../workspace/classpathService';
 import type { ProjectResult } from './projectResult';
 import { projectResultFromOutcome } from './projectResult';
 import {
@@ -15,23 +14,15 @@ import {
   runAnalysisTarget,
 } from './analysisExecution';
 import {
-  resolveFileAnalysisTarget,
   resolveFileAnalysisTargetDetailed,
-  resolveProjectAnalysisTarget,
   resolveProjectAnalysisTargetDetailed,
 } from '../workspace/analysisTargetResolver';
-import { getWorkspaceProjectUris } from '../workspace/projectDiscovery';
 
 const ERROR_ANALYSIS_FAILED = 'ANALYSIS_FAILED';
 const ERROR_ANALYSIS_CANCELLED = 'ANALYSIS_CANCELLED';
 
 export { NO_CLASS_TARGETS_CODE } from '../workspace/analysisTargetCodes';
 export type { ProjectResult } from './projectResult';
-
-export interface WorkspaceResult {
-  results: ProjectResult[];
-  cancelled?: boolean;
-}
 
 export interface ProjectCleanupWarning {
   projectUri: string;
@@ -112,25 +103,6 @@ export async function analyzeFileDetailed(
   }
 }
 
-export async function analyzeFile(config: Config, uri: Uri): Promise<AnalysisOutcome> {
-  const result = await analyzeFileDetailed(config, uri);
-  return result.outcome;
-}
-
-export async function analyzeWorkspace(
-  config: Config,
-  workspaceFolder: Uri,
-  notify?: {
-    onStart?: (uriString: string, index: number, total: number) => void;
-    onDone?: (uriString: string, count: number) => void;
-    onFail?: (uriString: string, message: string) => void;
-  },
-  token?: CancellationToken
-): Promise<WorkspaceResult> {
-  const projectUris = await getWorkspaceProjects(workspaceFolder);
-  return analyzeWorkspaceFromProjects(config, workspaceFolder, projectUris, notify, token);
-}
-
 export async function analyzeWorkspaceFromProjectsDetailed(
   config: Config,
   workspaceFolder: Uri,
@@ -191,50 +163,12 @@ export async function analyzeWorkspaceFromProjectsDetailed(
   return { results, cancelled, context };
 }
 
-export async function analyzeWorkspaceFromProjects(
-  config: Config,
-  workspaceFolder: Uri,
-  projectUris: string[],
-  notify?: {
-    onStart?: (uriString: string, index: number, total: number) => void;
-    onDone?: (uriString: string, count: number) => void;
-    onFail?: (uriString: string, message: string) => void;
-  },
-  token?: CancellationToken
-): Promise<WorkspaceResult> {
-  const result = await analyzeWorkspaceFromProjectsDetailed(
-    config,
-    workspaceFolder,
-    projectUris,
-    notify,
-    token
-  );
-  return {
-    results: result.results,
-    cancelled: result.cancelled,
-  };
-}
-
-export async function getWorkspaceProjects(workspaceFolder: Uri): Promise<string[]> {
-  return getWorkspaceProjectUris(workspaceFolder);
-}
-
-async function analyzeProject(
-  config: Config,
-  project: ProjectRef,
-  workspaceFolder: Uri
-): Promise<ProjectResult> {
-  const result = await analyzeProjectDetailed(config, project, workspaceFolder);
-  return result.projectResult;
-}
-
 async function analyzeProjectDetailed(
   config: AnalysisConfigProvider,
-  project: ProjectRef,
+  projectUri: Uri,
   workspaceFolder: Uri,
   token?: CancellationToken
 ): Promise<{ projectResult: ProjectResult; context: AnalysisExecutionContext }> {
-  const projectUri = normalizeProjectRef(project);
   const projectUriString = projectUri.toString();
   const context = createExecutionContext();
 
@@ -318,22 +252,6 @@ function cancelledProjectResult(projectUri: string): ProjectResult {
     findings: [],
     errorCode: ERROR_ANALYSIS_CANCELLED,
   };
-}
-
-function normalizeProjectRef(project: ProjectRef): Uri {
-  if (!project) {
-    throw new Error('Project reference is required');
-  }
-
-  if (project instanceof Uri) {
-    return project;
-  }
-
-  if (typeof project === 'string') {
-    return Uri.parse(project);
-  }
-
-  throw new Error('Unsupported project reference');
 }
 
 function createExecutionContext(): AnalysisExecutionContext {

--- a/src/test/L1.analysisService.test.ts
+++ b/src/test/L1.analysisService.test.ts
@@ -16,7 +16,7 @@ describe('analysisService', () => {
     clearModule('../lsp/spotbugsClient');
   });
 
-  it('returns resolution issues through analyzeFileDetailed while preserving the public analyzeFile contract', async () => {
+  it('returns resolution issues through analyzeFileDetailed', async () => {
     const vscode = installVscodeMock();
     const resolverModule =
       require('../workspace/analysisTargetResolver') as typeof import('../workspace/analysisTargetResolver');
@@ -43,16 +43,10 @@ describe('analysisService', () => {
       { getAnalysisSettings: () => ({ effort: 'default' }) } as any,
       vscode.Uri.file('/workspace/src/Foo.java') as any
     );
-    const publicOutcome = await service.analyzeFile(
-      { getAnalysisSettings: () => ({ effort: 'default' }) } as any,
-      vscode.Uri.file('/workspace/src/Foo.java') as any
-    );
-
     assert.deepStrictEqual(detailed.context.resolutionIssues.map((issue) => issue.code), [
       'OUTPUT_FALLBACK_USED',
     ]);
     assert.strictEqual(detailed.outcome.failure?.code, 'NO_CLASS_TARGETS');
-    assert.strictEqual(publicOutcome.failure?.code, 'NO_CLASS_TARGETS');
   });
 
   it('carries file-analysis diagnostic scope into detailed analysis context', async () => {
@@ -126,19 +120,11 @@ describe('analysisService', () => {
       installVscodeMock().Uri.file('/workspace') as any,
       ['file:///workspace/project-a', 'file:///workspace/project-b']
     );
-    const legacy = await service.analyzeWorkspaceFromProjects(
-      { getAnalysisSettings: () => ({ effort: 'default' }) } as any,
-      installVscodeMock().Uri.file('/workspace') as any,
-      ['file:///workspace/project-a', 'file:///workspace/project-b']
-    );
-
     assert.deepStrictEqual(
       detailed.context.resolutionIssues.map((issue) => issue.code),
       ['JAVA_LS_REQUEST_FAILED', 'JAVA_LS_EMPTY_RUNTIME_CLASSPATH']
     );
     assert.strictEqual(detailed.results.length, 2);
-    assert.strictEqual('context' in (legacy as any), false);
-    assert.strictEqual(legacy.results.length, 2);
   });
 
   it('aggregates backend cleanup warnings in workspace context without adding project result state', async () => {

--- a/src/workspace/analysisTargetResolver.ts
+++ b/src/workspace/analysisTargetResolver.ts
@@ -464,23 +464,8 @@ export function createTargetResolver(overrides: Partial<TargetResolverDeps> = {}
     };
   }
 
-  async function resolveFileAnalysisTarget(uri: Uri): Promise<TargetResolution> {
-    const result = await resolveFileAnalysisTargetDetailed(uri);
-    return result.resolution;
-  }
-
-  async function resolveProjectAnalysisTarget(
-    projectUri: Uri,
-    workspaceFolder: Uri
-  ): Promise<TargetResolution> {
-    const result = await resolveProjectAnalysisTargetDetailed(projectUri, workspaceFolder);
-    return result.resolution;
-  }
-
   return {
-    resolveFileAnalysisTarget,
     resolveFileAnalysisTargetDetailed,
-    resolveProjectAnalysisTarget,
     resolveProjectAnalysisTargetDetailed,
   };
 }
@@ -493,22 +478,11 @@ export async function resolveFileAnalysisTargetDetailed(
   return defaultResolver.resolveFileAnalysisTargetDetailed(uri);
 }
 
-export async function resolveFileAnalysisTarget(uri: Uri): Promise<TargetResolution> {
-  return defaultResolver.resolveFileAnalysisTarget(uri);
-}
-
 export async function resolveProjectAnalysisTargetDetailed(
   projectUri: Uri,
   workspaceFolder: Uri
 ): Promise<TargetResolutionResult> {
   return defaultResolver.resolveProjectAnalysisTargetDetailed(projectUri, workspaceFolder);
-}
-
-export async function resolveProjectAnalysisTarget(
-  projectUri: Uri,
-  workspaceFolder: Uri
-): Promise<TargetResolution> {
-  return defaultResolver.resolveProjectAnalysisTarget(projectUri, workspaceFolder);
 }
 
 const OUTPUT_PROJECT_ROOT_SUFFIXES = [

--- a/src/workspace/classpathCommandRunner.ts
+++ b/src/workspace/classpathCommandRunner.ts
@@ -24,14 +24,6 @@ type CommandResult = AttemptSummary & {
   response?: JavaLsClasspathResponse;
 };
 
-export async function runClasspathAttempts(
-  attempts: ClasspathAttempt[],
-  opts?: ClasspathLookupOptions
-): Promise<ClasspathResult | undefined> {
-  const outcome = await runClasspathAttemptsOutcome(attempts, opts);
-  return outcome.status === 'resolved' ? outcome.classpath : undefined;
-}
-
 export async function runClasspathAttemptsOutcome(
   attempts: ClasspathAttempt[],
   opts?: ClasspathLookupOptions

--- a/src/workspace/classpathService.ts
+++ b/src/workspace/classpathService.ts
@@ -3,10 +3,7 @@ import * as path from 'path';
 import { Uri } from 'vscode';
 import type { ClasspathLookupOutcome } from '../lsp/javaLsOutcome';
 import { collectClasspathAttempts } from './classpathAttemptSelector';
-import {
-  runClasspathAttempts,
-  runClasspathAttemptsOutcome,
-} from './classpathCommandRunner';
+import { runClasspathAttemptsOutcome } from './classpathCommandRunner';
 import type { ClasspathResult } from './classpathTypes';
 import {
   orderOutputFolderCandidates,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "sourceMap": true,
     "rootDir": "src",
     "outDir": "out",
-    "strict": true
+    "strict": true,
+    "noUnusedLocals": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", ".vscode-test"]


### PR DESCRIPTION
## Summary

- remove unused non-detailed wrappers from the analysis service, target resolver, and classpath command runner
- simplify project analysis to accept the URI shape used by all runtime callers
- remove stale compatibility-contract tests and unused configuration context storage
- enable `noUnusedLocals` so unused implementation code fails compilation

## Testing

- [x] `npm run lint`
- [x] `npm run format:check`
- [ ] `npm test`
- [x] Other: clean compile, `npm run test:unit` (343 passing), and VS Code extension host tests (10 passing)

## Notes

The extension runtime already uses the detailed analysis and target-resolution APIs. This removes only repository-internal compatibility wrappers with no runtime callers. The local `npm test` wrapper was not used because `@vscode/test-electron` 2.5.2 looks for the obsolete macOS `Electron` binary name; the same host suite passed by supplying the installed `Code` executable explicitly.
