### PR TITLE
refactor: consolidate path setting logic

### DIFF
--- a/src/commands/filterFiles.ts
+++ b/src/commands/filterFiles.ts
@@ -8,21 +8,21 @@ import type {
   FilterKind,
 } from '../model/filterFiles';
 import { validateFilterFilesPreflight } from '../services/filterFileValidation';
-
-export interface FilterPathConfiguration {
-  target: 'global' | 'workspace';
-  paths: string[];
-  workspaceRoots: string[];
-}
+import {
+  type PathSettingState,
+  planPathAdditions,
+  planPathRemoval,
+  readPathSetting,
+} from '../services/pathSetting';
 
 export interface FilterConfigurationDeps {
   selectFilterKind(): Thenable<FilterKind | undefined>;
   selectFilterFiles(kind: FilterKind): Thenable<readonly Uri[] | undefined>;
-  readConfiguration(kind: FilterKind): FilterPathConfiguration;
+  readConfiguration(kind: FilterKind): PathSettingState;
   writeConfiguration(
     kind: FilterKind,
     paths: string[],
-    target: FilterPathConfiguration['target']
+    target: PathSettingState['target']
   ): Promise<void>;
   validateFilterFiles(
     kind: FilterKind,
@@ -85,31 +85,20 @@ export async function addFilterFiles(
   }
 
   const state = deps.readConfiguration(kind);
-  const configuredKeys = new Set(
-    state.paths.map((configuredPath) => configuredPathKey(configuredPath, state))
-  );
-  const additions: string[] = [];
-  for (const selectedPath of selectedPaths) {
-    const key = absolutePathKey(selectedPath);
-    if (configuredKeys.has(key)) {
-      continue;
-    }
-    configuredKeys.add(key);
-    additions.push(pathForStorage(selectedPath, state));
-  }
+  const plan = planPathAdditions(state, selectedPaths);
 
-  if (additions.length === 0) {
+  if (plan.additions.length === 0) {
     await window.showInformationMessage(
       l10n.t('The selected SpotBugs filter files are already configured.')
     );
     return;
   }
 
-  await deps.writeConfiguration(kind, [...state.paths, ...additions], state.target);
+  await deps.writeConfiguration(kind, plan.paths, state.target);
   await window.showInformationMessage(
     l10n.t(
       'Added {0} SpotBugs filter file(s) to {1} settings.',
-      additions.length,
+      plan.additions.length,
       state.target === 'workspace' ? l10n.t('Workspace') : l10n.t('User')
     )
   );
@@ -127,11 +116,8 @@ export async function removeFilterFile(
   }
 
   const state = deps.readConfiguration(target.filterKind);
-  const selectedKey = configuredPathKey(target.filterPath, state);
-  const remainingPaths = state.paths.filter(
-    (configuredPath) => configuredPathKey(configuredPath, state) !== selectedKey
-  );
-  if (remainingPaths.length === state.paths.length) {
+  const remainingPaths = planPathRemoval(state, target.filterPath);
+  if (!remainingPaths) {
     await window.showInformationMessage(
       l10n.t('The filter configuration changed. Refresh the Filters view and try again.')
     );
@@ -171,7 +157,7 @@ function defaultFilterConfigurationDeps(): FilterConfigurationDeps {
         canSelectMany: true,
         filters: { [xmlFilesLabel]: ['xml'] },
       }),
-    readConfiguration: readFilterPathConfiguration,
+    readConfiguration: (kind) => readPathSetting(FILTER_CONFIGURATION[kind][0]),
     writeConfiguration: async (kind, paths, target) => {
       await workspace
         .getConfiguration(SETTINGS_SECTION)
@@ -185,75 +171,4 @@ function defaultFilterConfigurationDeps(): FilterConfigurationDeps {
       });
     },
   };
-}
-
-function readFilterPathConfiguration(kind: FilterKind): FilterPathConfiguration {
-  const configuration = workspace.getConfiguration(SETTINGS_SECTION);
-  const inspected = configuration.inspect<unknown>(
-    FILTER_CONFIGURATION[kind][0]
-  );
-  const workspaceDefined = inspected?.workspaceValue !== undefined;
-  const globalDefined = inspected?.globalValue !== undefined;
-  const workspaceRoots = workspace.workspaceFolders?.map((folder) => folder.uri.fsPath) ?? [];
-  const target =
-    workspaceDefined || (!globalDefined && workspaceRoots.length > 0)
-      ? 'workspace'
-      : 'global';
-  const value =
-    target === 'workspace' ? inspected?.workspaceValue : inspected?.globalValue;
-
-  return {
-    target,
-    paths: normalizedStringArray(value),
-    workspaceRoots,
-  };
-}
-
-function normalizedStringArray(value: unknown): string[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-  return Array.from(
-    new Set(
-      value
-        .filter((entry): entry is string => typeof entry === 'string')
-        .map((entry) => entry.trim())
-        .filter(Boolean)
-    )
-  );
-}
-
-function pathForStorage(
-  absolutePath: string,
-  state: FilterPathConfiguration
-): string {
-  if (state.target !== 'workspace' || state.workspaceRoots.length !== 1) {
-    return absolutePath;
-  }
-
-  const relativePath = path.relative(state.workspaceRoots[0], absolutePath);
-  if (
-    relativePath === '' ||
-    path.isAbsolute(relativePath) ||
-    relativePath === '..' ||
-    relativePath.startsWith(`..${path.sep}`)
-  ) {
-    return absolutePath;
-  }
-  return relativePath.split(path.sep).join('/');
-}
-
-function configuredPathKey(
-  configuredPath: string,
-  state: FilterPathConfiguration
-): string {
-  const absolutePath = path.isAbsolute(configuredPath)
-    ? configuredPath
-    : path.resolve(state.workspaceRoots[0] ?? process.cwd(), configuredPath);
-  return absolutePathKey(absolutePath);
-}
-
-function absolutePathKey(value: string): string {
-  const normalized = path.normalize(path.resolve(value));
-  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
 }

--- a/src/commands/pluginInventory.ts
+++ b/src/commands/pluginInventory.ts
@@ -6,6 +6,12 @@ import { formatAnalysisErrors } from '../model/analysisErrors';
 import type { AnalysisError } from '../model/analysisProtocol';
 import { validatePluginJarsPreflight } from '../services/filterFileValidation';
 import {
+  type PathSettingState,
+  planPathAdditions,
+  planPathRemoval,
+  readPathSetting,
+} from '../services/pathSetting';
+import {
   getPluginInventory,
   type PluginInventoryResult,
   type PluginInventoryServiceDeps,
@@ -16,18 +22,12 @@ export interface PluginInventoryView {
   showInventory(result: PluginInventoryResult): void;
 }
 
-export interface PluginPathConfiguration {
-  target: 'global' | 'workspace';
-  paths: string[];
-  workspaceRoots: string[];
-}
-
 export interface PluginConfigurationDeps {
   selectPluginJars(): Thenable<readonly Uri[] | undefined>;
-  readConfiguration(): PluginPathConfiguration;
+  readConfiguration(): PathSettingState;
   writeConfiguration(
     paths: string[],
-    target: PluginPathConfiguration['target']
+    target: PathSettingState['target']
   ): Promise<void>;
   validatePluginJars(paths: string[]): Promise<AnalysisError | undefined>;
 }
@@ -78,31 +78,20 @@ export async function addPluginJars(
   }
 
   const state = deps.readConfiguration();
-  const configuredKeys = new Set(
-    state.paths.map((configuredPath) => configuredPathKey(configuredPath, state))
-  );
-  const additions: string[] = [];
-  for (const selectedPath of selectedPaths) {
-    const key = absolutePathKey(selectedPath);
-    if (configuredKeys.has(key)) {
-      continue;
-    }
-    configuredKeys.add(key);
-    additions.push(pathForStorage(selectedPath, state));
-  }
+  const plan = planPathAdditions(state, selectedPaths);
 
-  if (additions.length === 0) {
+  if (plan.additions.length === 0) {
     await window.showInformationMessage(
       l10n.t('The selected SpotBugs plugin JARs are already configured.')
     );
     return;
   }
 
-  await deps.writeConfiguration([...state.paths, ...additions], state.target);
+  await deps.writeConfiguration(plan.paths, state.target);
   await window.showInformationMessage(
     l10n.t(
       'Added {0} SpotBugs plugin JAR(s) to {1} settings.',
-      additions.length,
+      plan.additions.length,
       state.target === 'workspace' ? l10n.t('Workspace') : l10n.t('User')
     )
   );
@@ -120,11 +109,8 @@ export async function removePluginJar(
   }
 
   const state = deps.readConfiguration();
-  const selectedKey = absolutePathKey(target.pluginPath);
-  const remainingPaths = state.paths.filter(
-    (configuredPath) => configuredPathKey(configuredPath, state) !== selectedKey
-  );
-  if (remainingPaths.length === state.paths.length) {
+  const remainingPaths = planPathRemoval(state, target.pluginPath);
+  if (!remainingPaths) {
     await window.showInformationMessage(
       l10n.t('The plugin configuration changed. Refresh the Plugins view and try again.')
     );
@@ -149,7 +135,7 @@ function defaultPluginConfigurationDeps(): PluginConfigurationDeps {
         canSelectMany: true,
         filters: { [jarFilesLabel]: ['jar'] },
       }),
-    readConfiguration: readPluginPathConfiguration,
+    readConfiguration: () => readPathSetting(settingKeys.pluginsPaths),
     writeConfiguration: async (paths, target) => {
       await workspace
         .getConfiguration(SETTINGS_SECTION)
@@ -158,73 +144,4 @@ function defaultPluginConfigurationDeps(): PluginConfigurationDeps {
     validatePluginJars: (paths) =>
       validatePluginJarsPreflight({ effort: 'default', plugins: paths }),
   };
-}
-
-function readPluginPathConfiguration(): PluginPathConfiguration {
-  const configuration = workspace.getConfiguration(SETTINGS_SECTION);
-  const inspected = configuration.inspect<unknown>(settingKeys.pluginsPaths);
-  const workspaceDefined = inspected?.workspaceValue !== undefined;
-  const globalDefined = inspected?.globalValue !== undefined;
-  const workspaceRoots = workspace.workspaceFolders?.map((folder) => folder.uri.fsPath) ?? [];
-  const target =
-    workspaceDefined || (!globalDefined && workspaceRoots.length > 0)
-      ? 'workspace'
-      : 'global';
-  const value =
-    target === 'workspace' ? inspected?.workspaceValue : inspected?.globalValue;
-
-  return {
-    target,
-    paths: normalizedStringArray(value),
-    workspaceRoots,
-  };
-}
-
-function normalizedStringArray(value: unknown): string[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-  return Array.from(
-    new Set(
-      value
-        .filter((entry): entry is string => typeof entry === 'string')
-        .map((entry) => entry.trim())
-        .filter(Boolean)
-    )
-  );
-}
-
-function pathForStorage(
-  absolutePath: string,
-  state: PluginPathConfiguration
-): string {
-  if (state.target !== 'workspace' || state.workspaceRoots.length !== 1) {
-    return absolutePath;
-  }
-
-  const relativePath = path.relative(state.workspaceRoots[0], absolutePath);
-  if (
-    relativePath === '' ||
-    path.isAbsolute(relativePath) ||
-    relativePath === '..' ||
-    relativePath.startsWith(`..${path.sep}`)
-  ) {
-    return absolutePath;
-  }
-  return relativePath.split(path.sep).join('/');
-}
-
-function configuredPathKey(
-  configuredPath: string,
-  state: PluginPathConfiguration
-): string {
-  const absolutePath = path.isAbsolute(configuredPath)
-    ? configuredPath
-    : path.resolve(state.workspaceRoots[0] ?? process.cwd(), configuredPath);
-  return absolutePathKey(absolutePath);
-}
-
-function absolutePathKey(value: string): string {
-  const normalized = path.normalize(path.resolve(value));
-  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
 }

--- a/src/services/pathSetting.ts
+++ b/src/services/pathSetting.ts
@@ -1,0 +1,112 @@
+import * as path from 'path';
+import { workspace } from 'vscode';
+import { SETTINGS_SECTION } from '../constants/settings';
+
+export interface PathSettingState {
+  target: 'global' | 'workspace';
+  paths: string[];
+  workspaceRoots: string[];
+}
+
+export function readPathSetting(settingKey: string): PathSettingState {
+  const inspected = workspace
+    .getConfiguration(SETTINGS_SECTION)
+    .inspect<unknown>(settingKey);
+  return createPathSettingState(
+    inspected,
+    workspace.workspaceFolders?.map((folder) => folder.uri.fsPath) ?? []
+  );
+}
+
+export function createPathSettingState(
+  inspected: { globalValue?: unknown; workspaceValue?: unknown } | undefined,
+  workspaceRoots: readonly string[]
+): PathSettingState {
+  const workspaceDefined = inspected?.workspaceValue !== undefined;
+  const globalDefined = inspected?.globalValue !== undefined;
+  const target =
+    workspaceDefined || (!globalDefined && workspaceRoots.length > 0)
+      ? 'workspace'
+      : 'global';
+  const value =
+    target === 'workspace' ? inspected?.workspaceValue : inspected?.globalValue;
+
+  return {
+    target,
+    paths: normalizedStringArray(value),
+    workspaceRoots: [...workspaceRoots],
+  };
+}
+
+export function planPathAdditions(
+  state: PathSettingState,
+  absolutePaths: readonly string[]
+) {
+  const configuredKeys = new Set(
+    state.paths.map((configuredPath) => configuredPathKey(configuredPath, state))
+  );
+  const additions: string[] = [];
+  for (const absolutePath of absolutePaths) {
+    const key = absolutePathKey(absolutePath);
+    if (configuredKeys.has(key)) {
+      continue;
+    }
+    configuredKeys.add(key);
+    additions.push(pathForStorage(absolutePath, state));
+  }
+  return { paths: [...state.paths, ...additions], additions };
+}
+
+export function planPathRemoval(
+  state: PathSettingState,
+  selectedPath: string
+): string[] | undefined {
+  const selectedKey = configuredPathKey(selectedPath, state);
+  const paths = state.paths.filter(
+    (configuredPath) => configuredPathKey(configuredPath, state) !== selectedKey
+  );
+  return paths.length === state.paths.length ? undefined : paths;
+}
+
+function normalizedStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return Array.from(
+    new Set(
+      value
+        .filter((entry): entry is string => typeof entry === 'string')
+        .map((entry) => entry.trim())
+        .filter(Boolean)
+    )
+  );
+}
+
+function pathForStorage(absolutePath: string, state: PathSettingState): string {
+  if (state.target !== 'workspace' || state.workspaceRoots.length !== 1) {
+    return absolutePath;
+  }
+
+  const relativePath = path.relative(state.workspaceRoots[0], absolutePath);
+  if (
+    relativePath === '' ||
+    path.isAbsolute(relativePath) ||
+    relativePath === '..' ||
+    relativePath.startsWith(`..${path.sep}`)
+  ) {
+    return absolutePath;
+  }
+  return relativePath.split(path.sep).join('/');
+}
+
+function configuredPathKey(configuredPath: string, state: PathSettingState): string {
+  const absolutePath = path.isAbsolute(configuredPath)
+    ? configuredPath
+    : path.resolve(state.workspaceRoots[0] ?? process.cwd(), configuredPath);
+  return absolutePathKey(absolutePath);
+}
+
+function absolutePathKey(value: string): string {
+  const normalized = path.normalize(path.resolve(value));
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+}

--- a/src/test/L0.filterFiles.test.ts
+++ b/src/test/L0.filterFiles.test.ts
@@ -2,9 +2,9 @@ import * as assert from 'assert';
 import type { Uri } from 'vscode';
 import type {
   FilterConfigurationDeps,
-  FilterPathConfiguration,
 } from '../commands/filterFiles';
 import type { FilterKind } from '../model/filterFiles';
+import type { PathSettingState } from '../services/pathSetting';
 import { installVscodeMock, resetVscodeMock } from './helpers/mockVscode';
 
 const vscode = installVscodeMock();
@@ -21,46 +21,27 @@ type Validation = [FilterKind, string[]];
 describe('filter file commands', () => {
   beforeEach(() => resetVscodeMock());
 
-  it('adds validated files with single-root relative and multi-root absolute paths', async () => {
+  it('validates and adds selected filter files', async () => {
     const writes: Write[] = [];
     const validations: Validation[] = [];
 
     await addFilterFiles(
       { filterKind: 'exclude' },
       deps(
-        state(['filters/existing.xml'], ['/workspace']),
-        uris('/workspace/filters/existing.xml', '/workspace/filters/new.xml'),
+        state([], ['/workspace']),
+        uris('/workspace/filters/new.xml'),
         writes,
         validations
-      )
-    );
-    await addFilterFiles(
-      undefined,
-      deps(
-        state([], ['/workspace-a', '/workspace-b']),
-        uris('/workspace-a/filters/baseline.xml'),
-        writes,
-        validations,
-        'baseline'
       )
     );
 
     assert.deepStrictEqual(validations[0], [
       'exclude',
-      ['/workspace/filters/existing.xml', '/workspace/filters/new.xml'],
+      ['/workspace/filters/new.xml'],
     ]);
     assert.deepStrictEqual(writes[0], [
       'exclude',
-      ['filters/existing.xml', 'filters/new.xml'],
-      'workspace',
-    ]);
-    assert.deepStrictEqual(validations[1], [
-      'baseline',
-      ['/workspace-a/filters/baseline.xml'],
-    ]);
-    assert.deepStrictEqual(writes[1], [
-      'baseline',
-      ['/workspace-a/filters/baseline.xml'],
+      ['filters/new.xml'],
       'workspace',
     ]);
   });
@@ -96,7 +77,7 @@ describe('filter file commands', () => {
     );
 
     await removeFilterFile(
-      { filterKind: 'include', filterPath: '/workspace/filters/a.xml' },
+      { filterKind: 'include', filterPath: 'filters/a.xml' },
       commandDeps
     );
     await removeFilterFile(
@@ -151,7 +132,7 @@ describe('filterTreeDataProvider', () => {
 function state(
   paths: string[],
   workspaceRoots: string[]
-): FilterPathConfiguration {
+): PathSettingState {
   return { target: 'workspace', paths, workspaceRoots };
 }
 
@@ -160,7 +141,7 @@ function uris(...paths: string[]): Uri[] {
 }
 
 function deps(
-  configuration: FilterPathConfiguration,
+  configuration: PathSettingState,
   selected: readonly Uri[],
   writes: Write[],
   validations: Validation[] = [],

--- a/src/test/L0.pathSetting.test.ts
+++ b/src/test/L0.pathSetting.test.ts
@@ -1,0 +1,70 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import type { PathSettingState } from '../services/pathSetting';
+import { installVscodeMock } from './helpers/mockVscode';
+
+installVscodeMock();
+const planner = require('../services/pathSetting') as typeof import('../services/pathSetting');
+
+describe('pathSetting', () => {
+  const root = path.resolve('/workspace');
+  const state = (
+    paths: string[] = [],
+    target: PathSettingState['target'] = 'workspace',
+    workspaceRoots: string[] = [root]
+  ): PathSettingState => ({ target, paths, workspaceRoots });
+
+  it('selects and normalizes the active scope', () => {
+    const cases: Array<
+      [Parameters<typeof planner.createPathSettingState>[0], string[], PathSettingState]
+    > = [
+      [undefined, [root], state()],
+      [{ globalValue: [' global.jar '] }, [root], state(['global.jar'], 'global')],
+      [
+        {
+          globalValue: ['global.jar'],
+          workspaceValue: [' workspace.jar ', '', 'workspace.jar', 42],
+        },
+        [root],
+        state(['workspace.jar']),
+      ],
+      [undefined, [], state([], 'global', [])],
+    ];
+
+    for (const [inspection, roots, expected] of cases) {
+      assert.deepStrictEqual(planner.createPathSettingState(inspection, roots), expected);
+    }
+  });
+
+  it('plans duplicate-free additions with the correct stored path', () => {
+    const existing = path.join(root, 'plugins', 'existing.jar');
+    const added = path.join(root, 'plugins', 'new.jar');
+    assert.deepStrictEqual(
+      planner.planPathAdditions(state(['plugins/existing.jar']), [existing, added, added]),
+      {
+        paths: ['plugins/existing.jar', 'plugins/new.jar'],
+        additions: ['plugins/new.jar'],
+      }
+    );
+
+    const inside = path.join(root, 'plugins', 'plugin.jar');
+    const outside = path.resolve(root, '..', 'outside', 'plugin.jar');
+    for (const [setting, selected] of [
+      [state([], 'global'), inside],
+      [state([], 'workspace', [root, path.resolve('/workspace-b')]), inside],
+      [state(), outside],
+      [state(), root],
+    ] as Array<[PathSettingState, string]>) {
+      assert.deepStrictEqual(planner.planPathAdditions(setting, [selected]).additions, [selected]);
+    }
+  });
+
+  it('removes relative or absolute targets and ignores stale ones', () => {
+    const setting = state(['filters/a.xml', 'plugins/b.jar']);
+    assert.deepStrictEqual(planner.planPathRemoval(setting, 'filters/a.xml'), ['plugins/b.jar']);
+    assert.deepStrictEqual(planner.planPathRemoval(setting, path.join(root, 'plugins', 'b.jar')), [
+      'filters/a.xml',
+    ]);
+    assert.strictEqual(planner.planPathRemoval(setting, 'missing.xml'), undefined);
+  });
+});

--- a/src/test/L0.pluginInventory.test.ts
+++ b/src/test/L0.pluginInventory.test.ts
@@ -3,9 +3,9 @@ import type { Uri } from 'vscode';
 import type { AnalysisSettings } from '../core/config';
 import type {
   PluginConfigurationDeps,
-  PluginPathConfiguration,
 } from '../commands/pluginInventory';
 import type { PluginInventoryResult } from '../services/pluginInventoryService';
+import type { PathSettingState } from '../services/pathSetting';
 import { installVscodeMock, resetVscodeMock } from './helpers/mockVscode';
 
 installVscodeMock();
@@ -85,7 +85,7 @@ describe('pluginInventoryCommands', () => {
     assert.strictEqual(observedResource, undefined);
   });
 
-  it('adds picker selections with single-root relative and multi-root absolute paths', async () => {
+  it('validates and adds selected plugin jars', async () => {
     const vscode = resetVscodeMock();
     const { addPluginJars } = require('../commands/pluginInventory') as typeof import('../commands/pluginInventory');
     const writes: Array<{ paths: string[]; target: string }> = [];
@@ -96,35 +96,17 @@ describe('pluginInventoryCommands', () => {
       pluginConfigurationDeps(
         {
           target: 'workspace',
-          paths: ['plugins/existing.jar'],
+          paths: [],
           workspaceRoots: ['/workspace'],
         },
-        [
-          selected('/workspace/plugins/existing.jar'),
-          selected('/workspace/plugins/new.jar'),
-        ],
-        writes
-      )
-    );
-    await addPluginJars(
-      pluginConfigurationDeps(
-        {
-          target: 'workspace',
-          paths: [],
-          workspaceRoots: ['/workspace-a', '/workspace-b'],
-        },
-        [selected('/workspace-a/plugins/multi-root.jar')],
+        [selected('/workspace/plugins/new.jar')],
         writes
       )
     );
 
     assert.deepStrictEqual(writes, [
       {
-        paths: ['plugins/existing.jar', 'plugins/new.jar'],
-        target: 'workspace',
-      },
-      {
-        paths: ['/workspace-a/plugins/multi-root.jar'],
+        paths: ['plugins/new.jar'],
         target: 'workspace',
       },
     ]);
@@ -133,7 +115,7 @@ describe('pluginInventoryCommands', () => {
   it('removes only the matching configured path and ignores stale rows', async () => {
     const { removePluginJar } = require('../commands/pluginInventory') as typeof import('../commands/pluginInventory');
     const writes: Array<{ paths: string[]; target: string }> = [];
-    const state: PluginPathConfiguration = {
+    const state: PathSettingState = {
       target: 'workspace',
       paths: ['plugins/a.jar', '/outside/b.jar'],
       workspaceRoots: ['/workspace'],
@@ -150,7 +132,7 @@ describe('pluginInventoryCommands', () => {
 });
 
 function pluginConfigurationDeps(
-  state: PluginPathConfiguration,
+  state: PathSettingState,
   selected: readonly Uri[],
   writes: Array<{ paths: string[]; target: string }>
 ): PluginConfigurationDeps {


### PR DESCRIPTION
## Summary

- centralize configuration-scope selection and path normalization for filter files and plugin jars
- share duplicate detection, workspace-relative storage, and removal planning between both commands
- add focused planner tests for scope selection, storage rules, duplicate picks, and stale removals
- reduce the overall change by 23 lines while keeping baseline and suppression workflows unchanged

## Testing

- [x] `npm run lint`
- [x] `npm run format:check`
- [ ] `npm test`
- [x] Other: clean compile, `npm run test:unit` (346 passing), and VS Code extension host tests (10 passing)

## Notes

Baseline creation and finding suppression intentionally remain outside this abstraction because their configuration scope and concurrent-update behavior differ. The local `npm test` wrapper was not used because `@vscode/test-electron` 2.5.2 looks for the obsolete macOS `Electron` binary name; the same host suite passed by supplying the installed `Code` executable explicitly.
