### PR TITLE
refactor: consolidate finding renderer helpers

### DIFF
--- a/src/formatters/findingFormatting.ts
+++ b/src/formatters/findingFormatting.ts
@@ -2,25 +2,19 @@ import { FindingSummary } from '../model/finding';
 import { Severity } from '../model/severity';
 
 export function formatFindingSummary(finding: FindingSummary): string {
-  const pattern = finding.abbrev || finding.type || 'Bug';
-  const raw = finding.message || '';
-  let msg = raw.trim();
-  const prefix = `${pattern}:`;
-  if (msg.toUpperCase().startsWith(prefix.toUpperCase())) {
-    msg = msg.substring(prefix.length).trim();
-  }
-  const inIdx = msg.indexOf(' in ');
-  if (inIdx > 0) {
-    msg = msg.substring(0, inIdx).trim();
-  }
-  if (!msg) {
-    msg = finding.type || 'SpotBugs finding';
-  }
-  return `[${pattern}] ${msg}`;
+  return formatFinding(finding, 'Bug', 'SpotBugs finding');
 }
 
 export function formatFindingPatternLabel(finding: FindingSummary): string {
-  const pattern = finding.abbrev || finding.type || 'Pattern';
+  return formatFinding(finding, 'Pattern', 'SpotBugs Pattern');
+}
+
+function formatFinding(
+  finding: FindingSummary,
+  patternFallback: string,
+  messageFallback: string
+): string {
+  const pattern = finding.abbrev || finding.type || patternFallback;
   const raw = finding.message || '';
   let msg = raw.trim();
   const prefix = `${pattern}:`;
@@ -32,7 +26,7 @@ export function formatFindingPatternLabel(finding: FindingSummary): string {
     msg = msg.substring(0, inIdx).trim();
   }
   if (!msg) {
-    msg = finding.type || 'SpotBugs Pattern';
+    msg = finding.type || messageFallback;
   }
   return `[${pattern}] ${msg}`;
 }

--- a/src/ui/findingDescriptionRenderer.ts
+++ b/src/ui/findingDescriptionRenderer.ts
@@ -1,4 +1,3 @@
-import type * as vscode from 'vscode';
 import { formatFindingSummary } from '../formatters/findingFormatting';
 import { Finding } from '../model/finding';
 import {
@@ -6,6 +5,12 @@ import {
   rewriteLegacySpotBugsHelpUrl,
 } from '../services/spotbugsDocumentationLinks';
 import * as sanitizeHtml from 'sanitize-html';
+import {
+  escapeAttribute,
+  escapeHtml,
+  fallbackLocalizationApi,
+  type LocalizationApi,
+} from './rendererSupport';
 
 const PANEL_TITLE = 'SpotBugs Details';
 const DETAIL_HTML_ALLOWED_TAGS = [
@@ -36,21 +41,9 @@ const DETAIL_HTML_ALLOWED_TAGS = [
 const DETAIL_HTML_ALLOWED_SCHEMES = ['http', 'https', 'mailto'];
 const DETAIL_HTML_ALLOWED_PROTOCOLS = new Set(['http:', 'https:', 'mailto:']);
 
-type Localize = (message: string, ...args: Array<string | number | boolean>) => string;
-type LocalizationApi = {
-  l10n: { t: Localize };
-  readonly vscodeL10nType?: typeof vscode.l10n;
-};
-
-const fallbackVscode: LocalizationApi = {
-  l10n: {
-    t: formatFallback,
-  },
-};
-
 export function renderFindingDescriptionHtml(
   finding: Finding,
-  vscode: LocalizationApi = fallbackVscode
+  vscode: LocalizationApi = fallbackLocalizationApi
 ): string {
   const title = getFindingDescriptionTitle(finding);
   const summary = formatFindingSummary(finding);
@@ -214,19 +207,6 @@ export function getFindingDescriptionTitle(finding: Finding): string {
   return finding.shortDescription?.trim() || formatFindingSummary(finding) || PANEL_TITLE;
 }
 
-function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-
-function escapeAttribute(value: string): string {
-  return escapeHtml(value);
-}
-
 function getFindingDetailSanitizeOptions(
   currentBugType?: string
 ): sanitizeHtml.IOptions {
@@ -291,14 +271,4 @@ function getAllowedAbsoluteUrl(
   }
 
   return undefined;
-}
-
-function formatFallback(
-  message: string,
-  ...args: Array<string | number | boolean>
-): string {
-  return message.replace(/\{(\d+)\}/g, (placeholder, indexValue: string) => {
-    const index = Number(indexValue);
-    return index < args.length ? String(args[index]) : placeholder;
-  });
 }

--- a/src/ui/findingInspectorRenderer.ts
+++ b/src/ui/findingInspectorRenderer.ts
@@ -1,26 +1,19 @@
-import type * as vscode from 'vscode';
 import { formatFindingSummary } from '../formatters/findingFormatting';
 import { Finding } from '../model/finding';
 import { getAllowedWebDocumentationUrl } from '../services/spotbugsDocumentationLinks';
 import { getFindingDescriptionTitle } from './findingDescriptionRenderer';
 import { FindingInspectorSnapshot } from './findingInspectorState';
-
-type Localize = (message: string, ...args: Array<string | number | boolean>) => string;
-type LocalizationApi = {
-  l10n: { t: Localize };
-  readonly vscodeL10nType?: typeof vscode.l10n;
-};
-
-const fallbackVscode: LocalizationApi = {
-  l10n: {
-    t: formatFallback,
-  },
-};
+import {
+  escapeAttribute,
+  escapeHtml,
+  fallbackLocalizationApi,
+  type LocalizationApi,
+} from './rendererSupport';
 
 export function renderFindingInspectorHtml(
   snapshot: FindingInspectorSnapshot,
   nonce: string,
-  vscode: LocalizationApi = fallbackVscode
+  vscode: LocalizationApi = fallbackLocalizationApi
 ): string {
   const body =
     snapshot.status === 'empty'
@@ -205,27 +198,4 @@ function formatLocation(finding: Finding): string | undefined {
     return `${file}:${start}-${end}`;
   }
   return `${file}:${start}`;
-}
-
-function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-
-function escapeAttribute(value: string): string {
-  return escapeHtml(value);
-}
-
-function formatFallback(
-  message: string,
-  ...args: Array<string | number | boolean>
-): string {
-  return message.replace(/\{(\d+)\}/g, (placeholder, indexValue: string) => {
-    const index = Number(indexValue);
-    return index < args.length ? String(args[index]) : placeholder;
-  });
 }

--- a/src/ui/rendererSupport.ts
+++ b/src/ui/rendererSupport.ts
@@ -1,0 +1,40 @@
+import type * as vscode from 'vscode';
+
+type Localize = (
+  message: string,
+  ...args: Array<string | number | boolean>
+) => string;
+
+export type LocalizationApi = {
+  l10n: { t: Localize };
+  readonly vscodeL10nType?: typeof vscode.l10n;
+};
+
+export const fallbackLocalizationApi: LocalizationApi = {
+  l10n: {
+    t: formatFallback,
+  },
+};
+
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export function escapeAttribute(value: string): string {
+  return escapeHtml(value);
+}
+
+function formatFallback(
+  message: string,
+  ...args: Array<string | number | boolean>
+): string {
+  return message.replace(/\{(\d+)\}/g, (placeholder, indexValue: string) => {
+    const index = Number(indexValue);
+    return index < args.length ? String(args[index]) : placeholder;
+  });
+}


### PR DESCRIPTION
## Summary

- centralize localization fallback and HTML escaping primitives shared by the finding renderers
- consolidate the duplicated finding-summary formatting algorithm while preserving both public formatters
- reduce production code by 26 lines and lower measured production TypeScript duplication from 1.48% to 1.05%

## Testing

- [x] `npm run lint`
- [x] `npm run format:check`
- [ ] `npm test`
- [x] Other: clean compile, focused renderer/formatter tests (15 passing), `npm run test:unit` (346 passing), and VS Code extension host tests (10 passing)

## Notes

The HTML sanitizer, export workflow, and suppression workflow are unchanged. The local `npm test` wrapper was not used because `@vscode/test-electron` 2.5.2 looks for the obsolete macOS `Electron` binary name; the same host suite passed with the installed `Code` executable supplied explicitly.
