### PR TITLE
refactor: consolidate recursive file traversal

### DIFF
--- a/src/workspace/analysisTargetResolver.ts
+++ b/src/workspace/analysisTargetResolver.ts
@@ -18,6 +18,7 @@ import {
   orderOutputFolderCandidates,
   type OutputFolderSelectionOptions,
 } from './outputResolver';
+import { containsMatchingFile } from './fileTraversal';
 
 export interface AnalysisTarget {
   targetPath: string;
@@ -802,44 +803,7 @@ function isJavaSourceFile(targetPath: string): boolean {
 }
 
 async function containsJavaSources(targetPath: string): Promise<boolean> {
-  try {
-    const stat = await fs.promises.stat(targetPath);
-    if (stat.isFile()) {
-      return isJavaSourceFile(targetPath);
-    }
-    if (!stat.isDirectory()) {
-      return false;
-    }
-  } catch {
-    return false;
-  }
-
-  const queue: string[] = [targetPath];
-  while (queue.length > 0) {
-    const current = queue.pop();
-    if (!current) {
-      continue;
-    }
-    let entries: fs.Dirent[];
-    try {
-      entries = await fs.promises.readdir(current, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    for (const entry of entries) {
-      const entryPath = path.join(current, entry.name);
-      if (entry.isFile()) {
-        if (isJavaSourceFile(entryPath)) {
-          return true;
-        }
-        continue;
-      }
-      if (entry.isDirectory()) {
-        queue.push(entryPath);
-      }
-    }
-  }
-  return false;
+  return containsMatchingFile(targetPath, isJavaSourceFile);
 }
 
 async function isJavaSourceDirectoryPath(

--- a/src/workspace/fileTraversal.ts
+++ b/src/workspace/fileTraversal.ts
@@ -1,0 +1,46 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export async function containsMatchingFile(
+  targetPath: string,
+  predicate: (filePath: string) => boolean
+): Promise<boolean> {
+  try {
+    const stat = await fs.promises.stat(targetPath);
+    if (stat.isFile()) {
+      return predicate(targetPath);
+    }
+    if (!stat.isDirectory()) {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+
+  const queue: string[] = [targetPath];
+  while (queue.length > 0) {
+    const current = queue.pop();
+    if (!current) {
+      continue;
+    }
+    let entries: fs.Dirent[];
+    try {
+      entries = await fs.promises.readdir(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const entryPath = path.join(current, entry.name);
+      if (entry.isFile()) {
+        if (predicate(entryPath)) {
+          return true;
+        }
+        continue;
+      }
+      if (entry.isDirectory()) {
+        queue.push(entryPath);
+      }
+    }
+  }
+  return false;
+}

--- a/src/workspace/outputResolver.ts
+++ b/src/workspace/outputResolver.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { containsMatchingFile } from './fileTraversal';
 
 const DEFAULT_OUTPUT_DIRS = [
   path.join('build', 'classes', 'java', 'main'),
@@ -40,29 +41,11 @@ function isLooseClassTarget(targetPath: string): boolean {
 }
 
 export async function hasClassTargets(targetPath: string): Promise<boolean> {
-  return hasTargets(targetPath, isBytecodeTarget);
+  return containsMatchingFile(targetPath, isBytecodeTarget);
 }
 
 export async function hasLooseClassTargets(targetPath: string): Promise<boolean> {
-  return hasTargets(targetPath, isLooseClassTarget);
-}
-
-async function hasTargets(
-  targetPath: string,
-  isTargetFile: (targetPath: string) => boolean
-): Promise<boolean> {
-  try {
-    const stat = await fs.promises.stat(targetPath);
-    if (stat.isFile()) {
-      return isTargetFile(targetPath);
-    }
-    if (stat.isDirectory()) {
-      return await containsTarget(targetPath, isTargetFile);
-    }
-  } catch {
-    return false;
-  }
-  return false;
+  return containsMatchingFile(targetPath, isLooseClassTarget);
 }
 
 export async function findOutputFolderFromProject(
@@ -106,35 +89,4 @@ export function orderOutputFolderCandidates<T extends OutputFolderCandidate>(
     const bRank = options.rankCandidate?.(b) ?? 0;
     return aRank - bRank || a.index - b.index;
   });
-}
-
-async function containsTarget(
-  root: string,
-  isTargetFile: (targetPath: string) => boolean
-): Promise<boolean> {
-  const queue: string[] = [root];
-  while (queue.length > 0) {
-    const current = queue.pop();
-    if (!current) {
-      continue;
-    }
-    let entries: fs.Dirent[];
-    try {
-      entries = await fs.promises.readdir(current, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    for (const entry of entries) {
-      if (entry.isFile()) {
-        if (isTargetFile(entry.name)) {
-          return true;
-        }
-        continue;
-      }
-      if (entry.isDirectory()) {
-        queue.push(path.join(current, entry.name));
-      }
-    }
-  }
-  return false;
 }


### PR DESCRIPTION
## Summary

- Extract shared recursive file matching into `containsMatchingFile`.
- Reuse the traversal for Java source, class, and archive target detection.
- Preserve file, directory, unreadable path, and symlink traversal behavior while reducing the implementation by 38 lines.

## Testing

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test`
- [x] Other: verified the VS Code extension-host suite passes with 10 tests

## Notes

The final test run was performed after `npm run clean` so deleted SARIF test artifacts from the updated base branch could not remain in `out/`.