### PR TITLE
refactor: remove unused TypeScript code

### DIFF
--- a/scripts/validateJavaBackendVersion.js
+++ b/scripts/validateJavaBackendVersion.js
@@ -115,6 +115,4 @@ if (require.main === module) {
 
 module.exports = {
   assertJavaBackendVersions,
-  readJavaBackendVersions,
-  validateJavaBackendVersions,
 };

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -39,13 +39,4 @@ export class Logger {
     const errorMessage = error instanceof Error ? error.message : String(error);
     this.log(`[ERROR] ${message}${error ? `: ${errorMessage}` : ''}`);
   }
-
-  /**
-   * Reveals the output channel in the UI.
-   */
-  public static show() {
-    if (this.outputChannel) {
-      this.outputChannel.show();
-    }
-  }
 }

--- a/src/services/javaLsClient.ts
+++ b/src/services/javaLsClient.ts
@@ -1,7 +1,6 @@
 import { Uri } from 'vscode';
 import type { JavaProjectsOutcome } from '../lsp/javaLsOutcome';
 import { requestAllJavaProjects } from '../lsp/javaLsGateway';
-import { buildWorkspace, BuildMode } from './workspaceBuildService';
 
 export class JavaLsClient {
   static async getAllProjectsOutcome(): Promise<JavaProjectsOutcome> {
@@ -74,9 +73,5 @@ export class JavaLsClient {
   static async getAllProjects(): Promise<string[]> {
     const outcome = await JavaLsClient.getAllProjectsOutcome();
     return outcome.projectUris;
-  }
-
-  static async buildWorkspace(mode: BuildMode = 'auto'): Promise<number | undefined> {
-    return buildWorkspace({ mode, ensureCommands: false });
   }
 }

--- a/src/ui/findingFilters.ts
+++ b/src/ui/findingFilters.ts
@@ -15,15 +15,6 @@ export interface FindingFilterOption {
   detail?: string;
 }
 
-const FILTER_KIND_LABELS: Record<FindingFilterKind, string> = {
-  severity: 'Severity',
-  category: 'Category',
-  package: 'Package',
-  class: 'Class',
-  path: 'Path',
-  rule: 'Rule',
-};
-
 const FILTER_KIND_ORDER: FindingFilterKind[] = [
   'severity',
   'category',
@@ -37,10 +28,6 @@ const SEVERITY_ORDER = ['Error', 'Warning', 'Info'];
 
 export function getFindingFilterKinds(): FindingFilterKind[] {
   return FILTER_KIND_ORDER.slice();
-}
-
-export function getFindingFilterKindLabel(kind: FindingFilterKind): string {
-  return FILTER_KIND_LABELS[kind];
 }
 
 export function applyFindingFilters(


### PR DESCRIPTION
## Summary

- Remove the unused finding-filter label map and accessor.
- Remove the unused output-channel reveal method and Java LS workspace-build wrapper.
- Keep only the version-validation function consumed by the Java extension build script in the module exports.
- Reduce the TypeScript and build-script implementation by 29 lines without changing active behavior.

## Testing

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test`
- [x] Other: `node scripts/validateJavaBackendVersion.js` and verified the module exports only `assertJavaBackendVersions`

## Notes

Finding filter labels continue to come from the localized presentation layer, workspace builds continue through `workspaceBuildService`, and `buildJdtlsExt.js` still consumes the retained version assertion.